### PR TITLE
Modified for larger attendance codes. Added 2 noGoods.

### DIFF
--- a/Rock/Model/AttendanceCodeService.Partial.cs
+++ b/Rock/Model/AttendanceCodeService.Partial.cs
@@ -36,7 +36,7 @@ namespace Rock.Model
         /// <summary>
         /// A list of <see cref="System.String"/> values that are not allowable as attendance codes.
         /// </summary>
-        private static List<string> noGood = new List<string> { "666", "KKK", "FCK", "SHT", "5HT", "DCK" };
+        private static List<string> noGood = new List<string> { "666", "KKK", "FCK", "SHT", "5HT", "DCK", "F4G", "D4M" };
 
         /// <summary>
         /// Returns a queryable collection of <see cref="Rock.Model.AttendanceCode"/> entities that used a specified code on a specified date.
@@ -70,7 +70,7 @@ namespace Rock.Model
             {
                 // Find a good unique code for today
                 while ( code == string.Empty ||
-                    noGood.Any( s => s == code ) ||
+                    noGood.Any( s => code.Contains(s) ) ||
                     service.Get( RockDateTime.Today, code ).Any() )
                 {
                     code = GenerateRandomCode( codeLength );


### PR DESCRIPTION
Generated codes can be larger than three characters. Modified noGood list to check if code "contains" a noGood, instead just equals.  Also, added two noGood codes.