### PR TITLE
Fix inherited grouptypes and groups in Attendance Reporting

### DIFF
--- a/RockWeb/Blocks/CheckIn/AttendanceReporting.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceReporting.ascx.cs
@@ -48,6 +48,9 @@ namespace RockWeb.Blocks.CheckIn
 
         private RockContext _rockContext = null;
 
+        private List<DateTime> _possibleAttendances = null;
+        private Dictionary<int, string> _scheduleNameLookup = null;
+
         #endregion
 
         #region Base Control Methods
@@ -576,9 +579,6 @@ function(item) {
 
             gChartAttendance.DataBind();
         }
-
-        private List<DateTime> _possibleAttendances = null;
-        private Dictionary<int, string> _scheduleNameLookup = null;
 
         /// <summary>
         /// Binds the attendees grid.

--- a/RockWeb/Blocks/CheckIn/AttendanceReporting.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceReporting.ascx.cs
@@ -40,7 +40,7 @@ namespace RockWeb.Blocks.CheckIn
     [Description( "Shows a graph of attendance statistics which can be configured for specific groups, date range, etc." )]
     [DefinedValueField( Rock.SystemGuid.DefinedType.CHART_STYLES, "Chart Style", DefaultValue = Rock.SystemGuid.DefinedValue.CHART_STYLE_ROCK )]
     [LinkedPage( "Detail Page", "Select the page to navigate to when the chart is clicked" )]
-    [BooleanField( "Show Group Ancestry", "By default the group ancestry path is shown.  Unselect this to show only the group name.", true)]
+    [BooleanField( "Show Group Ancestry", "By default the group ancestry path is shown.  Unselect this to show only the group name.", true )]
     [GroupTypeField( "Check-in Type", required: false, key: "GroupTypeTemplate", groupTypePurposeValueGuid: Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE )]
     public partial class AttendanceReporting : RockBlock
     {


### PR DESCRIPTION
@mikepetersonccv I stole all of @azturner's brilliant work on CheckInConfiguration to update this block.

This change displays groups at their current grouptype/area instead of at the top-level grouptype/area (see previous PR's screenshot for incorrect behavior).  It also allows groups to have a parent group and still be displayed.

![screenshot 2015-05-20 10 35 18](https://cloud.githubusercontent.com/assets/1210933/7729592/9cc33678-fee3-11e4-837c-0d7c077e988c.png)

One remaining issue whenever switching to the attendee view; there are too many columns for the size of the page and I would occasionally get a timeout.   

![screenshot 2015-05-20 11 09 43](https://cloud.githubusercontent.com/assets/1210933/7729478/022fd936-fee3-11e4-8d8c-514f18ce11b6.png)

The timeout occurred when trying to load a single Sunday morning for a single campus (208 check-ins).  I'm guessing the timeout is due to the location query -- maybe we should add a Show/Hide Location block attribute?