### PR TITLE
Enums should be treated as ints

### DIFF
--- a/Rock.Rest/ApiController.cs
+++ b/Rock.Rest/ApiController.cs
@@ -222,7 +222,7 @@ namespace Rock.Rest
                                 // No need to parse anything
                                 property.SetValue( targetModel, null );
                             }
-                            else if ( propertyType == typeof( int ) || propertyType == typeof( int? ) )
+                            else if ( propertyType == typeof( int ) || propertyType == typeof( int? ) || propertyType.IsEnum )
                             {
                                 // By default, objects that hold integer values, hold int64, so coerce to int32
                                 try


### PR DESCRIPTION
Otherwise they throw cannot convert int64 to enum

Fixes #960 