### PR TITLE
Fix XSS Bug, Issue #563

### DIFF
--- a/RockWeb/Http404Error.aspx.cs
+++ b/RockWeb/Http404Error.aspx.cs
@@ -31,6 +31,9 @@ public partial class Http404Error : System.Web.UI.Page
     {
         try
         {
+            // Set form action to pass XSS test
+            form1.Action = "/";
+
             // Check to see if exception should be logged
             if ( Convert.ToBoolean( GlobalAttributesCache.Read().GetValue( "Log404AsException" ) ) )
             {


### PR DESCRIPTION
Set the form action to be "/" so that non-escaped text is not present in
the action param.  The default 404 handler page was not passing XSS tests.  By hard setting the form1.Action to be "/" it now passes a XSS test.  Issue #563
