### PR TITLE
A default campus for the Add Family block

### DIFF
--- a/RockWeb/Blocks/Crm/PersonDetail/AddFamily.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/AddFamily.ascx.cs
@@ -114,6 +114,10 @@ namespace RockWeb.Blocks.Crm.PersonDetail
             var campusi = CampusCache.All();
             cpCampus.Campuses = campusi;
             cpCampus.Visible = campusi.Any();
+            if ( campusi.Count == 1 )
+            {
+                cpCampus.SelectedCampusId = campusi.FirstOrDefault().Id;
+            }
 
             var familyGroupType = GroupTypeCache.GetFamilyGroupType();
             if ( familyGroupType != null )


### PR DESCRIPTION
If there is only one campus, the Add Family campus field will default to it.