### PR TITLE
- Fixed issue with CategoryTreeView where some Data Views or Reports …

### DIFF
--- a/RockWeb/Blocks/Core/CategoryTreeView.ascx
+++ b/RockWeb/Blocks/Core/CategoryTreeView.ascx
@@ -94,9 +94,14 @@
                                 iconCssClass: item.IconCssClass,
                                 parentId: item.ParentId,
                                 hasChildren: item.HasChildren,
-                                isCategory: item.IsCategory
+                                isCategory: item.IsCategory,
+                                entityId: item.Id
                             };
 
+                            // If this Tree Node represents a Category, add a prefix to its identifier to prevent collisions with other Entity identifiers.
+                            if (item.IsCategory) {
+                                node.id = '<%= CategoryNodePrefix %>' + node.id;
+                            }
                             if (item.Children && typeof item.Children.length === 'number') {
                                 node.children = _mapCategories(item.Children);
                             }
@@ -110,8 +115,13 @@
 
                         var $node = $('[data-id="' + id + '"]'),
                             isCategory = $node.attr('data-iscategory') === 'true',
-                            urlParameter = (isCategory ? 'CategoryId' : '<%= PageParameterName %>'),
-                                itemSearch = '?' + urlParameter + '=' + id;
+                            urlParameter = (isCategory ? 'CategoryId' : '<%= PageParameterName %>');
+
+                        // Get the id of the Entity represented by this Tree Node if it has been specified as an attribute.
+                        // If not, assume the id of the Entity is the same as the Node.
+                        var entityId = $node.attr('data-entityid') || id;
+
+                        var itemSearch = '?' + urlParameter + '=' + entityId;
 
                         var currentItemId = $selectedId.val();
 
@@ -126,7 +136,7 @@
                             var regex = new RegExp("{" + urlParameter + "}", "i");
 
                             if (pageRouteTemplate.match(regex)) {
-                                locationUrl = Rock.settings.get('baseUrl') + pageRouteTemplate.replace(regex, id);
+                                locationUrl = Rock.settings.get('baseUrl') + pageRouteTemplate.replace(regex, entityId);
                                 locationUrl += "?ExpandedIds=" + encodeURIComponent(expandedDataIds);
                             }
                             else {
@@ -148,7 +158,7 @@
                             restUrl: '<%= ResolveUrl( "~/api/categories/getchildren/" ) %>',
                             restParams: '<%= RestParms %>',
                             mapping: {
-                                include: ['isCategory'],
+                                include: ['isCategory', 'entityId'],
                                 mapData: _mapCategories
                             },
                             selectedIds: $selectedId.val() ? $selectedId.val().split(',') : null,

--- a/RockWeb/Blocks/Core/CategoryTreeView.ascx.cs
+++ b/RockWeb/Blocks/Core/CategoryTreeView.ascx.cs
@@ -46,6 +46,8 @@ namespace RockWeb.Blocks.Core
     [CategoryField( "Exclude Categories", "Select any category that you need to exclude from the tree view", true, Category = "CustomSetting" )]
     public partial class CategoryTreeView : RockBlockCustomSettings
     {
+        public const string CategoryNodePrefix = "C";
+
         /// <summary>
         /// Gets the settings tool tip.
         /// </summary>
@@ -178,12 +180,24 @@ namespace RockWeb.Blocks.Core
                     lAddItem.Text = entityTypeFriendlyName;
                 }
 
+                // Attempt to retrieve an EntityId from the Page URL parameters.
                 PageParameterName = GetAttributeValue( "PageParameterKey" );
+
+                string selectedNodeId = null;
+                
                 int? itemId = PageParameter( PageParameterName ).AsIntegerOrNull();
-                string selectedEntityType = cachedEntityType.Name;
-                if ( !itemId.HasValue )
+                string selectedEntityType;
+                if (itemId.HasValue)
                 {
+                    selectedNodeId = itemId.ToString();
+                    selectedEntityType = (cachedEntityType != null) ? cachedEntityType.Name : string.Empty;
+                }
+                else
+                {
+                    // If an EntityId was not specified, check for a CategoryId.
                     itemId = PageParameter( "CategoryId" ).AsIntegerOrNull();
+
+                    selectedNodeId = CategoryNodePrefix + itemId;
                     selectedEntityType = "category";
                 }
 
@@ -193,14 +207,14 @@ namespace RockWeb.Blocks.Core
 
                 CategoryCache selectedCategory = null;
 
-                if ( itemId.HasValue )
+                if ( !string.IsNullOrEmpty( selectedNodeId ) )
                 {
-                    hfSelectedItemId.Value = itemId.Value.ToString();
+                    hfSelectedItemId.Value = selectedNodeId;
                     List<string> parentIdList = new List<string>();
 
                     if ( selectedEntityType.Equals( "category" ) )
                     {
-                        selectedCategory = CategoryCache.Read( itemId.Value );
+                        selectedCategory = CategoryCache.Read( itemId.GetValueOrDefault() );
                     }
                     else
                     {

--- a/RockWeb/Scripts/Rock/Extensions/rockTree.js
+++ b/RockWeb/Scripts/Rock/Extensions/rockTree.js
@@ -151,7 +151,15 @@
                 // Wrapper function around jQuery.ajax. Appends a handler to databind the
                 // resulting JSON from the server and returns the promise
                 getNodes = function (parentId, parentNode) {
-                    var restUrl = self.options.restUrl + parentId;
+                    var restUrl = self.options.restUrl;
+
+                    // If the Tree Node we are loading has an EntityId attribute, use it to identify the associated Data Entity key - otherwise use the Tree Node identifier itself.
+                    // The Data Entity key identifies the node data we are requesting from the REST source to load into the tree.
+                    if (parentNode && parentNode.entityId) {
+                        restUrl += parentNode.entityId;
+                    } else {
+                        restUrl += parentId;
+                    }
 
                     if (self.options.restParams) {
                         restUrl += self.options.restParams;


### PR DESCRIPTION
…cannot be selected in the tree because of collisions between Tree Node identifiers. (Fixes #1080)