### PR TITLE
Feature immediate post save trigger

### DIFF
--- a/Rock/Data/DbContext.cs
+++ b/Rock/Data/DbContext.cs
@@ -311,6 +311,7 @@ namespace Rock.Data
                 }
                 else
                 {
+                    TriggerWorkflows( item.Entity, WorkflowTriggerType.ImmediatePostSave, personAlias );
                     TriggerWorkflows( item.Entity, WorkflowTriggerType.PostSave, personAlias );
                 }
             }
@@ -347,7 +348,7 @@ namespace Rock.Data
 
                     if ( match )
                     {
-                        if ( triggerType == WorkflowTriggerType.PreSave || triggerType == WorkflowTriggerType.PreDelete )
+                        if ( triggerType == WorkflowTriggerType.PreSave || triggerType == WorkflowTriggerType.PreDelete || triggerType == WorkflowTriggerType.ImmediatePostSave )
                         {
                             var workflowType = workflowTypeService.Get( trigger.WorkflowTypeId );
 

--- a/Rock/Model/WorkflowTrigger.cs
+++ b/Rock/Model/WorkflowTrigger.cs
@@ -203,7 +203,12 @@ namespace Rock.Model
         /// <summary>
         /// Post Delete
         /// </summary>
-        PostDelete = 3
+        PostDelete = 3,
+
+        /// <summary>
+        /// Immediate Post Save
+        /// </summary>
+        ImmediatePostSave = 4
     }
 
     #endregion

--- a/RockWeb/Blocks/WorkFlow/WorkflowTriggerDetail.ascx
+++ b/RockWeb/Blocks/WorkFlow/WorkflowTriggerDetail.ascx
@@ -32,7 +32,7 @@
                         </div>
                         <div class="col-md-6">
                             <Rock:DataDropDownList ID="ddlWorkflowType" runat="server" SourceTypeName="Rock.Model.WorkflowTrigger, Rock" PropertyName="WorkflowType" Required="true" Help="The workflow type to run when a change occurs." />
-                            <Rock:RockRadioButtonList ID="rblTriggerType" runat="server" RepeatDirection="Horizontal" Label="Trigger Type" Help="Determines when the tigger should be fired. Using a 'pre' event allows the workflow to cancel the action and notify the user." />
+                            <Rock:RockRadioButtonList ID="rblTriggerType" runat="server" RepeatDirection="Horizontal" Label="Trigger Type" Help="Determines when the trigger should be fired. Using a 'pre' event allows the workflow to cancel the action and notify the user. 'Post' events are considered more efficient because they run the workflow in a job within 60 seconds, thus preventing the user interface execution from being blocked. Immediate post save should be used when the Id of a new entity needs to be known and the workflow should not wait for the job-based execution." />
                             
                         </div>
                     </div>

--- a/RockWeb/Blocks/WorkFlow/WorkflowTriggerDetail.ascx
+++ b/RockWeb/Blocks/WorkFlow/WorkflowTriggerDetail.ascx
@@ -32,7 +32,7 @@
                         </div>
                         <div class="col-md-6">
                             <Rock:DataDropDownList ID="ddlWorkflowType" runat="server" SourceTypeName="Rock.Model.WorkflowTrigger, Rock" PropertyName="WorkflowType" Required="true" Help="The workflow type to run when a change occurs." />
-                            <Rock:RockRadioButtonList ID="rblTriggerType" runat="server" RepeatDirection="Horizontal" Label="Trigger Type" Help="Determines when the trigger should be fired. Using a 'pre' event allows the workflow to cancel the action and notify the user. 'Post' events are considered more efficient because they run the workflow in a job within 60 seconds, thus preventing the user interface execution from being blocked. Immediate post save should be used when the Id of a new entity needs to be known and the workflow should not wait for the job-based execution." />
+                            <Rock:RockRadioButtonList ID="rblTriggerType" runat="server" RepeatDirection="Horizontal" Label="Trigger Type" Help="Determines when the trigger should be fired. 'Pre' events allow the workflow to cancel the action and notify the user. 'Post' events are more efficient because they prevent the user interface from being blocked. 'Immediate Post Save' events are used when the workflow should run immediately and the entity ID is required." />
                             
                         </div>
                     </div>


### PR DESCRIPTION
This feature is an immediate-post-save workflow trigger option.  This option is ideal for workflows that should be executed at run-time (not queued for a transactional worker) and that require the database assigned Id to be set.  

NewSpring will be using this workflow trigger type for our REST based sync between Rock and our other platforms.  The workflow, REST Sync, requires that the Id be assigned already to newly created entities and we want the sync to be real time.

I did not see the value in adding an immediate post delete.  The reason is that pre-delete would function effectively the same way because an entity being deleted already has a database assigned id.