### PR TITLE
feature-mud-rest-api-error-handling

### DIFF
--- a/Rock.Client/ErrorHandling/RestApiConstants.cs
+++ b/Rock.Client/ErrorHandling/RestApiConstants.cs
@@ -1,0 +1,34 @@
+﻿// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+
+namespace Rock.Client.ErrorHandling
+{
+    public static class RestApiConstants
+    {
+        /// <summary>
+        /// A list of Error Codes that can be returned to a REST client.
+        /// </summary>
+        public static class ErrorCodes
+        {
+            public const string Unspecified = "Rock.RestApi.Error";
+            
+            public const string EntityValidationError = "Rock.RestApi.EntityValidationError";
+            public const string DataAccessError = "Rock.RestApi.DataAccessError";
+        }
+    }
+}

--- a/Rock.Client/ErrorHandling/RestApiErrorDetail.cs
+++ b/Rock.Client/ErrorHandling/RestApiErrorDetail.cs
@@ -1,0 +1,93 @@
+﻿// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+
+namespace Rock.Client.ErrorHandling
+{
+    /// <summary>
+    ///     The default data contract for providing details of a processing error to a Rest API consumer.
+    /// </summary>
+    public class RestApiErrorDetail
+    {
+        /// <summary>
+        ///     An application-specific identifier for the error.
+        ///     The error code is a hierarchical string in the form of "{Application}.{Component}.{ErrorName}".
+        ///     For errors returned from the Rock REST API, the error code is of the form "Rock.RestApi.{ErrorSpecificName}".
+        /// </summary>
+        public string ErrorCode = RestApiConstants.ErrorCodes.Unspecified;
+
+        /// <summary>
+        /// A user-friendly message that provides additional details about the error and any possible resolution.
+        /// </summary>
+        public string Details = "Please contact your Rock RMS system administrator for further assistance.";
+
+        /// <summary>
+        /// A user-friendly message that describes the general nature of the error.
+        /// </summary>
+        public string Message = "The Rock RMS Server encountered a problem while trying to process your request.";
+
+        /// <summary>
+        ///     An optional error code providing an internal identifier for the error.
+        /// </summary>
+        public string InternalCode = null;
+
+        /// <summary>
+        /// The server-side stack trace at the time the error occurred.
+        /// This information is useful for diagnostic purposes, and is only available to system administrators.
+        /// </summary>
+        public string StackTrace = null;
+
+        public RestApiErrorDetail()
+        {
+        }
+
+        public RestApiErrorDetail(string code, string message)
+            : this(code, null, message, null)
+        {
+        }
+
+        public RestApiErrorDetail(string code, string message, string details)
+            : this(code, null, message, details)
+        {
+        }
+
+        public RestApiErrorDetail(string code, string subCode, string message, string details)
+        {
+            ErrorCode = code;
+            InternalCode = subCode;
+            Message = message;
+            Details = details;
+        }
+
+        public override string ToString()
+        {
+            string message = "[ErrorCode=" + this.ErrorCode;
+
+            if (!string.IsNullOrEmpty(this.InternalCode))
+                message += ",SubCode=" + this.InternalCode;
+
+            message += "]\n";
+
+            message += this.Message;
+
+            if (!string.IsNullOrEmpty(this.Details))
+                message += "\n" + this.Details;
+
+            return message;
+        }
+    }
+}

--- a/Rock.Client/Rock.Client.csproj
+++ b/Rock.Client/Rock.Client.csproj
@@ -136,6 +136,8 @@
     <Compile Include="CodeGenerated\WorkflowLog.cs" />
     <Compile Include="CodeGenerated\WorkflowTrigger.cs" />
     <Compile Include="CodeGenerated\WorkflowType.cs" />
+    <Compile Include="ErrorHandling\RestApiConstants.cs" />
+    <Compile Include="ErrorHandling\RestApiErrorDetail.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Rock.Rest/ErrorHandling/EntityValidationException.cs
+++ b/Rock.Rest/ErrorHandling/EntityValidationException.cs
@@ -1,0 +1,38 @@
+// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+
+namespace Rock.Rest.ErrorHandling
+{
+    /// <summary>
+    /// An Exception that occurs when an Entity fails a validation check.
+    /// </summary>
+    public class EntityValidationException : Exception
+    {
+        public EntityValidationException(IEnumerable<string> messages)
+            : base("One or more validation errors occurred. Check the Messages property for details.")
+        {
+            this.Messages = new List<string>(messages);
+        }
+
+        public string EntityTypeName;
+        public string EntityId;
+
+        public List<string> Messages;
+    }
+}

--- a/Rock.Rest/ErrorHandling/RestApiExceptionFilterAttribute.cs
+++ b/Rock.Rest/ErrorHandling/RestApiExceptionFilterAttribute.cs
@@ -1,0 +1,164 @@
+﻿// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Data.Entity.Infrastructure;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http.Filters;
+using Rock.Client.ErrorHandling;
+using Rock.Model;
+
+namespace Rock.Rest.ErrorHandling
+{
+    /// <summary>
+    /// An exception handler for Rock REST API Controllers.
+    /// This filter is responsible for translating uncaught .NET Exceptions into corresponding Http Responses.
+    /// The response contains information about the error in a standard detail object that can be parsed programatically.
+    /// </summary>
+    public class RestApiExceptionFilterAttribute : ExceptionFilterAttribute
+    {
+        public override void OnException(HttpActionExecutedContext actionExecutedContext)
+        {
+            // Determine if we should include Exception and StackTrace information in the error report.
+            // These details are returned if the web service is configured to do so, or if the current user is a Rock Administrator.
+            bool includeExceptionDetails = actionExecutedContext.ActionContext.RequestContext.IncludeErrorDetail
+                                            || UserLoginService.IsAdministrator(UserLoginService.GetCurrentUser());
+
+            var errorDetail = CreateErrorDetailObject(actionExecutedContext.Exception, includeExceptionDetails);
+
+            actionExecutedContext.Response = actionExecutedContext.Request.CreateResponse(HttpStatusCode.BadRequest, errorDetail);
+        }
+
+        /// <summary>
+        /// Create the error detail object to be returned in the Response.
+        /// </summary>
+        /// <param name="error"></param>
+        /// <param name="includeExceptionDetail"></param>
+        /// <returns></returns>
+        private RestApiErrorDetail CreateErrorDetailObject(Exception error, bool includeExceptionDetail)
+        {
+            // Translate known Exceptions to provide additional information in the response.
+            if (error is EntityValidationException)
+                return CreateEntityValidationExceptionDetail((EntityValidationException)error, includeExceptionDetail);
+
+            if (error is DbUpdateException)
+                return CreateDbUpdateExceptionDetail((DbUpdateException)error, includeExceptionDetail);
+
+            // If no specific processing of this exception is available, return a default error detail object.
+            return CreateBaseExceptionDetail(error, includeExceptionDetail);
+        }
+
+        private RestApiErrorDetail CreateBaseExceptionDetail(Exception e, bool showAdministrativeDetails)
+        {
+            // Create a default detail object for this error. 
+            var errorDetail = new RestApiErrorDetail();
+
+            errorDetail.ErrorCode = RestApiConstants.ErrorCodes.Unspecified;
+
+            if (showAdministrativeDetails)
+            {
+                errorDetail.Message = e.Message;
+                errorDetail.Details = GetExceptionMessageSummary(e.InnerException);
+
+                errorDetail.InternalCode = e.GetType().Name;
+                errorDetail.StackTrace = e.StackTrace;                
+            }
+            else
+            {
+                errorDetail.Message = "The Rock RMS Server encountered a problem while trying to process your request.";
+                errorDetail.Details = "Additional information about this error may be obtained by contacting your system administrator.";
+            }
+
+            return errorDetail;
+        }
+
+        /// <summary>
+        /// Provides a summary of messages for the specified Exception and all associated inner Exceptions.
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <returns></returns>
+        private string GetExceptionMessageSummary(Exception ex)
+        {
+            string message = string.Empty;
+            string lastMessage = string.Empty;
+
+            while (ex != null)
+            {
+                // Add the inner exception message unless it is simply a repeat of the previous message.
+                if (!ex.Message.Equals(lastMessage))
+                {
+                    if (message.Length > 0)
+                        message += Environment.NewLine;
+
+                    message += ex.Message;
+                }
+
+                lastMessage = ex.Message;
+
+                ex = ex.InnerException;
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Create an ErrorDetail object for an Entity Validation Exception.
+        /// </summary>
+        /// <param name="error"></param>
+        /// <param name="includeExceptionDetail"></param>
+        /// <returns></returns>
+        private RestApiErrorDetail CreateEntityValidationExceptionDetail(EntityValidationException error, bool includeExceptionDetail)
+        {
+            var errorDetail = CreateBaseExceptionDetail(error, includeExceptionDetail);
+
+            errorDetail.InternalCode = RestApiConstants.ErrorCodes.EntityValidationError;
+
+            // If details are included, return the Validation Messages in the Details property.
+            if (includeExceptionDetail)
+                errorDetail.Details = String.Join(Environment.NewLine, error.Messages);
+
+            return errorDetail;
+        }
+
+        /// <summary>
+        /// Create an ErrorDetail object for an Entity Update Exception.
+        /// </summary>
+        /// <param name="error"></param>
+        /// <param name="includeExceptionDetail"></param>
+        /// <returns></returns>
+        private RestApiErrorDetail CreateDbUpdateExceptionDetail(DbUpdateException error, bool includeExceptionDetail)
+        {
+            var errorDetail = CreateBaseExceptionDetail(error, includeExceptionDetail);
+
+            errorDetail.ErrorCode = RestApiConstants.ErrorCodes.DataAccessError;
+
+            string message = "An error occurred while attempting to update one or more Entities.";
+            
+            // Return the list of Entities that could not be updated.
+            foreach (var entry in error.Entries)
+            {
+                var entity = entry.Entity;
+
+                message += Environment.NewLine + entity.GetType().Name + ": \"" + entity.ToString() + "\"";
+            }
+
+            errorDetail.Message = message;
+
+            return errorDetail;
+        }
+    }
+}

--- a/Rock.Rest/Rock.Rest.csproj
+++ b/Rock.Rest/Rock.Rest.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -231,6 +232,8 @@
     <Compile Include="Controllers\TagsController.Partial.cs" />
     <Compile Include="Controllers\UserLoginsController.Partial.cs" />
     <Compile Include="EnableCorsFromOriginAttribute.cs" />
+    <Compile Include="ErrorHandling\RestApiExceptionFilterAttribute.cs" />
+    <Compile Include="ErrorHandling\EntityValidationException.cs" />
     <Compile Include="Filters\AuthenticateAttribute.cs" />
     <Compile Include="Filters\SecuredAttribute.cs" />
     <Compile Include="Filters\RequireHttpsAttribute.cs" />
@@ -243,6 +246,10 @@
     <ProjectReference Include="..\DotLiquid\DotLiquid.csproj">
       <Project>{cb9372cd-9c1d-47ab-92d8-702d4d68324f}</Project>
       <Name>DotLiquid</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Rock.Client\Rock.Client.csproj">
+      <Project>{6ea64bb9-9740-453a-939b-df43ad9ac164}</Project>
+      <Name>Rock.Client</Name>
     </ProjectReference>
     <ProjectReference Include="..\Rock\Rock.csproj">
       <Project>{8f8c2a79-24f4-4157-8b99-45f75fa85799}</Project>

--- a/Rock.sln
+++ b/Rock.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
-MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock", "Rock\Rock.csproj", "{8F8C2A79-24F4-4157-8B99-45F75FA85799}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CEF5DC8B-8F73-4CA9-A93F-554338D3EBB0}"
@@ -20,7 +18,7 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "RockWeb", "http://localhost
 	ProjectSection(WebsiteProperties) = preProject
 		UseIISExpress = "true"
 		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.5.1"
-		ProjectReferences = "{8f8c2a79-24f4-4157-8b99-45f75fa85799}|Rock.dll;{957b1dbe-b921-4fae-8e5e-b7ad7f01b161}|Rock.Migrations.dll;{b89dfd33-ce93-44e1-8616-c31acdfe89cb}|Rock.Rest.dll;{381a2fc8-6f4f-4b66-a9b4-14932d43b76a}|Rock.Version.dll;{05f3587d-86dd-4cf3-a80a-d8cf598e1fd1}|Rock.PayFlowPro.dll;{cb9372cd-9c1d-47ab-92d8-702d4d68324f}|DotLiquid.dll;"
+		ProjectReferences = "{8f8c2a79-24f4-4157-8b99-45f75fa85799}|Rock.dll;{957b1dbe-b921-4fae-8e5e-b7ad7f01b161}|Rock.Migrations.dll;{b89dfd33-ce93-44e1-8616-c31acdfe89cb}|Rock.Rest.dll;{381a2fc8-6f4f-4b66-a9b4-14932d43b76a}|Rock.Version.dll;{05f3587d-86dd-4cf3-a80a-d8cf598e1fd1}|Rock.PayFlowPro.dll;{cb9372cd-9c1d-47ab-92d8-702d4d68324f}|DotLiquid.dll;{6EA64BB9-9740-453A-939B-DF43AD9AC164}|Rock.Client.dll;"
 		Debug.AspNetCompiler.VirtualPath = "/localhost_6229"
 		Debug.AspNetCompiler.PhysicalPath = "RockWeb\"
 		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_6229\"
@@ -41,6 +39,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.PayFlowPro", "Rock.PayFlowPro\Rock.PayFlowPro.csproj", "{05F3587D-86DD-4CF3-A80A-D8CF598E1FD1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotLiquid", "DotLiquid\DotLiquid.csproj", "{CB9372CD-9C1D-47AB-92D8-702D4D68324F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Client", "Rock.Client\Rock.Client.csproj", "{6EA64BB9-9740-453A-939B-DF43AD9AC164}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -122,6 +122,16 @@ Global
 		{CB9372CD-9C1D-47AB-92D8-702D4D68324F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{CB9372CD-9C1D-47AB-92D8-702D4D68324F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{CB9372CD-9C1D-47AB-92D8-702D4D68324F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6EA64BB9-9740-453A-939B-DF43AD9AC164}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Rock/Model/UserLoginService.Partial.cs
+++ b/Rock/Model/UserLoginService.Partial.cs
@@ -401,6 +401,25 @@ namespace Rock.Model
             }
         }
 
+        /// <summary>
+        /// Determines if the specified User is a Rock Administrator.
+        /// </summary>
+        /// <param name="userLogin"></param>
+        /// <returns></returns>
+        public static bool IsAdministrator(UserLogin userLogin)
+        {
+            if (userLogin == null)
+                return false;
+
+            var service = new GroupService(new RockContext());
+
+            var adminGroup = service.GetByGuid(new Guid(Rock.SystemGuid.Group.GROUP_ADMINISTRATORS));
+
+            bool isAdmin = adminGroup.Members.Any(m => m.PersonId == userLogin.PersonId);
+
+            return isAdmin;
+        }
+
         #endregion
 
     }

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Rock</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\DataImporter\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This is my first attempt at submitting changes to GitHub, so apologies in advance if I cause any trouble!
Here is a change to add error handling to the REST ApiController.
Using this implementation, the ApiController can throw simple .NET Exceptions which are then translated by the ExceptionFilter into a HttpResponse with a Content object containing the error details.
All comments appreciated!
