### PR TITLE
+ Added default campus setting to Add Family block

### DIFF
--- a/RockWeb/Blocks/Crm/PersonDetail/AddFamily.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/AddFamily.ascx.cs
@@ -45,11 +45,12 @@ namespace RockWeb.Blocks.Crm.PersonDetail
     [DefinedValueField( Rock.SystemGuid.DefinedType.PERSON_MARITAL_STATUS, "Adult Marital Status", "The default marital status for adults in the family.", false, false, "", "", 3 )]
     [DefinedValueField( Rock.SystemGuid.DefinedType.PERSON_MARITAL_STATUS, "Child Marital Status", "The marital status to use for children in the family.", false, false,
         Rock.SystemGuid.DefinedValue.PERSON_MARITAL_STATUS_SINGLE, "", 4 )]
-    [BooleanField( "Marital Status Confirmation", "Should user be asked to confirm saving an adults without a marital status?", true, "", 5 )]
-    [BooleanField( "Grade", "Require a grade for each child", "Don't require", "Should Grade be required for each child added?", false, "", 6 )]
-    [BooleanField("SMS", "SMS is enabled by default", "SMS is not enabled by default", "Should SMS be enabled for cell phone numbers by default?", false, "", 7)]
-    [AttributeCategoryField( "Attribute Categories", "The Attribute Categories to display attributes from", true, "Rock.Model.Person", false, "", "", 8 )]
-
+    [CampusField( "Default Campus", "The default campus for each family", false, "", "", 5 )]
+    [BooleanField( "Marital Status Confirmation", "Should user be asked to confirm saving an adults without a marital status?", true, "", 6 )]
+    [BooleanField( "Grade", "Require a grade for each child", "Don't require", "Should Grade be required for each child added?", false, "", 7 )]
+    [BooleanField("SMS", "SMS is enabled by default", "SMS is not enabled by default", "Should SMS be enabled for cell phone numbers by default?", false, "", 8)]
+    [AttributeCategoryField( "Attribute Categories", "The Attribute Categories to display attributes from", true, "Rock.Model.Person", false, "", "", 9 )]
+    
     public partial class AddFamily : Rock.Web.UI.RockBlock
     {
 
@@ -114,7 +115,15 @@ namespace RockWeb.Blocks.Crm.PersonDetail
             var campusi = CampusCache.All();
             cpCampus.Campuses = campusi;
             cpCampus.Visible = campusi.Any();
-
+            Guid? defaultCampus = GetAttributeValue( "DefaultCampus" ).AsGuidOrNull();
+            if ( defaultCampus != null )
+            {
+                var selectedCampus = new CampusService( new RockContext() ).Queryable()
+                    .Where( c => c.Guid == defaultCampus )
+                    .FirstOrDefault();
+                cpCampus.SelectedCampusId = selectedCampus.Id;
+            }
+            
             var familyGroupType = GroupTypeCache.GetFamilyGroupType();
             if ( familyGroupType != null )
             {


### PR DESCRIPTION
After staring for too long at the block settings for the Add Family block I thought it made sense to have a default campus for churches operating as multi-service rather than multi-campus.