### PR TITLE
Fix Boolean FormatException processing Attribute Values with "Yes" or user-defined text instead of "True"

### DIFF
--- a/Rock/Workflow/Action/CheckIn/FilterGroupsBySpecialNeeds.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsBySpecialNeeds.cs
@@ -55,8 +55,8 @@ namespace Rock.Workflow.Action.CheckIn
                 return false;
             }
 
-            bool removeSNGroups = bool.Parse( GetAttributeValue( action, "RemoveSpecialNeedsGroups" ) ?? "true" );
-            bool removeNonSNGroups = bool.Parse( GetAttributeValue( action, "RemoveNonSpecialNeedsGroups" ) ?? "false" );
+            bool removeSNGroups = GetAttributeValue( action, "RemoveSpecialNeedsGroups" ).AsBoolean( resultIfNullOrEmpty: true );
+            bool removeNonSNGroups = GetAttributeValue( action, "RemoveNonSpecialNeedsGroups" ).AsBoolean();
 
             var family = checkInState.CheckIn.Families.FirstOrDefault( f => f.Selected );
             if ( family != null )
@@ -65,12 +65,12 @@ namespace Rock.Workflow.Action.CheckIn
 
                 foreach ( var person in family.People )
                 {
-                    bool isSNPerson = bool.Parse( person.Person.GetAttributeValue( "IsSpecialNeeds" ) ?? "false" );
+                    bool isSNPerson = person.Person.GetAttributeValue( "IsSpecialNeeds" ).AsBoolean();
                     foreach ( var groupType in person.GroupTypes.ToList() )
                     {
                         foreach ( var group in groupType.Groups.ToList() )
                         {
-                            bool isSNGroup = bool.Parse( group.Group.GetAttributeValue( "IsSpecialNeeds" ) ?? "false" );
+                            bool isSNGroup = group.Group.GetAttributeValue( "IsSpecialNeeds" ).AsBoolean();
 
                             // If the group is special needs but the person is not, then remove it.
                             if ( removeSNGroups && isSNGroup && !( isSNPerson ) )

--- a/Rock/Workflow/Action/CheckIn/LoadGroups.cs
+++ b/Rock/Workflow/Action/CheckIn/LoadGroups.cs
@@ -30,10 +30,11 @@ namespace Rock.Workflow.Action.CheckIn
     /// <summary>
     /// Loads the groups available for each location.
     /// </summary>
-    [Description("Loads the groups available for each selected (or optionally all) location(s)")]
-    [Export(typeof(ActionComponent))]
+    [Description( "Loads the groups available for each selected (or optionally all) location(s)" )]
+    [Export( typeof( ActionComponent ) )]
     [ExportMetadata( "ComponentName", "Load Groups" )]
-    [BooleanField( "Load All", "By default groups are only loaded for the selected person, group type, and location.  Select this option to load groups for all the loaded people and group types." )]    public class LoadGroups : CheckInActionComponent
+    [BooleanField( "Load All", "By default groups are only loaded for the selected person, group type, and location.  Select this option to load groups for all the loaded people and group types." )]
+    public class LoadGroups : CheckInActionComponent
     {
         /// <summary>
         /// Executes the specified workflow.
@@ -49,12 +50,7 @@ namespace Rock.Workflow.Action.CheckIn
             var checkInState = GetCheckInState( entity, out errorMessages );
             if ( checkInState != null )
             {
-
-                bool loadAll = false;
-                if ( bool.TryParse( GetAttributeValue( action, "LoadAll" ), out loadAll ) && loadAll )
-                {
-                    loadAll = true;
-                }
+                bool loadAll = GetAttributeValue( action, "LoadAll" ).AsBoolean();
 
                 foreach ( var family in checkInState.CheckIn.Families.Where( f => f.Selected ).ToList() )
                 {
@@ -62,7 +58,7 @@ namespace Rock.Workflow.Action.CheckIn
                     {
                         foreach ( var groupType in person.GroupTypes.Where( g => g.Selected || loadAll ).ToList() )
                         {
-                            var kioskGroupType = checkInState.Kiosk.FilteredGroupTypes(checkInState.ConfiguredGroupTypes).Where( g => g.GroupType.Id == groupType.GroupType.Id ).FirstOrDefault();
+                            var kioskGroupType = checkInState.Kiosk.FilteredGroupTypes( checkInState.ConfiguredGroupTypes ).Where( g => g.GroupType.Id == groupType.GroupType.Id ).FirstOrDefault();
                             if ( kioskGroupType != null )
                             {
                                 foreach ( var kioskGroup in kioskGroupType.KioskGroups )

--- a/Rock/Workflow/Action/CheckIn/LoadLocations.cs
+++ b/Rock/Workflow/Action/CheckIn/LoadLocations.cs
@@ -30,8 +30,8 @@ namespace Rock.Workflow.Action.CheckIn
     /// <summary>
     /// Adds the locations for each members group types
     /// </summary>
-    [Description("Adds the locations for each members group types")]
-    [Export(typeof(ActionComponent))]
+    [Description( "Adds the locations for each members group types" )]
+    [Export( typeof( ActionComponent ) )]
     [ExportMetadata( "ComponentName", "Load Locations" )]
     [BooleanField( "Load All", "By default locations are only loaded for the selected person and group type.  Select this option to load locations for all the loaded people and group types." )]
     public class LoadLocations : CheckInActionComponent
@@ -50,12 +50,7 @@ namespace Rock.Workflow.Action.CheckIn
             var checkInState = GetCheckInState( entity, out errorMessages );
             if ( checkInState != null )
             {
-
-                bool loadAll = false;
-                if ( bool.TryParse( GetAttributeValue( action, "LoadAll" ), out loadAll ) && loadAll )
-                {
-                    loadAll = true;
-                }
+                bool loadAll = GetAttributeValue( action, "LoadAll" ).AsBoolean();
 
                 foreach ( var family in checkInState.CheckIn.Families.Where( f => f.Selected ).ToList() )
                 {
@@ -63,7 +58,7 @@ namespace Rock.Workflow.Action.CheckIn
                     {
                         foreach ( var groupType in person.GroupTypes.Where( t => t.Selected || loadAll ).ToList() )
                         {
-                            var kioskGroupType = checkInState.Kiosk.FilteredGroupTypes( checkInState.ConfiguredGroupTypes ) .Where( g => g.GroupType.Id == groupType.GroupType.Id ).FirstOrDefault();
+                            var kioskGroupType = checkInState.Kiosk.FilteredGroupTypes( checkInState.ConfiguredGroupTypes ).Where( g => g.GroupType.Id == groupType.GroupType.Id ).FirstOrDefault();
                             if ( kioskGroupType != null )
                             {
                                 foreach ( var group in groupType.Groups.Where( g => g.Selected || loadAll ).ToList() )

--- a/Rock/Workflow/Action/CheckIn/LoadSchedules.cs
+++ b/Rock/Workflow/Action/CheckIn/LoadSchedules.cs
@@ -30,8 +30,8 @@ namespace Rock.Workflow.Action.CheckIn
     /// <summary>
     /// Loads the schedules available for each group
     /// </summary>
-    [Description("Loads the schedules available for each group")]
-    [Export(typeof(ActionComponent))]
+    [Description( "Loads the schedules available for each group" )]
+    [Export( typeof( ActionComponent ) )]
     [ExportMetadata( "ComponentName", "Load Schedules" )]
     [BooleanField( "Load All", "By default schedules are only loaded for the selected person, group type, location, and group.  Select this option to load schedules for all the loaded people, group types, locations, and groups." )]
     public class LoadSchedules : CheckInActionComponent
@@ -50,53 +50,48 @@ namespace Rock.Workflow.Action.CheckIn
             var checkInState = GetCheckInState( entity, out errorMessages );
             if ( checkInState != null )
             {
+                bool loadAll = GetAttributeValue( action, "LoadAll" ).AsBoolean();
 
-                bool loadAll = false;
-                if ( bool.TryParse( GetAttributeValue( action, "LoadAll" ), out loadAll ) && loadAll )
+                foreach ( var family in checkInState.CheckIn.Families.Where( f => f.Selected ).ToList() )
                 {
-                    loadAll = true;
+                    foreach ( var person in family.People.Where( p => p.Selected ).ToList() )
+                    {
+                        foreach ( var groupType in person.GroupTypes.Where( g => g.Selected || loadAll ).ToList() )
+                        {
+                            var kioskGroupType = checkInState.Kiosk.FilteredGroupTypes( checkInState.ConfiguredGroupTypes ).Where( g => g.GroupType.Id == groupType.GroupType.Id ).FirstOrDefault();
+                            if ( kioskGroupType != null )
+                            {
+                                foreach ( var group in groupType.Groups.Where( g => g.Selected || loadAll ).ToList() )
+                                {
+                                    foreach ( var location in group.Locations.Where( l => l.Selected || loadAll ).ToList() )
+                                    {
+                                        var kioskGroup = kioskGroupType.KioskGroups.Where( g => g.Group.Id == group.Group.Id ).FirstOrDefault();
+                                        if ( kioskGroup != null )
+                                        {
+                                            var kioskLocation = kioskGroup.KioskLocations.Where( l => l.Location.Id == location.Location.Id ).FirstOrDefault();
+                                            if ( kioskLocation != null )
+                                            {
+                                                foreach ( var kioskSchedule in kioskLocation.KioskSchedules )
+                                                {
+                                                    if ( !location.Schedules.Any( s => s.Schedule.Id == kioskSchedule.Schedule.Id ) )
+                                                    {
+                                                        var checkInSchedule = new CheckInSchedule();
+                                                        checkInSchedule.Schedule = kioskSchedule.Schedule.Clone( false );
+                                                        checkInSchedule.StartTime = kioskSchedule.StartTime;
+                                                        location.Schedules.Add( checkInSchedule );
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
-                 foreach ( var family in checkInState.CheckIn.Families.Where( f => f.Selected ).ToList() )
-                 {
-                     foreach ( var person in family.People.Where( p => p.Selected ).ToList() )
-                     {
-                         foreach ( var groupType in person.GroupTypes.Where( g => g.Selected || loadAll ).ToList() )
-                         {
-                             var kioskGroupType = checkInState.Kiosk.FilteredGroupTypes( checkInState.ConfiguredGroupTypes ) .Where( g => g.GroupType.Id == groupType.GroupType.Id ).FirstOrDefault();
-                             if ( kioskGroupType != null )
-                             {
-                                 foreach ( var group in groupType.Groups.Where( g => g.Selected || loadAll ).ToList() )
-                                 {
-                                     foreach ( var location in group.Locations.Where( l => l.Selected || loadAll ).ToList() )
-                                     {
-                                         var kioskGroup = kioskGroupType.KioskGroups.Where( g => g.Group.Id == group.Group.Id ).FirstOrDefault();
-                                         if ( kioskGroup != null )
-                                         {
-                                             var kioskLocation = kioskGroup.KioskLocations.Where( l => l.Location.Id == location.Location.Id ).FirstOrDefault();
-                                             if ( kioskLocation != null )
-                                             {
-                                                 foreach ( var kioskSchedule in kioskLocation.KioskSchedules )
-                                                 {
-                                                     if ( !location.Schedules.Any( s => s.Schedule.Id == kioskSchedule.Schedule.Id ) )
-                                                     {
-                                                         var checkInSchedule = new CheckInSchedule();
-                                                         checkInSchedule.Schedule = kioskSchedule.Schedule.Clone( false );
-                                                         checkInSchedule.StartTime = kioskSchedule.StartTime;
-                                                         location.Schedules.Add( checkInSchedule );
-                                                     }
-                                                 }
-                                             }
-                                         }
-                                     }
-                                 }
-                             }
-                         }
-                     }
-                 }
-
-                 return true;
-             }
+                return true;
+            }
 
             return false;
         }

--- a/Rock/Workflow/Action/CheckIn/SaveAttendance.cs
+++ b/Rock/Workflow/Action/CheckIn/SaveAttendance.cs
@@ -52,13 +52,9 @@ namespace Rock.Workflow.Action.CheckIn
             if ( checkInState != null )
             {
                 AttendanceCode attendanceCode = null;
-                bool reuseCodeForFamily = false;
-                if ( bool.TryParse( GetAttributeValue( action, "ReuseCodeForFamily" ), out reuseCodeForFamily ) && reuseCodeForFamily )
-                {
-                    reuseCodeForFamily = true;
-                }
-
                 DateTime startDateTime = RockDateTime.Now;
+
+                bool reuseCodeForFamily = GetAttributeValue( action, "ReuseCodeForFamily" ).AsBoolean();
 
                 int securityCodeLength = 3;
                 if ( !int.TryParse( GetAttributeValue( action, "SecurityCodeLength" ), out securityCodeLength ) )

--- a/RockWeb/Blocks/CheckIn/Admin.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Admin.ascx.cs
@@ -71,7 +71,7 @@ namespace RockWeb.Blocks.CheckIn
                 }
                 else
                 {
-                    bool enableLocationSharing = bool.Parse( GetAttributeValue( "EnableLocationSharing" ) ?? "false" );
+                    bool enableLocationSharing = GetAttributeValue( "EnableLocationSharing" ).AsBoolean();
 
                     // Inject script used for geo location determiniation
                     if ( enableLocationSharing )
@@ -342,7 +342,7 @@ namespace RockWeb.Blocks.CheckIn
         /// </summary>
         private void TooFar()
         {
-            bool allowManualSetup = bool.Parse( GetAttributeValue( "AllowManualSetup" ) ?? "true" );
+            bool allowManualSetup = GetAttributeValue( "AllowManualSetup" ).AsBoolean( resultIfNullOrEmpty: true );
 
             if ( allowManualSetup )
             {

--- a/RockWeb/Blocks/CheckIn/Admin.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Admin.ascx.cs
@@ -23,20 +23,19 @@ using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-
+using Rock;
 using Rock.Attribute;
 using Rock.CheckIn;
 using Rock.Constants;
+using Rock.Data;
 using Rock.Model;
 using Rock.Web.Cache;
 using Rock.Web.UI.Controls;
-using Rock;
-using Rock.Data;
 
 namespace RockWeb.Blocks.CheckIn
 {
-    [DisplayName("Administration")]
-    [Category("Check-in")]
+    [DisplayName( "Administration" )]
+    [Category( "Check-in" )]
     [Description( "Check-in Administration block" )]
     [BooleanField( "Allow Manual Setup", "If enabled, the block will allow the kiosk to be setup manually if it was not set via other means.", true )]
     [BooleanField( "Enable Location Sharing", "If enabled, the block will attempt to determine the kiosk's location via location sharing geocode.", false, "Geo Location", 0 )]
@@ -128,9 +127,9 @@ namespace RockWeb.Blocks.CheckIn
                     using ( var rockContext = new RockContext() )
                     {
                         ddlKiosk.DataSource = new DeviceService( rockContext )
-                        	.Queryable().AsNoTracking()
+                            .Queryable().AsNoTracking()
                             .Where( d => d.DeviceType.Guid.Equals( kioskDeviceType ) )
-                            .OrderBy(d => d.Name)
+                            .OrderBy( d => d.Name )
                             .Select( d => new
                             {
                                 d.Id,
@@ -192,7 +191,6 @@ namespace RockWeb.Blocks.CheckIn
             string geoScript = string.Format( @"
     <script>
         $(document).ready(function (e) {{
-
             tryGeoLocation();
 
             function tryGeoLocation() {{
@@ -213,7 +211,7 @@ namespace RockWeb.Blocks.CheckIn
                 $(""input[id$='hfLongitude']"").val( longitude );
                 $(""div.checkin-header h1"").html( 'Checking Your Location...' );
                 $(""div.checkin-header"").append( ""<p class='text-muted'>"" + latitude + "" "" + longitude + ""</p>"" );
-                // now perform a postback to fire the check geo location 
+                // now perform a postback to fire the check geo location
                 {0};
             }}
 
@@ -255,6 +253,7 @@ namespace RockWeb.Blocks.CheckIn
         }
 
         #region GeoLocation related
+
         /// <summary>
         /// Handles attempting to find a registered Device kiosk by it's latitude and longitude.
         /// This event method is called automatically when the GeoLocation script get's the client's location.
@@ -355,13 +354,13 @@ namespace RockWeb.Blocks.CheckIn
             {
                 maWarning.Show( "You are too far. Try again later.", ModalAlertType.Alert );
             }
-            
         }
 
         protected void lbRetry_Click( object sender, EventArgs e )
         {
             // TODO
         }
+
         #endregion
 
         #region Manually Setting Kiosks related
@@ -386,7 +385,7 @@ namespace RockWeb.Blocks.CheckIn
             }
 
             var groupTypeIds = new List<int>();
-            foreach(ListItem item in cblGroupTypes.Items)
+            foreach ( ListItem item in cblGroupTypes.Items )
             {
                 if ( item.Selected )
                 {
@@ -440,7 +439,6 @@ namespace RockWeb.Blocks.CheckIn
                 .ToList();
         }
 
-
         private void BindGroupTypes()
         {
             BindGroupTypes( string.Empty );
@@ -462,7 +460,7 @@ namespace RockWeb.Blocks.CheckIn
 
                 if ( selectedValues != string.Empty )
                 {
-                    foreach ( string id in selectedValues.Split(',') )
+                    foreach ( string id in selectedValues.Split( ',' ) )
                     {
                         ListItem item = cblGroupTypes.Items.FindByValue( id );
                         if ( item != null )
@@ -508,7 +506,7 @@ namespace RockWeb.Blocks.CheckIn
             }
         }
 
-        private void RedirectToNewTheme(string theme)
+        private void RedirectToNewTheme( string theme )
         {
             var pageRef = RockPage.PageReference;
             pageRef.QueryString = new System.Collections.Specialized.NameValueCollection();

--- a/RockWeb/Blocks/Finance/ScheduledTransactionEdit.ascx.cs
+++ b/RockWeb/Blocks/Finance/ScheduledTransactionEdit.ascx.cs
@@ -40,7 +40,6 @@ namespace RockWeb.Blocks.Finance
     [DisplayName( "Scheduled Transaction Edit" )]
     [Category( "Finance" )]
     [Description( "Edit an existing scheduled transaction." )]
-
     [BooleanField( "Impersonation", "Allow (only use on an internal page used by staff)", "Don't Allow",
         "Should the current user be able to view and edit other people's transactions?  IMPORTANT: This should only be enabled on an internal page that is secured to trusted users", false, "", 0 )]
     [AccountsField( "Accounts", "The accounts to display.  By default all active accounts with a Public Name will be displayed", false, "", "", 1 )]
@@ -51,35 +50,31 @@ namespace RockWeb.Blocks.Finance
     // Text Options
 
     [TextField( "Panel Title", "The text to display in panel heading", false, "Scheduled Transaction", "Text Options", 4 )]
-
     [TextField( "Contribution Info Title", "The text to display as heading of section for selecting account and amount.", false, "Contribution Information", "Text Options", 5 )]
     [TextField( "Add Account Text", "The button text to display for adding an additional account", false, "Add Another Account", "Text Options", 6 )]
-
     [TextField( "Payment Info Title", "The text to display as heading of section for entering credit card or bank account information.", false, "Payment Information", "Text Options", 7 )]
-
     [TextField( "Confirmation Title", "The text to display as heading of section for confirming information entered.", false, "Confirm Information", "Text Options", 8 )]
-    [CodeEditorField( "Confirmation Header", "The text (HTML) to display at the top of the confirmation section.", 
+    [CodeEditorField( "Confirmation Header", "The text (HTML) to display at the top of the confirmation section.",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 <p>
-Please confirm the information below. Once you have confirmed that the information is accurate click the 'Finish' button to complete your transaction. 
+Please confirm the information below. Once you have confirmed that the information is accurate click the 'Finish' button to complete your transaction.
 </p>
 ", "Text Options", 9 )]
-    [CodeEditorField( "Confirmation Footer", "The text (HTML) to display at the bottom of the confirmation section.", 
+    [CodeEditorField( "Confirmation Footer", "The text (HTML) to display at the bottom of the confirmation section.",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 <div class='alert alert-info'>
-By clicking the 'finish' button below I agree to allow {{ OrganizationName }} to debit the amount above from my account. I acknowledge that I may 
-update the transaction information at any time by returning to this website. Please call the Finance Office if you have any additional questions. 
+By clicking the 'finish' button below I agree to allow {{ OrganizationName }} to debit the amount above from my account. I acknowledge that I may
+update the transaction information at any time by returning to this website. Please call the Finance Office if you have any additional questions.
 </div>
 ", "Text Options", 10 )]
-
-    [CodeEditorField( "Success Header", "The text (HTML) to display at the top of the success section.", 
+    [CodeEditorField( "Success Header", "The text (HTML) to display at the top of the success section.",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 <p>
-Thank you for your generous contribution.  Your support is helping {{ OrganizationName }} actively 
-achieve our mission.  We are so grateful for your commitment. 
+Thank you for your generous contribution.  Your support is helping {{ OrganizationName }} actively
+achieve our mission.  We are so grateful for your commitment.
 </p>
 ", "Text Options", 11 )]
-    [CodeEditorField( "Success Footer", "The text (HTML) to display at the bottom of the success section.", 
+    [CodeEditorField( "Success Footer", "The text (HTML) to display at the bottom of the success section.",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 ", "Text Options", 12 )]
 
@@ -273,7 +268,7 @@ achieve our mission.  We are so grateful for your commitment.
                     txtBankName.Text = "Test Bank";
                     txtRoutingNumber.Text = "111111118";
                     txtAccountNumber.Text = "1111111111";
-                     */ 
+                     */
                 }
             }
         }
@@ -456,7 +451,7 @@ achieve our mission.  We are so grateful for your commitment.
             var qryParams = new Dictionary<string, string>();
 
             string personParam = PageParameter( "Person" );
-            if (!string.IsNullOrWhiteSpace(personParam))
+            if ( !string.IsNullOrWhiteSpace( personParam ) )
             {
                 qryParams.Add( "Person", personParam );
             }
@@ -520,10 +515,9 @@ achieve our mission.  We are so grateful for your commitment.
             Person targetPerson = null;
             using ( var rockContext = new RockContext() )
             {
-
                 // If impersonation is allowed, and a valid person key was used, set the target to that person
-                bool allowImpersonation = false;
-                if ( bool.TryParse( GetAttributeValue( "Impersonation" ), out allowImpersonation ) && allowImpersonation )
+                bool allowImpersonation = GetAttributeValue( "Impersonation" ).AsBoolean();
+                if ( allowImpersonation )
                 {
                     string personKey = PageParameter( "Person" );
                     if ( !string.IsNullOrWhiteSpace( personKey ) )
@@ -589,11 +583,7 @@ achieve our mission.  We are so grateful for your commitment.
             var selectedGuids = GetAttributeValues( "Accounts" ).Select( Guid.Parse ).ToList();
             bool showAll = !selectedGuids.Any();
 
-            bool additionalAccounts = true;
-            if ( !bool.TryParse( GetAttributeValue( "AdditionalAccounts" ), out additionalAccounts ) )
-            {
-                additionalAccounts = true;
-            }
+            bool additionalAccounts = GetAttributeValue( "AdditionalAccounts" ).AsBoolean( resultIfNullOrEmpty: true );
 
             SelectedAccounts = new List<AccountItem>();
             AvailableAccounts = new List<AccountItem>();
@@ -925,7 +915,7 @@ achieve our mission.  We are so grateful for your commitment.
             if ( ScheduledTransactionId.HasValue )
             {
                 scheduledTransaction = new FinancialScheduledTransactionService( rockContext )
-                    .Queryable("AuthorizedPersonAlias.Person").FirstOrDefault( s => s.Id == ScheduledTransactionId.Value );
+                    .Queryable( "AuthorizedPersonAlias.Person" ).FirstOrDefault( s => s.Id == ScheduledTransactionId.Value );
             }
 
             if ( scheduledTransaction == null )
@@ -1006,7 +996,7 @@ achieve our mission.  We are so grateful for your commitment.
                 if ( ScheduledTransactionId.HasValue )
                 {
                     scheduledTransaction = transactionService
-                        .Queryable("AuthorizedPersonAlias.Person,FinancialGateway")
+                        .Queryable( "AuthorizedPersonAlias.Person,FinancialGateway" )
                         .FirstOrDefault( s => s.Id == ScheduledTransactionId.Value );
                 }
 
@@ -1021,7 +1011,7 @@ achieve our mission.  We are so grateful for your commitment.
                     scheduledTransaction.FinancialGateway.LoadAttributes();
                 }
 
-                if ( scheduledTransaction.AuthorizedPersonAlias == null || scheduledTransaction.AuthorizedPersonAlias.Person == null)
+                if ( scheduledTransaction.AuthorizedPersonAlias == null || scheduledTransaction.AuthorizedPersonAlias.Person == null )
                 {
                     errorMessage = "There was a problem determining the person associated with the transaction";
                     return false;
@@ -1134,7 +1124,7 @@ achieve our mission.  We are so grateful for your commitment.
                     ScheduleId = scheduledTransaction.GatewayScheduleId;
                     TransactionCode = scheduledTransaction.TransactionCode;
 
-                    if (transactionService.GetStatus( scheduledTransaction, out errorMessage ))
+                    if ( transactionService.GetStatus( scheduledTransaction, out errorMessage ) )
                     {
                         rockContext.SaveChanges();
                     }
@@ -1205,8 +1195,8 @@ achieve our mission.  We are so grateful for your commitment.
                 paymentInfo.LastName = authorizedPerson.LastName;
                 paymentInfo.Email = authorizedPerson.Email;
 
-                bool displayPhone = false;
-                if ( bool.TryParse( GetAttributeValue( "DisplayPhone" ), out displayPhone ) && displayPhone )
+                bool displayPhone = GetAttributeValue( "DisplayPhone" ).AsBoolean();
+                if ( displayPhone )
                 {
                     var phoneNumber = personService.GetPhoneNumber( authorizedPerson, DefinedValueCache.Read( new Guid( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_HOME ) ) );
                     paymentInfo.Phone = phoneNumber != null ? phoneNumber.ToString() : string.Empty;
@@ -1347,11 +1337,10 @@ achieve our mission.  We are so grateful for your commitment.
 
             string scriptFormat = @"
     Sys.Application.add_load(function () {{
-
         // As amounts are entered, validate that they are numeric and recalc total
         $('.account-amount').on('change', function() {{
-            var totalAmt = Number(0);   
-                 
+            var totalAmt = Number(0);
+
             $('.account-amount .form-control').each(function (index) {{
                 var itemValue = $(this).val();
                 if (itemValue != null && itemValue != '') {{
@@ -1375,7 +1364,7 @@ achieve our mission.  We are so grateful for your commitment.
 
         // Set the date prompt based on the frequency value entered
         $('#ButtonDropDown_btnFrequency .dropdown-menu a').click( function () {{
-            var $when = $(this).parents('div.form-group:first').next(); 
+            var $when = $(this).parents('div.form-group:first').next();
             if ($(this).attr('data-id') == '{3}') {{
                 $when.find('label:first').html('When');
             }} else {{
@@ -1385,7 +1374,7 @@ achieve our mission.  We are so grateful for your commitment.
                 var $dateInput = $when.find('input');
                 var dt = new Date(Date.parse($dateInput.val()));
                 var curr = new Date();
-                if ( (dt-curr) <= 0 ) {{ 
+                if ( (dt-curr) <= 0 ) {{
                     curr.setDate(curr.getDate() + 1);
                     var dd = curr.getDate();
                     var mm = curr.getMonth()+1;
@@ -1394,10 +1383,9 @@ achieve our mission.  We are so grateful for your commitment.
                     $dateInput.data('datePicker').value(mm+'/'+dd+'/'+yy);
                 }}
             }};
-            
         }});
 
-        // Save the state of the selected payment type pill to a hidden field so that state can 
+        // Save the state of the selected payment type pill to a hidden field so that state can
         // be preserved through postback
         $('a[data-toggle=""pill""]').on('shown.bs.tab', function (e) {{
             var tabHref = $(e.target).attr(""href"");
@@ -1416,14 +1404,14 @@ achieve our mission.  We are so grateful for your commitment.
         // Toggle credit card display if saved card option is available
         $('div.radio-content').prev('.form-group').find('input:radio').unbind('click').on('click', function () {{
             var $content = $(this).parents('div.form-group:first').next('.radio-content')
-            var radioDisplay = $content.css('display');            
+            var radioDisplay = $content.css('display');
             if ($(this).val() == 0 && radioDisplay == 'none') {{
                 $content.slideToggle();
             }}
             else if ($(this).val() != 0 && radioDisplay != 'none') {{
                 $content.slideToggle();
             }}
-        }});      
+        }});
 
         // Hide or show a div based on selection of checkbox
         $('input:checkbox.toggle-input').unbind('click').on('click', function () {{
@@ -1438,7 +1426,6 @@ achieve our mission.  We are so grateful for your commitment.
 				return false;
 			}});
         }});
- 
     }});
 
 ";
@@ -1453,7 +1440,7 @@ achieve our mission.  We are so grateful for your commitment.
         #region Helper Classes
 
         /// <summary>
-        /// Lightweight object for each contribution item 
+        /// Lightweight object for each contribution item
         /// </summary>
         [Serializable]
         protected class AccountItem

--- a/RockWeb/Blocks/Finance/TransactionEntry.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionEntry.ascx.cs
@@ -40,11 +40,10 @@ namespace RockWeb.Blocks.Finance
     [DisplayName( "Transaction Entry" )]
     [Category( "Finance" )]
     [Description( "Creates a new financial transaction or scheduled transaction." )]
-
     [FinancialGatewayField( "Credit Card Gateway", "The payment gateway to use for Credit Card transactions", false, "", "", 0, "CCGateway" )]
     [FinancialGatewayField( "ACH Card Gateway", "The payment gateway to use for ACH (bank account) transactions", false, "", "", 1, "ACHGateway" )]
     [TextField( "Batch Name Prefix", "The batch prefix name to use when creating a new batch", false, "Online Giving", "", 2 )]
-    [DefinedValueField( Rock.SystemGuid.DefinedType.FINANCIAL_SOURCE_TYPE, "Source", "The Financial Source Type to use when creating transactions", false, false, 
+    [DefinedValueField( Rock.SystemGuid.DefinedType.FINANCIAL_SOURCE_TYPE, "Source", "The Financial Source Type to use when creating transactions", false, false,
         Rock.SystemGuid.DefinedValue.FINANCIAL_SOURCE_TYPE_WEBSITE, "", 3 )]
     [BooleanField( "Impersonation", "Allow (only use on an internal page used by staff)", "Don't Allow",
         "Should the current user be able to view and edit other people's transactions?  IMPORTANT: This should only be enabled on an internal page that is secured to trusted users", false, "", 4 )]
@@ -63,48 +62,42 @@ namespace RockWeb.Blocks.Finance
     // Text Options
 
     [TextField( "Panel Title", "The text to display in panel heading", false, "Gifts", "Text Options", 13 )]
-
     [TextField( "Contribution Info Title", "The text to display as heading of section for selecting account and amount.", false, "Contribution Information", "Text Options", 14 )]
     [TextField( "Add Account Text", "The button text to display for adding an additional account", false, "Add Another Account", "Text Options", 15 )]
-
     [TextField( "Personal Info Title", "The text to display as heading of section for entering personal information.", false, "Personal Information", "Text Options", 16 )]
-
     [TextField( "Payment Info Title", "The text to display as heading of section for entering credit card or bank account information.", false, "Payment Information", "Text Options", 17 )]
-
     [TextField( "Confirmation Title", "The text to display as heading of section for confirming information entered.", false, "Confirm Information", "Text Options", 18 )]
-    [CodeEditorField( "Confirmation Header", "The text (HTML) to display at the top of the confirmation section.  <span class='tip tip-lava'></span> <span class='tip tip-html'></span>", 
+    [CodeEditorField( "Confirmation Header", "The text (HTML) to display at the top of the confirmation section.  <span class='tip tip-lava'></span> <span class='tip tip-html'></span>",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 <p>
-    Please confirm the information below. Once you have confirmed that the information is 
+    Please confirm the information below. Once you have confirmed that the information is
     accurate click the 'Finish' button to complete your transaction.
 </p>
 ", "Text Options", 19 )]
-    [CodeEditorField( "Confirmation Footer", "The text (HTML) to display at the bottom of the confirmation section. <span class='tip tip-lava'></span> <span class='tip tip-html'></span>", 
+    [CodeEditorField( "Confirmation Footer", "The text (HTML) to display at the bottom of the confirmation section. <span class='tip tip-lava'></span> <span class='tip tip-html'></span>",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 <div class='alert alert-info'>
-    By clicking the 'finish' button below I agree to allow {{ OrganizationName }} 
+    By clicking the 'finish' button below I agree to allow {{ OrganizationName }}
     to transfer the amount above from my account. I acknowledge that I may
-    update the transaction information at any time by returning to this website. Please 
+    update the transaction information at any time by returning to this website. Please
     call the Finance Office if you have any additional questions.
 </div>
 ", "Text Options", 20 )]
-
     [TextField( "Success Title", "The text to display as heading of section for displaying details of gift.", false, "Gift Information", "Text Options", 21 )]
-    [CodeEditorField( "Success Header", "The text (HTML) to display at the top of the success section. <span class='tip tip-lava'></Fspan> <span class='tip tip-html'></span>", 
+    [CodeEditorField( "Success Header", "The text (HTML) to display at the top of the success section. <span class='tip tip-lava'></Fspan> <span class='tip tip-html'></span>",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 <p>
     Thank you for your generous contribution.  Your support is helping {{ OrganizationName }} actively
     achieve our mission.  We are so grateful for your commitment.
 </p>
 ", "Text Options", 22 )]
-    [CodeEditorField( "Success Footer", "The text (HTML) to display at the bottom of the success section. <span class='tip tip-lava'></span> <span class='tip tip-html'></span>", 
+    [CodeEditorField( "Success Footer", "The text (HTML) to display at the bottom of the success section. <span class='tip tip-lava'></span> <span class='tip tip-html'></span>",
         CodeEditorMode.Html, CodeEditorTheme.Rock, 200, true, @"
 ", "Text Options", 23 )]
-
     [TextField( "Save Account Title", "The text to display as heading of section for saving payment information.", false, "Make Giving Even Easier", "Text Options", 24 )]
-
     [DefinedValueField( "2E6540EA-63F0-40FE-BE50-F2A84735E600", "Connection Status", "The connection status to use for new individuals (default: 'Web Prospect'.)", true, false, "368DD475-242C-49C4-A42C-7278BE690CC2", "", 25 )]
     [DefinedValueField( "8522BADD-2871-45A5-81DD-C76DA07E2E7E", "Record Status", "The record status to use for new individuals (default: 'Pending'.)", true, false, "283999EC-7346-42E3-B807-BCE9B2BABB49", "", 26 )]
+
     #endregion
 
     public partial class TransactionEntry : Rock.Web.UI.RockBlock
@@ -138,7 +131,7 @@ namespace RockWeb.Blocks.Finance
         /// <value>
         /// The group location identifier.
         /// </value>
-        protected int? GroupLocationId 
+        protected int? GroupLocationId
         {
             get { return ViewState["GroupLocationId"] as int?; }
             set { ViewState["GroupLocationId"] = value; }
@@ -350,8 +343,8 @@ namespace RockWeb.Blocks.Finance
 
                 if ( supportedFrequencies.Any() )
                 {
-                    bool allowScheduled = false;
-                    if ( bool.TryParse( GetAttributeValue( "AllowScheduled" ), out allowScheduled ) && allowScheduled )
+                    bool allowScheduled = GetAttributeValue( "AllowScheduled" ).AsBoolean();
+                    if ( allowScheduled )
                     {
                         _showRepeatingOptions = true;
                         var oneTimeFrequency = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_ONE_TIME );
@@ -525,12 +518,12 @@ namespace RockWeb.Blocks.Finance
 
                         var personService = new PersonService( rockContext );
 
-                        bool displayPhone = false;
-                        if ( bool.TryParse( GetAttributeValue( "DisplayPhone" ), out displayPhone ) && displayPhone )
+                        bool displayPhone = GetAttributeValue( "DisplayPhone" ).AsBoolean();
+                        if ( displayPhone )
                         {
                             var phoneNumber = personService.GetPhoneNumber( person, DefinedValueCache.Read( new Guid( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_HOME ) ) );
 
-                            // If person did not have a home phone number, read the cell phone number (which would then 
+                            // If person did not have a home phone number, read the cell phone number (which would then
                             // get saved as a home number also if they don't change it, which is ok ).
                             if ( phoneNumber == null || string.IsNullOrWhiteSpace( phoneNumber.Number ) )
                             {
@@ -892,11 +885,7 @@ namespace RockWeb.Blocks.Finance
             var selectedGuids = GetAttributeValues( "Accounts" ).Select( Guid.Parse ).ToList();
             bool showAll = !selectedGuids.Any();
 
-            bool additionalAccounts = true;
-            if ( !bool.TryParse( GetAttributeValue( "AdditionalAccounts" ), out additionalAccounts ) )
-            {
-                additionalAccounts = true;
-            }
+            bool additionalAccounts = GetAttributeValue( "AdditionalAccounts" ).AsBoolean( resultIfNullOrEmpty: true );
 
             SelectedAccounts = new List<AccountItem>();
             AvailableAccounts = new List<AccountItem>();
@@ -1037,8 +1026,8 @@ namespace RockWeb.Blocks.Finance
                     }
                     phone.CountryCode = PhoneNumber.CleanNumber( pnbPhone.CountryCode );
                     phone.Number = PhoneNumber.CleanNumber( pnbPhone.Number );
-                } 
-                
+                }
+
                 if ( familyGroup == null )
                 {
                     var groupLocationService = new GroupLocationService( rockContext );
@@ -1086,7 +1075,7 @@ namespace RockWeb.Blocks.Finance
 
                 if ( _ccGateway != null )
                 {
-                    var ccGatewayComponent = _ccGateway.GetGatewayComponent(); 
+                    var ccGatewayComponent = _ccGateway.GetGatewayComponent();
                     var ccCurrencyType = DefinedValueCache.Read( new Guid( Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_CREDIT_CARD ) );
                     if ( ccGatewayComponent != null && ccGatewayComponent.SupportsSavedAccount( ccCurrencyType ) )
                     {
@@ -1191,7 +1180,7 @@ namespace RockWeb.Blocks.Finance
 
             var location = new Location();
             acAddress.GetValues( location );
-            if ( string.IsNullOrWhiteSpace( location.Street1 )  )
+            if ( string.IsNullOrWhiteSpace( location.Street1 ) )
             {
                 errorMessages.Add( "Make sure to enter a valid address.  An address is required for us to process this transaction" );
             }
@@ -1476,7 +1465,7 @@ namespace RockWeb.Blocks.Finance
                     return false;
                 }
 
-                if ( !person.PrimaryAliasId.HasValue)
+                if ( !person.PrimaryAliasId.HasValue )
                 {
                     errorMessage = "There was a problem creating the person's primary alias";
                     return false;
@@ -1505,7 +1494,7 @@ namespace RockWeb.Blocks.Finance
                     schedule.PersonId = person.Id;
 
                     var scheduledTransaction = gateway.AddScheduledPayment( financialGateway, schedule, paymentInfo, out errorMessage );
-                    if ( scheduledTransaction != null  )
+                    if ( scheduledTransaction != null )
                     {
                         scheduledTransaction.TransactionFrequencyValueId = schedule.TransactionFrequencyValue.Id;
                         scheduledTransaction.AuthorizedPersonAliasId = person.PrimaryAliasId.Value;
@@ -1517,7 +1506,7 @@ namespace RockWeb.Blocks.Finance
                         changeSummary.AppendFormat( "{0} starting {1}", schedule.TransactionFrequencyValue.Value, schedule.StartDate.ToShortDateString() );
                         changeSummary.AppendLine();
                         changeSummary.Append( paymentInfo.CurrencyTypeValue.Value );
-                        if (paymentInfo.CreditCardTypeValue != null)
+                        if ( paymentInfo.CreditCardTypeValue != null )
                         {
                             changeSummary.AppendFormat( " - {0}", paymentInfo.CreditCardTypeValue.Value );
                         }
@@ -1610,12 +1599,12 @@ namespace RockWeb.Blocks.Finance
                             transactionDetail.Amount = account.Amount;
                             transactionDetail.AccountId = account.Id;
                             transaction.TransactionDetails.Add( transactionDetail );
-                            History.EvaluateChange( txnChanges, account.Name, 0.0M.ToString( "C2" ), transactionDetail.Amount.ToString("C2") );
+                            History.EvaluateChange( txnChanges, account.Name, 0.0M.ToString( "C2" ), transactionDetail.Amount.ToString( "C2" ) );
                         }
 
                         var batchService = new FinancialBatchService( rockContext );
 
-                        // Get the batch 
+                        // Get the batch
                         var batch = batchService.Get(
                             GetAttributeValue( "BatchNamePrefix" ),
                             paymentInfo.CurrencyTypeValue,
@@ -1635,7 +1624,7 @@ namespace RockWeb.Blocks.Finance
                         }
 
                         decimal newControlAmount = batch.ControlAmount + transaction.TotalAmount;
-                        History.EvaluateChange( batchChanges, "Control Amount", batch.ControlAmount.ToString("C2"), newControlAmount.ToString("C2") );
+                        History.EvaluateChange( batchChanges, "Control Amount", batch.ControlAmount.ToString( "C2" ), newControlAmount.ToString( "C2" ) );
                         batch.ControlAmount = newControlAmount;
 
                         transaction.BatchId = batch.Id;
@@ -1692,7 +1681,6 @@ namespace RockWeb.Blocks.Finance
                 tdPaymentMethodReceipt.Description = paymentInfo.CurrencyTypeValue.Description;
                 tdAccountNumberReceipt.Description = paymentInfo.MaskedNumber;
                 tdWhenReceipt.Description = schedule != null ? schedule.ToString() : "Today";
-
 
                 // If there was a transaction code returned and this was not already created from a previous saved account,
                 // show the option to save the account.

--- a/RockWeb/Blocks/Reporting/DynamicData.ascx
+++ b/RockWeb/Blocks/Reporting/DynamicData.ascx
@@ -51,19 +51,17 @@
                                         </div>
                                     </div>
                                     <Rock:RockTextBox ID="tbParams" runat="server" Label="Parameters" TextMode="MultiLine" Rows="1" CssClass="input-xlarge"
-                                        Help="The parameters that the stored procedure expects in the format of 'param1=value;param2=value'.  Any parameter with the same name as a page parameter (i.e. querystring, 
+                                        Help="The parameters that the stored procedure expects in the format of 'param1=value;param2=value'.  Any parameter with the same name as a page parameter (i.e. querystring,
                                             form, or page route) will have it's value replaced with the page's current value.  A parameter with the name of 'CurrentPersonId' will have it's value replaced with the currently logged in person's id." />
                                     <Rock:RockCheckBox ID="cbPersonReport" runat="server" Text="Person Report"
                                         Help="Does this query return a list of people? If it does, then additional options will be available from the result grid.  (i.e. Communicate, etc).  Note: A column named 'Id' that contains the person's Id is required for a person report." />
-                                    
                                 </div>
                                 <div class="col-md-6">
                                     <Rock:RockTextBox ID="tbUrlMask" runat="server" Label="Selection Url" CssClass="input-large"
                                         Help="The Url to redirect user to when they click on a row in the grid.  Any column's value can be used in the url by including it in braces.  For example if the grid includes an 'Id' column that contains Person Ids, you can link to the Person view, by specifying a value here of '~/Person/{Id}" />
-                                    
+
                                     <Rock:RockTextBox ID="tbMergeFields" runat="server" Label="Communication Merge Fields" TextMode="MultiLine" Rows="1" CssClass="input-xlarge"
                                         Help="When creating a new communication from a person report, additional fields from the report can be used as merge fields on the communication.  Enter any column names that you'd like to be available for the communication." />
-
                                 </div>
 
                                 <div class="col-md-12">
@@ -76,14 +74,10 @@
                                         Help="Optional Lava for setting the page title. If nothing is provided then the page's title will be used. Example '{{rows[0].FullName}}' or if the query returns multiple result sets '{{table1.rows[0].FullName}}'." />
                                 </div>
                             </div>
-
                         </ContentTemplate>
                     </asp:UpdatePanel>
-
                 </Content>
             </Rock:ModalDialog>
-
         </asp:Panel>
-
     </ContentTemplate>
 </asp:UpdatePanel>

--- a/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
@@ -61,8 +61,8 @@ namespace RockWeb.Blocks.Reporting
     {
         #region Fields
 
-        Dictionary<int, string> _sortExpressions = new Dictionary<int, string>();
-        bool _updatePage = true;
+        private Dictionary<int, string> _sortExpressions = new Dictionary<int, string>();
+        private bool _updatePage = true;
 
         #endregion
 
@@ -106,7 +106,7 @@ namespace RockWeb.Blocks.Reporting
 
         #region Events
 
-        void DynamicData_BlockUpdated( object sender, EventArgs e )
+        protected void DynamicData_BlockUpdated( object sender, EventArgs e )
         {
             BuildControls( true );
         }
@@ -228,9 +228,8 @@ namespace RockWeb.Blocks.Reporting
                     query = query.ResolveMergeFields( PageParameters() );
 
                     var parameters = GetParameters();
-                    return DbService.GetDataSet( query, GetAttributeValue("StoredProcedure").AsBoolean(false) ? CommandType.StoredProcedure : CommandType.Text, parameters );
+                    return DbService.GetDataSet( query, GetAttributeValue( "StoredProcedure" ).AsBoolean( false ) ? CommandType.StoredProcedure : CommandType.Text, parameters );
                 }
-
                 catch ( System.Exception ex )
                 {
                     errorMessage = ex.Message;
@@ -296,7 +295,6 @@ namespace RockWeb.Blocks.Reporting
                     // load merge objects if needed by either for formatted output OR page title
                     if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PageTitleLava" ) ) || !string.IsNullOrWhiteSpace( formattedOutput ) )
                     {
-                        
                         if ( CurrentPerson != null )
                         {
                             // TODO: When support for "Person" is not supported anymore (should use "CurrentPerson" instead), remove this line
@@ -389,13 +387,12 @@ namespace RockWeb.Blocks.Reporting
                 phContent.Visible = true;
                 nbError.Visible = false;
             }
-
         }
 
         /// <summary>
         /// Sets the data key names.
         /// </summary>
-        private void SetDataKeyNames(Grid grid, DataTable dataTable )
+        private void SetDataKeyNames( Grid grid, DataTable dataTable )
         {
             string urlMask = GetAttributeValue( "UrlMask" );
             if ( !string.IsNullOrWhiteSpace( urlMask ) )
@@ -419,7 +416,7 @@ namespace RockWeb.Blocks.Reporting
             }
             else
             {
-                if (dataTable.Columns.Contains("Id"))
+                if ( dataTable.Columns.Contains( "Id" ) )
                 {
                     grid.DataKeyNames = new string[1] { "Id" };
                 }
@@ -509,7 +506,6 @@ namespace RockWeb.Blocks.Reporting
                 {
                     bf = new BoolField();
                 }
-
                 else if ( dataTableColumn.DataType == typeof( DateTime ) )
                 {
                     bf = new DateField();
@@ -545,7 +541,7 @@ namespace RockWeb.Blocks.Reporting
         /// </summary>
         /// <param name="dataTable">The data table.</param>
         /// <returns></returns>
-        private void SortTable( Grid grid, DataTable dataTable)
+        private void SortTable( Grid grid, DataTable dataTable )
         {
             System.Data.DataView dataView = dataTable.DefaultView;
 
@@ -559,7 +555,7 @@ namespace RockWeb.Blocks.Reporting
         #endregion
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private class DataRowDrop : DotLiquid.Drop
         {

--- a/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
@@ -475,7 +475,7 @@ namespace RockWeb.Blocks.Reporting
         /// <param name="dataTable">The data table.</param>
         private void AddGridColumns( Grid grid, DataTable dataTable )
         {
-            bool showColumns = bool.Parse( GetAttributeValue( "ShowColumns" ) );
+            bool showColumns = GetAttributeValue( "ShowColumns" ).AsBoolean();
             var columnList = GetAttributeValue( "Columns" ).SplitDelimitedValues().ToList();
 
             int rowsToEval = 10;

--- a/RockWeb/Blocks/Utility/DefinedTypeCheckList.ascx.cs
+++ b/RockWeb/Blocks/Utility/DefinedTypeCheckList.ascx.cs
@@ -36,14 +36,13 @@ namespace RockWeb.Blocks.Utility
     [DisplayName( "Defined Type Check List" )]
     [Category( "Utility" )]
     [Description( "Used for managing the values of a defined type as a checklist." )]
-
     [DefinedTypeField( "Defined Type", "The Defined Type to display values for." )]
     [TextField( "Attribute Key", "The attribute key on the Defined Type that is used to store whether item has been completed (should be a boolean field type)." )]
     [BooleanField( "Hide Checked Items", "Hide items that are already checked.", false )]
-    [BooleanField("Hide Block When Empty", "Hides entire block if no checklist items are available.", false)]
-    [TextField("Checklist Title", "Title for your checklist.",false,"","Description",1)]
-    [CodeEditorField("Checklist Description", "Description for your checklist. Leave this blank and nothing will be displayed.", 
-        CodeEditorMode.Html, CodeEditorTheme.Rock, 100, false, "", "Description", 2)]
+    [BooleanField( "Hide Block When Empty", "Hides entire block if no checklist items are available.", false )]
+    [TextField( "Checklist Title", "Title for your checklist.", false, "", "Description", 1 )]
+    [CodeEditorField( "Checklist Description", "Description for your checklist. Leave this blank and nothing will be displayed.",
+        CodeEditorMode.Html, CodeEditorTheme.Rock, 100, false, "", "Description", 2 )]
     public partial class DefinedTypeCheckList : RockBlock
     {
         private string attributeKey = string.Empty;
@@ -70,7 +69,7 @@ $('.checklist-item label strong, .checklist-desc-toggle').on('click', function (
     $header.find('i').toggleClass('fa-chevron-up fa-chevron-down');
 });
 ";
-            ScriptManager.RegisterStartupScript(this.Page, this.Page.GetType(), "DefinedValueChecklistScript", script, true);
+            ScriptManager.RegisterStartupScript( this.Page, this.Page.GetType(), "DefinedValueChecklistScript", script, true );
         }
 
         /// <summary>
@@ -116,8 +115,8 @@ $('.checklist-item label strong, .checklist-desc-toggle').on('click', function (
 
             if ( Page.IsPostBack && wasVisible && this.Visible == false )
             {
-                // If last item was just checked do a redirect back to the same page.  
-                // This is needed to hide the control since content is inside an update 
+                // If last item was just checked do a redirect back to the same page.
+                // This is needed to hide the control since content is inside an update
                 // panel
                 Response.Redirect( CurrentPageReference.BuildUrl(), false );
             }
@@ -138,36 +137,28 @@ $('.checklist-item label strong, .checklist-desc-toggle').on('click', function (
             this.Visible = true;
 
             // Should selected items be displayed
-            bool hideCheckedItems = false;
-            if ( !bool.TryParse( GetAttributeValue( "HideCheckedItems" ), out hideCheckedItems ) )
-            {
-                hideCheckedItems = false;
-            }
+            bool hideCheckedItems = GetAttributeValue( "HideCheckedItems" ).AsBoolean();
 
             // Should content be hidden when empty list
-            bool hideBlockWhenEmpty = false;
-            if ( !bool.TryParse( GetAttributeValue( "HideBlockWhenEmpty" ), out hideBlockWhenEmpty ) )
-            {
-                hideBlockWhenEmpty = false;
-            }
+            bool hideBlockWhenEmpty = GetAttributeValue( "HideBlockWhenEmpty" ).AsBoolean();
 
             Guid guid = Guid.Empty;
             if ( Guid.TryParse( GetAttributeValue( "DefinedType" ), out guid ) )
             {
                 var definedType = DefinedTypeCache.Read( guid );
-                if (definedType != null)
-                { 
+                if ( definedType != null )
+                {
                     // Get the values
                     var values = definedType.DefinedValues.OrderBy( v => v.Order ).ToList();
 
                     // Find all the unselected values
                     var selectedValues = new List<int>();
-                    foreach( var value in values)
+                    foreach ( var value in values )
                     {
                         bool selected = false;
                         if ( bool.TryParse( value.GetAttributeValue( attributeKey ), out selected ) && selected )
                         {
-                            selectedValues.Add(value.Id);
+                            selectedValues.Add( value.Id );
                         }
                     }
 
@@ -196,6 +187,5 @@ $('.checklist-item label strong, .checklist-desc-toggle').on('click', function (
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
Fixes and simplifies any code relying on GetAttributeValue to return a known boolean string.

Found the issue when FilterBySpecialNeeds was edited to display "Yes" or "No" instead of true/false.

There are a few instances where the default value was true (like TransactionEntry: Show Additional Accounts). In those instances the resultIfNullOrEmpty parameter is set to true.