### PR TITLE
Add a binary file picker attribute

### DIFF
--- a/Rock/Attribute/BinaryFileFieldAttribute.cs
+++ b/Rock/Attribute/BinaryFileFieldAttribute.cs
@@ -1,0 +1,50 @@
+﻿// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Rock.Attribute
+{
+    /// <summary>
+    /// Field Attribute to select a binary file
+    /// </summary>
+    [AttributeUsage( AttributeTargets.Class, AllowMultiple = true, Inherited = true )]
+    public class BinaryFileFieldAttribute : FieldAttribute
+    {
+        private const string BINARY_FILE_TYPE = "binaryFileType";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryFileFieldAttribute"/> class.
+        /// </summary>
+        /// <param name="binaryFileTypeGuid">The guid of the type of files</param>
+        /// <param name="name">The name.</param>
+        /// <param name="description">The description.</param>
+        /// <param name="required">if set to <c>true</c> [required].</param>
+        /// <param name="defaultBinaryFileGuid">The default binary file guid.</param>
+        /// <param name="category">The category.</param>
+        /// <param name="order">The order.</param>
+        /// <param name="key">The key.</param>
+        public BinaryFileFieldAttribute( string binaryFileTypeGuid, string name = "Binary File", string description = "", bool required = true, string defaultBinaryFileGuid = "", string category = "", int order = 0, string key = null )
+            : base( name, description, required, defaultBinaryFileGuid, category, order, key, typeof( Rock.Field.Types.BinaryFileFieldType ).FullName )
+        {
+            var configValue = new Field.ConfigurationValue( binaryFileTypeGuid );
+            FieldConfigurationValues.Add( BINARY_FILE_TYPE, configValue );
+        }
+    }
+}

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Address\VerificationContainer.cs" />
     <Compile Include="Address\VerificationComponent.cs" />
     <Compile Include="Address\Bing.cs" />
+    <Compile Include="Attribute\BinaryFileTypeFieldAttribute.cs" />
     <Compile Include="Attribute\CurrencyFieldAttribute.cs" />
     <Compile Include="Attribute\AttributeFieldAttribute.cs" />
     <Compile Include="Attribute\ContentChannelFieldAttribute.cs" />
@@ -161,7 +162,7 @@
     <Compile Include="Attribute\SiteFieldAttribute.cs" />
     <Compile Include="Attribute\PersonBadgesAttribute.cs" />
     <Compile Include="Attribute\CampusFieldAttribute.cs" />
-    <Compile Include="Attribute\BinaryFileTypeFieldAttribute.cs" />
+    <Compile Include="Attribute\BinaryFileFieldAttribute.cs" />
     <Compile Include="Attribute\ComponentFieldAttribute.cs" />
     <Compile Include="Attribute\ComponentsFieldAttribute.cs" />
     <Compile Include="Attribute\CategoryFieldAttribute.cs" />


### PR DESCRIPTION
This adds an attribute that can be used to show a binary file field on a workflow action.  I made the binaryFileTypeGuid required since, without it being set, the field has no options and doesn't make sense.