### PR TITLE
Provide helper classes for plugin developers to use theme colors

### DIFF
--- a/RockWeb/Styles/_checkin-core.less
+++ b/RockWeb/Styles/_checkin-core.less
@@ -78,28 +78,6 @@ body {
   }
 }
 
-// theme colors
-.primary-color {
-    color: @bg-color;
-}
-
-.secondary-color {
-    color: @text-color;
-}
-
-.background-primary {
-    background-color: @bg-color;
-}
-
-.background-secondary {
-    background-color: @text-color;
-}
-
-.base-font {
-    font-family: @font-family-base;
-}
-
-
 // 3. Components
 // -------------------------
 

--- a/RockWeb/Styles/_checkin-core.less
+++ b/RockWeb/Styles/_checkin-core.less
@@ -78,6 +78,27 @@ body {
   }
 }
 
+// theme colors
+.primary-color {
+    color: @bg-color;
+}
+
+.secondary-color {
+    color: @text-color;
+}
+
+.background-primary {
+    background-color: @bg-color;
+}
+
+.background-secondary {
+    background-color: @text-color;
+}
+
+.base-font {
+    font-family: @font-family-base;
+}
+
 
 // 3. Components
 // -------------------------

--- a/RockWeb/Styles/_checkin-core.less
+++ b/RockWeb/Styles/_checkin-core.less
@@ -235,11 +235,11 @@ body {
     z-index: @zindex-popover;
 
     .modal-content {
-        background-color: @bg-color;
+        background-color: @body-bg;
     }
 
     .modal-footer {
-        border-top-color: lighten(@bg-color, 20%);
+        border-top-color: lighten(@body-bg, 20%);
     }
 }
 

--- a/RockWeb/Styles/_helpers.less
+++ b/RockWeb/Styles/_helpers.less
@@ -87,8 +87,8 @@
   border: 1px solid darken(@accent-bold-color, 10%);
 }
 
-.bg-color {
-    background-color: @bg-color;
+.body-bg {
+    background-color: @body-bg;
 }
 
 .text-color {

--- a/RockWeb/Styles/_helpers.less
+++ b/RockWeb/Styles/_helpers.less
@@ -87,6 +87,14 @@
   border: 1px solid darken(@accent-bold-color, 10%);
 }
 
+.bg-color {
+    background-color: @bg-color;
+}
+
+.text-color {
+    color: @text-color;
+}
+
 // 3. Spacing (note: default @grid-gutter-width is 30px in BS3)
 // -------------------------
 

--- a/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
@@ -8644,4 +8644,3 @@ Copyright (c) 2012 Dan Eden*/
 .checkin-body-container {
   width: 80%;
 }
-/*# sourceMappingURL=checkin-theme.css.map */

--- a/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
@@ -2692,7 +2692,7 @@ body {
   font-size: 14px;
   line-height: 1.42857143;
   color: #92724c;
-  background-color: #ffffff;
+  background-color: #dbc189;
 }
 input,
 button,
@@ -2738,7 +2738,7 @@ img {
 .img-thumbnail {
   padding: 4px;
   line-height: 1.42857143;
-  background-color: #ffffff;
+  background-color: #dbc189;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -3886,7 +3886,7 @@ th {
   border-top: 2px solid #dddddd;
 }
 .table .table {
-  background-color: #ffffff;
+  background-color: #dbc189;
 }
 .table-condensed > thead > tr > th,
 .table-condensed > tbody > tr > th,
@@ -5428,7 +5428,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
   color: #555555;
-  background-color: #ffffff;
+  background-color: #dbc189;
   border: 1px solid #dddddd;
   border-bottom-color: transparent;
   cursor: default;
@@ -5474,7 +5474,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs.nav-justified > .active > a,
   .nav-tabs.nav-justified > .active > a:hover,
   .nav-tabs.nav-justified > .active > a:focus {
-    border-bottom-color: #ffffff;
+    border-bottom-color: #dbc189;
   }
 }
 .nav-pills > li {
@@ -5542,7 +5542,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs-justified > .active > a,
   .nav-tabs-justified > .active > a:hover,
   .nav-tabs-justified > .active > a:focus {
-    border-bottom-color: #ffffff;
+    border-bottom-color: #dbc189;
   }
 }
 .tab-content > .tab-pane {
@@ -6375,7 +6375,7 @@ a.list-group-item.active > .badge,
   padding: 4px;
   margin-bottom: 20px;
   line-height: 1.42857143;
-  background-color: #ffffff;
+  background-color: #dbc189;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -8643,7 +8643,7 @@ Copyright (c) 2012 Dan Eden*/
   color: #ffffff;
   border: 1px solid #2c1616;
 }
-.bg-color {
+.body-bg {
   background-color: #dbc189;
 }
 .text-color {

--- a/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
      
      Rock Advenure Kids Check-in Theme
      Crafted by: Spark Development Network
@@ -12,8 +12,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?v=4.3.0');
-  src: url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
+  src: url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?v=4.3.0');
+  src: url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -2058,8 +2058,8 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('../../../Styles/fonts/glyphicons-halflings-regular.eot');
+  src: url('../../../Styles/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../../Styles/fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../../Styles/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../../Styles/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;
@@ -8028,6 +8028,21 @@ body {
     background-size: 1348px 1024px;
   }
 }
+.primary-color {
+  color: #dbc189;
+}
+.secondary-color {
+  color: #92724c;
+}
+.background-primary {
+  background-color: #dbc189;
+}
+.background-secondary {
+  background-color: #92724c;
+}
+.base-font {
+  font-family: 'OpenSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
 .checkin-header {
   margin-top: 45px;
   margin-bottom: 24px;
@@ -8629,3 +8644,4 @@ Copyright (c) 2012 Dan Eden*/
 .checkin-body-container {
   width: 80%;
 }
+/*# sourceMappingURL=checkin-theme.css.map */

--- a/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.css
@@ -8028,21 +8028,6 @@ body {
     background-size: 1348px 1024px;
   }
 }
-.primary-color {
-  color: #dbc189;
-}
-.secondary-color {
-  color: #92724c;
-}
-.background-primary {
-  background-color: #dbc189;
-}
-.background-secondary {
-  background-color: #92724c;
-}
-.base-font {
-  font-family: 'OpenSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
 .checkin-header {
   margin-top: 45px;
   margin-bottom: 24px;
@@ -8657,6 +8642,12 @@ Copyright (c) 2012 Dan Eden*/
   background-color: #4e2727;
   color: #ffffff;
   border: 1px solid #2c1616;
+}
+.bg-color {
+  background-color: #dbc189;
+}
+.text-color {
+  color: #92724c;
 }
 .padding-all-none {
   padding: 0 !important;

--- a/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.less
+++ b/RockWeb/Themes/CheckinAdventureKids/Styles/checkin-theme.less
@@ -25,14 +25,14 @@
 @font-weight-bold:      700;
 @font-weight-semibold:  600;
 
-@bg-color:      #dbc189;
+@body-bg:      #dbc189;
 @text-color:    #92724C;
 
-@modal-body-bg: @bg-color;
+@modal-body-bg: @body-bg;
 @modal-body-text-color: @text-color;
-@modal-header-bg: @bg-color;
+@modal-header-bg: @body-bg;
 @modal-header-text-color: @text-color;
-@modal-footer-bg: @bg-color;
+@modal-footer-bg: @body-bg;
 @modal-footer-text-color: @text-color;
 
 @header-text-color:     #54412b;
@@ -128,7 +128,7 @@
 // Mix-ins
 // --------------------------------------------------
 .checkinBackground () {
-  	background: @bg-color url('../Assets/Images/background.jpg') top right no-repeat fixed;
+  	background: @body-bg url('../Assets/Images/background.jpg') top right no-repeat fixed;
 }
 
 .checkinBackgroundRetina()

--- a/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
@@ -8659,4 +8659,3 @@ body {
     background-size: 496px 504px;
   }
 }
-/*# sourceMappingURL=checkin-theme.css.map */

--- a/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
@@ -8027,21 +8027,6 @@ body {
     background-color: transparent;
   }
 }
-.primary-color {
-  color: #4b5c65;
-}
-.secondary-color {
-  color: #ffffff;
-}
-.background-primary {
-  background-color: #4b5c65;
-}
-.background-secondary {
-  background-color: #ffffff;
-}
-.base-font {
-  font-family: 'OpenSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
 .checkin-header {
   margin-top: 45px;
   margin-bottom: 24px;
@@ -8656,6 +8641,12 @@ Copyright (c) 2012 Dan Eden*/
   background-color: #23353d;
   color: #ffffff;
   border: 1px solid #10191d;
+}
+.bg-color {
+  background-color: #4b5c65;
+}
+.text-color {
+  color: #ffffff;
 }
 .padding-all-none {
   padding: 0 !important;

--- a/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
@@ -2692,7 +2692,7 @@ body {
   font-size: 14px;
   line-height: 1.42857143;
   color: #ffffff;
-  background-color: #ffffff;
+  background-color: #4b5c65;
 }
 input,
 button,
@@ -2738,7 +2738,7 @@ img {
 .img-thumbnail {
   padding: 4px;
   line-height: 1.42857143;
-  background-color: #ffffff;
+  background-color: #4b5c65;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -3886,7 +3886,7 @@ th {
   border-top: 2px solid #dddddd;
 }
 .table .table {
-  background-color: #ffffff;
+  background-color: #4b5c65;
 }
 .table-condensed > thead > tr > th,
 .table-condensed > tbody > tr > th,
@@ -5428,7 +5428,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
   color: #555555;
-  background-color: #ffffff;
+  background-color: #4b5c65;
   border: 1px solid #dddddd;
   border-bottom-color: transparent;
   cursor: default;
@@ -5474,7 +5474,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs.nav-justified > .active > a,
   .nav-tabs.nav-justified > .active > a:hover,
   .nav-tabs.nav-justified > .active > a:focus {
-    border-bottom-color: #ffffff;
+    border-bottom-color: #4b5c65;
   }
 }
 .nav-pills > li {
@@ -5542,7 +5542,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs-justified > .active > a,
   .nav-tabs-justified > .active > a:hover,
   .nav-tabs-justified > .active > a:focus {
-    border-bottom-color: #ffffff;
+    border-bottom-color: #4b5c65;
   }
 }
 .tab-content > .tab-pane {
@@ -6375,7 +6375,7 @@ a.list-group-item.active > .badge,
   padding: 4px;
   margin-bottom: 20px;
   line-height: 1.42857143;
-  background-color: #ffffff;
+  background-color: #4b5c65;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -8642,7 +8642,7 @@ Copyright (c) 2012 Dan Eden*/
   color: #ffffff;
   border: 1px solid #10191d;
 }
-.bg-color {
+.body-bg {
   background-color: #4b5c65;
 }
 .text-color {

--- a/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
      
      Rock Advenure Kids Check-in Theme
      Crafted by: Spark Development Network
@@ -12,8 +12,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?v=4.3.0');
-  src: url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
+  src: url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?v=4.3.0');
+  src: url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -2058,8 +2058,8 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('../../../Styles/fonts/glyphicons-halflings-regular.eot');
+  src: url('../../../Styles/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../../Styles/fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../../Styles/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../../Styles/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;
@@ -8027,6 +8027,21 @@ body {
     background-color: transparent;
   }
 }
+.primary-color {
+  color: #4b5c65;
+}
+.secondary-color {
+  color: #ffffff;
+}
+.background-primary {
+  background-color: #4b5c65;
+}
+.background-secondary {
+  background-color: #ffffff;
+}
+.base-font {
+  font-family: 'OpenSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
 .checkin-header {
   margin-top: 45px;
   margin-bottom: 24px;
@@ -8644,3 +8659,4 @@ body {
     background-size: 496px 504px;
   }
 }
+/*# sourceMappingURL=checkin-theme.css.map */

--- a/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.less
+++ b/RockWeb/Themes/CheckinBlueCrystal/Styles/checkin-theme.less
@@ -25,14 +25,14 @@
 @font-weight-bold:      700;
 @font-weight-semibold:  600;
 
-@bg-color:      #4b5c65;
+@body-bg:      #4b5c65;
 @text-color:    #fff;
 
-@modal-body-bg: @bg-color;
+@modal-body-bg: @body-bg;
 @modal-body-text-color: @text-color;
-@modal-header-bg: @bg-color;
+@modal-header-bg: @body-bg;
 @modal-header-text-color: @text-color;
-@modal-footer-bg: @bg-color;
+@modal-footer-bg: @body-bg;
 @modal-footer-text-color: @text-color;
 
 @header-text-color:     #fff;
@@ -142,7 +142,7 @@
 // --------------------------------------------------
 
 html {
-    background: @bg-color url('../Assets/Images/background.jpg') top right no-repeat fixed;
+    background: @body-bg url('../Assets/Images/background.jpg') top right no-repeat fixed;
     background-size: cover;
     height: 100%;
 }

--- a/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
      
      Rock Park Check-in Theme
      Crafted by: Spark Development Network
@@ -12,8 +12,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?v=4.3.0');
-  src: url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('../../../Assets/Fonts/FontAwesome/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
+  src: url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?v=4.3.0');
+  src: url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('../../../../Assets/Fonts/FontAwesome/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -2058,8 +2058,8 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('../../../Styles/fonts/glyphicons-halflings-regular.eot');
+  src: url('../../../Styles/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../../Styles/fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../../Styles/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../../Styles/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;
@@ -8028,6 +8028,21 @@ body {
     background-size: 1348px 1024px;
   }
 }
+.primary-color {
+  color: #85b11c;
+}
+.secondary-color {
+  color: #ffffff;
+}
+.background-primary {
+  background-color: #85b11c;
+}
+.background-secondary {
+  background-color: #ffffff;
+}
+.base-font {
+  font-family: 'OpenSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
 .checkin-header {
   margin-top: 45px;
   margin-bottom: 24px;
@@ -8630,3 +8645,4 @@ Copyright (c) 2012 Dan Eden*/
 .checkin-count li {
   color: #4c4c4b;
 }
+/*# sourceMappingURL=checkin-theme.css.map */

--- a/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
@@ -8028,21 +8028,6 @@ body {
     background-size: 1348px 1024px;
   }
 }
-.primary-color {
-  color: #85b11c;
-}
-.secondary-color {
-  color: #ffffff;
-}
-.background-primary {
-  background-color: #85b11c;
-}
-.background-secondary {
-  background-color: #ffffff;
-}
-.base-font {
-  font-family: 'OpenSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
 .checkin-header {
   margin-top: 45px;
   margin-bottom: 24px;
@@ -8657,6 +8642,12 @@ Copyright (c) 2012 Dan Eden*/
   background-color: #e3151a;
   color: #ffffff;
   border: 1px solid #b41115;
+}
+.bg-color {
+  background-color: #85b11c;
+}
+.text-color {
+  color: #ffffff;
 }
 .padding-all-none {
   padding: 0 !important;

--- a/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
@@ -2692,7 +2692,7 @@ body {
   font-size: 14px;
   line-height: 1.42857143;
   color: #ffffff;
-  background-color: #ffffff;
+  background-color: #85b11c;
 }
 input,
 button,
@@ -2738,7 +2738,7 @@ img {
 .img-thumbnail {
   padding: 4px;
   line-height: 1.42857143;
-  background-color: #ffffff;
+  background-color: #85b11c;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -3886,7 +3886,7 @@ th {
   border-top: 2px solid #dddddd;
 }
 .table .table {
-  background-color: #ffffff;
+  background-color: #85b11c;
 }
 .table-condensed > thead > tr > th,
 .table-condensed > tbody > tr > th,
@@ -5428,7 +5428,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
   color: #555555;
-  background-color: #ffffff;
+  background-color: #85b11c;
   border: 1px solid #dddddd;
   border-bottom-color: transparent;
   cursor: default;
@@ -5474,7 +5474,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs.nav-justified > .active > a,
   .nav-tabs.nav-justified > .active > a:hover,
   .nav-tabs.nav-justified > .active > a:focus {
-    border-bottom-color: #ffffff;
+    border-bottom-color: #85b11c;
   }
 }
 .nav-pills > li {
@@ -5542,7 +5542,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs-justified > .active > a,
   .nav-tabs-justified > .active > a:hover,
   .nav-tabs-justified > .active > a:focus {
-    border-bottom-color: #ffffff;
+    border-bottom-color: #85b11c;
   }
 }
 .tab-content > .tab-pane {
@@ -6375,7 +6375,7 @@ a.list-group-item.active > .badge,
   padding: 4px;
   margin-bottom: 20px;
   line-height: 1.42857143;
-  background-color: #ffffff;
+  background-color: #85b11c;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -8643,7 +8643,7 @@ Copyright (c) 2012 Dan Eden*/
   color: #ffffff;
   border: 1px solid #b41115;
 }
-.bg-color {
+.body-bg {
   background-color: #85b11c;
 }
 .text-color {

--- a/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
+++ b/RockWeb/Themes/CheckinPark/Styles/checkin-theme.css
@@ -8645,4 +8645,3 @@ Copyright (c) 2012 Dan Eden*/
 .checkin-count li {
   color: #4c4c4b;
 }
-/*# sourceMappingURL=checkin-theme.css.map */

--- a/RockWeb/Themes/CheckinPark/Styles/checkin-theme.less
+++ b/RockWeb/Themes/CheckinPark/Styles/checkin-theme.less
@@ -25,14 +25,14 @@
 @font-weight-bold:      700;
 @font-weight-semibold:  600;
 
-@bg-color:      #85b11c;
+@body-bg:      #85b11c;
 @text-color:    #fff;
 
-@modal-body-bg: @bg-color;
+@modal-body-bg: @body-bg;
 @modal-body-text-color: @text-color;
-@modal-header-bg: @bg-color;
+@modal-header-bg: @body-bg;
 @modal-header-text-color: @text-color;
-@modal-footer-bg: @bg-color;
+@modal-footer-bg: @body-bg;
 @modal-footer-text-color: @text-color;
 
 @header-text-color:     #fff;
@@ -128,7 +128,7 @@
 // Mix-ins
 // --------------------------------------------------
 .checkinBackground () {
-  	background: @bg-color url('../Assets/Images/background.jpg') top right no-repeat fixed;
+  	background: @body-bg url('../Assets/Images/background.jpg') top right no-repeat fixed;
 }
 
 .checkinBackgroundRetina()

--- a/RockWeb/Themes/DashboardStark/Styles/theme.css
+++ b/RockWeb/Themes/DashboardStark/Styles/theme.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
    Rock's Core CSS
 
     1. Imports - Used to import the various core less files
@@ -3052,7 +3052,7 @@ table.attribute-grid tr th:nth-child(3) {
   overflow: hidden;
   text-align: left;
   text-indent: -999px;
-  background: url(../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
+  background: url(../../../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
 }
 .card-mastercard {
   background-position: -55px 0;
@@ -4124,6 +4124,12 @@ iframe.email-body {
   background-color: #428bca;
   color: #ecf0f3;
   border: 1px solid #3071a9;
+}
+.body-bg {
+  background-color: #ffffff;
+}
+.text-color {
+  color: #333333;
 }
 .padding-all-none {
   padding: 0 !important;

--- a/RockWeb/Themes/Flat/Styles/theme.css
+++ b/RockWeb/Themes/Flat/Styles/theme.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Montserrat:700);
+﻿@import url(http://fonts.googleapis.com/css?family=Montserrat:700);
 @import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,700,800,600);
 /*
    Rock's Core CSS
@@ -3054,7 +3054,7 @@ table.attribute-grid tr th:nth-child(3) {
   overflow: hidden;
   text-align: left;
   text-indent: -999px;
-  background: url(../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
+  background: url(../../../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
 }
 .card-mastercard {
   background-position: -55px 0;
@@ -4126,6 +4126,12 @@ iframe.email-body {
   background-color: #18bc9c;
   color: #ffffff;
   border: 1px solid #128f76;
+}
+.body-bg {
+  background-color: #ffffff;
+}
+.text-color {
+  color: #2c3e50;
 }
 .padding-all-none {
   padding: 0 !important;

--- a/RockWeb/Themes/Rock/Styles/theme.css
+++ b/RockWeb/Themes/Rock/Styles/theme.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
    Rock's Core CSS
 
     1. Imports - Used to import the various core less files
@@ -3052,7 +3052,7 @@ table.attribute-grid tr th:nth-child(3) {
   overflow: hidden;
   text-align: left;
   text-indent: -999px;
-  background: url(../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
+  background: url(../../../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
 }
 .card-mastercard {
   background-position: -55px 0;
@@ -4124,6 +4124,12 @@ iframe.email-body {
   background-color: #282526;
   color: #d3cec5;
   border: 1px solid #0e0c0d;
+}
+.body-bg {
+  background-color: #f3f3f4;
+}
+.text-color {
+  color: #6a6a6a;
 }
 .padding-all-none {
   padding: 0 !important;
@@ -5742,4 +5748,3 @@ body.navbar-side-close #content-wrapper {
 .title .first-word {
   font-weight: 900;
 }
-/*#endregion */

--- a/RockWeb/Themes/Stark/Styles/theme.css
+++ b/RockWeb/Themes/Stark/Styles/theme.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
    Rock's Core CSS
 
     1. Imports - Used to import the various core less files
@@ -3052,7 +3052,7 @@ table.attribute-grid tr th:nth-child(3) {
   overflow: hidden;
   text-align: left;
   text-indent: -999px;
-  background: url(../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
+  background: url(../../../../../Assets/Images/sprite-cards.png) 0 0 no-repeat;
 }
 .card-mastercard {
   background-position: -55px 0;
@@ -4124,6 +4124,12 @@ iframe.email-body {
   background-color: #428bca;
   color: #ecf0f3;
   border: 1px solid #3071a9;
+}
+.body-bg {
+  background-color: #ffffff;
+}
+.text-color {
+  color: #333333;
 }
 .padding-all-none {
   padding: 0 !important;


### PR DESCRIPTION
@edmistj Current theme colors are included on control styles, but aren't accessible by themselves.  This adds a couple classes for plugin developers to use themes without using the exact control style. 

It looks like _helpers.less was designed to do something similar, but that's not included anywhere & it didn't compile when I added it.

Side note: the latest Web Essentials is stable and auto-recompiles on save. 