### PR TITLE
Fix issue with FilterBySpecialNeeds checking for a null attributevalue

### DIFF
--- a/Rock/Workflow/Action/CheckIn/FilterGroupsByAbilityLevel.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsByAbilityLevel.cs
@@ -58,7 +58,11 @@ namespace Rock.Workflow.Action.CheckIn
 
                 foreach ( var person in family.People )
                 {
-                    person.Person.LoadAttributes( rockContext );
+                    if ( person.Person.Attributes == null )
+                    {
+                        person.Person.LoadAttributes( rockContext );
+                    }
+
                     string personAbilityLevel = person.Person.GetAttributeValue( "AbilityLevel" ).ToUpper();
                     if ( string.IsNullOrWhiteSpace( personAbilityLevel ) )
                     {

--- a/Rock/Workflow/Action/CheckIn/FilterGroupsBySpecialNeeds.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsBySpecialNeeds.cs
@@ -65,6 +65,11 @@ namespace Rock.Workflow.Action.CheckIn
 
                 foreach ( var person in family.People )
                 {
+                    if ( person.Person.Attributes == null )
+                    {
+                        person.Person.LoadAttributes( rockContext );
+                    }
+
                     bool isSNPerson = person.Person.GetAttributeValue( "IsSpecialNeeds" ).AsBoolean();
                     foreach ( var groupType in person.GroupTypes.ToList() )
                     {


### PR DESCRIPTION
SpecialNeeds was checking for an attribute value prior to person.Attributes being loaded from the database.  

AbilityLevel was checking for an attribute value but always loading person.Attributes (maybe it was the first action in the stock workflow?).

Now attribute values are available regardless of the workflow action order.