### PR TITLE
Return the created entity after a REST POST

### DIFF
--- a/Rock.Rest/ApiController.cs
+++ b/Rock.Rest/ApiController.cs
@@ -128,7 +128,7 @@ namespace Rock.Rest
             System.Web.HttpContext.Current.Items.Add( "CurrentPerson", GetPerson() );
             Service.Context.SaveChanges();
 
-            var response = ControllerContext.Request.CreateResponse( HttpStatusCode.Created );
+            var response = ControllerContext.Request.CreateResponse( HttpStatusCode.Created, value );
 
             // TODO set response.Headers.Location as per REST POST convention
             //response.Headers.Location = new Uri( Request.RequestUri, "/api/pages/" + page.Id.ToString() );

--- a/Rock.Rest/ApiController.cs
+++ b/Rock.Rest/ApiController.cs
@@ -128,7 +128,7 @@ namespace Rock.Rest
             System.Web.HttpContext.Current.Items.Add( "CurrentPerson", GetPerson() );
             Service.Context.SaveChanges();
 
-            var response = ControllerContext.Request.CreateResponse( HttpStatusCode.Created, value );
+            var response = ControllerContext.Request.CreateResponse( HttpStatusCode.Created, value.Id );
 
             // TODO set response.Headers.Location as per REST POST convention
             //response.Headers.Location = new Uri( Request.RequestUri, "/api/pages/" + page.Id.ToString() );

--- a/Rock.Rest/Controllers/PeopleController.Partial.cs
+++ b/Rock.Rest/Controllers/PeopleController.Partial.cs
@@ -190,7 +190,7 @@ namespace Rock.Rest.Controllers
             System.Web.HttpContext.Current.Items.Add( "CurrentPerson", GetPerson() );
             PersonService.SaveNewPerson( person, (Rock.Data.RockContext)Service.Context, null, false );
 
-            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, person );
+            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, person.Id );
         }
 
         #endregion

--- a/Rock.Rest/Controllers/PeopleController.Partial.cs
+++ b/Rock.Rest/Controllers/PeopleController.Partial.cs
@@ -44,7 +44,7 @@ namespace Rock.Rest.Controllers
         {
             // NOTE: We want PrimaryAliasId to be populated, so call this.Get( false ) which includes "Aliases"
             var person = this.Get( true ).FirstOrDefault( a => a.Id == id );
-            if (person == null)
+            if ( person == null )
             {
                 throw new HttpResponseException( HttpStatusCode.NotFound );
             }
@@ -60,7 +60,7 @@ namespace Rock.Rest.Controllers
             // NOTE: We want PrimaryAliasId to be populated, so call this.Get( false ) which includes "Aliases"
             return this.GetById( key );
         }
-        
+
         /// <summary>
         /// Returns a Queryable of Person records
         /// </summary>
@@ -82,12 +82,12 @@ namespace Rock.Rest.Controllers
         /// <returns></returns>
         [Authenticate, Secured]
         [EnableQuery]
-        public IQueryable<Person> Get( bool includeDeceased)
+        public IQueryable<Person> Get( bool includeDeceased )
         {
             var rockContext = this.Service.Context as RockContext;
 
             // NOTE: We want PrimaryAliasId to be populated, so include "Aliases"
-            return new PersonService( rockContext ).Queryable( "Aliases", includeDeceased);
+            return new PersonService( rockContext ).Queryable( "Aliases", includeDeceased );
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Rock.Rest.Controllers
             System.Web.HttpContext.Current.Items.Add( "CurrentPerson", GetPerson() );
             PersonService.SaveNewPerson( person, (Rock.Data.RockContext)Service.Context, null, false );
 
-            return  ControllerContext.Request.CreateResponse( HttpStatusCode.Created );
+            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, person );
         }
 
         #endregion
@@ -254,7 +254,7 @@ namespace Rock.Rest.Controllers
             var phoneNumbersQry = new PhoneNumberService( rockContext ).Queryable();
 
             // join with PhoneNumbers to avoid lazy loading
-            var joinQry = sortedPersonQry.GroupJoin( phoneNumbersQry, p => p.Id, n => n.PersonId, (Person, PhoneNumbers) => new { Person, PhoneNumbers } );
+            var joinQry = sortedPersonQry.GroupJoin( phoneNumbersQry, p => p.Id, n => n.PersonId, ( Person, PhoneNumbers ) => new { Person, PhoneNumbers } );
 
             var topQry = joinQry.Take( count );
 
@@ -340,7 +340,7 @@ namespace Rock.Rest.Controllers
                     {
                         personInfoHtml += familyGroupTypeRoles.First( a => a.Id == familyGroupMember.GroupRoleId ).Name;
                     }
-                    
+
                     if ( personAge != null )
                     {
                         personInfoHtml += " <em>(" + personAge.ToString() + " yrs old)</em>";
@@ -398,7 +398,7 @@ namespace Rock.Rest.Controllers
 
                         personInfoHtml += emailAndPhoneHtml;
                     }
-                    
+
                     personSearchResult.PickerItemDetailsHtml = string.Format( itemDetailFormat, imageHtml, personInfoHtml );
                 }
 
@@ -437,9 +437,9 @@ namespace Rock.Rest.Controllers
                 {
                     recordTypeValueGuid = DefinedValueCache.Read( person.RecordTypeValueId.Value ).Guid;
                 }
-                
+
                 var appPath = System.Web.VirtualPathUtility.ToAbsolute( "~" );
-                html.AppendFormat( 
+                html.AppendFormat(
                     "<header>{0} <h3>{1}<small>{2}</small></h3></header>",
                     Person.GetPhotoImageTag( person.PhotoId, person.Age, person.Gender, recordTypeValueGuid, 65, 65 ),
                     person.FullName,
@@ -448,7 +448,7 @@ namespace Rock.Rest.Controllers
                 var spouse = person.GetSpouse( rockContext );
                 if ( spouse != null )
                 {
-                    html.AppendFormat( 
+                    html.AppendFormat(
                         "<strong>Spouse</strong> {0}",
                         spouse.LastName == person.LastName ? spouse.FirstName : spouse.FullName );
                 }

--- a/Rock.Rest/Controllers/TaggedItemsController.Partial.cs
+++ b/Rock.Rest/Controllers/TaggedItemsController.Partial.cs
@@ -122,7 +122,7 @@ namespace Rock.Rest.Controllers
             System.Web.HttpContext.Current.Items.Add( "CurrentPerson", GetPerson() );
             Service.Context.SaveChanges();
 
-            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, tag );
+            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, tag.Id );
         }
 
         /// <summary>

--- a/Rock.Rest/Controllers/TaggedItemsController.Partial.cs
+++ b/Rock.Rest/Controllers/TaggedItemsController.Partial.cs
@@ -122,7 +122,7 @@ namespace Rock.Rest.Controllers
             System.Web.HttpContext.Current.Items.Add( "CurrentPerson", GetPerson() );
             Service.Context.SaveChanges();
 
-            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created );
+            return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, tag );
         }
 
         /// <summary>


### PR DESCRIPTION
This will improve the efficiency of 3rd party software that uses the REST endpoint.  This is a very common requirement to need the Id (among other data points) when creating an entity through a REST client.

Consider this real world example of NewSpring's current usage:
1.) Create person locally
2.) Be sure to assign guid for reference
3.) 1st API request POST to Rock to create person there
4.) 2nd API request GET person back from Rock by Guid
5.) Update local person with Rock's Id and other default data (guid, primaryAliasId, etc) assigned upon creation

And with this pull request:
1.) Create person locally
2.) 1st API request POST to Rock to create person there
3.) Update local person with Rock's Id and other default data assigned upon creation

http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5 - I believe the POST specification in the link allows for returning the entity in this verbiage: "contain an entity which describes the status of the request and refers to the new resource"

The primary change is to lines generating the responses: 
return ControllerContext.Request.CreateResponse( HttpStatusCode.Created, person );