### PR TITLE
- Added message to DISC assessment results after the user takes the test...

### DIFF
--- a/RockWeb/Blocks/Crm/Disc.ascx
+++ b/RockWeb/Blocks/Crm/Disc.ascx
@@ -185,7 +185,8 @@
                 <h1 class="panel-title margin-t-sm"><i class="fa fa-bar-chart"></i> DISC Assessment</h1>
             </div>
             <div class="panel-body">
-                
+
+                <asp:Literal ID="lPrintTip" runat="server" Text="<div class='alert alert-success' role='alert'><strong>Tip!</strong> Consider printing this page out for future reference.</div>" Visible="false"></asp:Literal>
                 <asp:Literal ID="lHeading" runat="server"></asp:Literal>
 
                 <ul class="discchart">

--- a/RockWeb/Blocks/Crm/Disc.ascx.cs
+++ b/RockWeb/Blocks/Crm/Disc.ascx.cs
@@ -419,6 +419,10 @@ namespace Rockweb.Blocks.Crm
             pnlQuestions.Visible = false;
             pnlResults.Visible = true;
 
+            if ( CurrentPersonId == _targetPerson.Id )
+            {
+                lPrintTip.Visible = true;
+            }
             lHeading.Text = string.Format( "<div class='disc-heading'><h1>{0}</h1><h4>Personality Type: {1}</h4></div>", _targetPerson.FullName, savedScores.PersonalityType );
 
             // Show re-take test button if MinDaysToRetake has passed...


### PR DESCRIPTION
https://app.asana.com/0/21785109381202/22232800693612
Reminds them to print them for their records. Message should only be show if the assessment is for the current user. Think that's the only possibility for the Disc.ascx block.
