### PR TITLE
- Fixed issue with empty Boolean Field filter

### DIFF
--- a/Rock/Field/Types/BooleanFieldType.cs
+++ b/Rock/Field/Types/BooleanFieldType.cs
@@ -329,7 +329,8 @@ namespace Rock.Field.Types
             var ddl = control as DropDownList;
             if (ddl != null )
             {
-                return ddl.SelectedValue;
+                // Return the filter value only if a value has been selected.
+                return string.IsNullOrEmpty(ddl.SelectedValue) ? null : ddl.SelectedValue;
             }
 
             return string.Empty;


### PR DESCRIPTION
When a Boolean Field is show as a Grid column and the Filter is blank, the filter should be ignored. Instead, the filter only returns records with an empty value in the Boolean Field.