### PR TITLE
Fix Exception in Group Detail Lava

### DIFF
--- a/RockWeb/Blocks/Groups/GroupDetailLava.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupDetailLava.ascx.cs
@@ -508,7 +508,7 @@ namespace RockWeb.Blocks.Groups
         private void DisplayViewGroup()
         {
 
-            if ( _groupId != -1 )
+            if ( _groupId > 0 )
             {
                 RockContext rockContext = new RockContext();
                 GroupService groupService = new GroupService( rockContext );


### PR DESCRIPTION
Group Detail Lava was trying to parse non-existent query strings and when the member ordering was introduced in 5b56a30da091eb7c27f542e7b92486c33283b40d a possible exception was created.