### PR TITLE
Feature csf photo url fix

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -629,9 +629,9 @@ namespace Rock.Model
         {
             get
             {
-                if ( this.RecordTypeValueId != null )
+                if ( this.RecordTypeValue != null )
                 {
-                    return Person.GetPhotoUrl( this.PhotoId, this.Age, this.Gender, DefinedValueCache.Read( this.RecordTypeValueId.Value ).Guid );
+                    return Person.GetPhotoUrl( this.PhotoId, this.Age, this.Gender, this.RecordTypeValue.Guid );
                 }
                 else
                 {


### PR DESCRIPTION
Would resolve Rock Issue #565.  What was ultimately happening was that a Person entity object could not be serialized to a json string in applications that did not have an HttpContext.  I updated the GetPhotoUrl method to return the photo's virtual path if the HttpContext was null.  If it is preferred I woudl be open to returning an empty string instead.
