### PR TITLE
Add a UI control for a FinancialAccount's URL

### DIFF
--- a/RockWeb/Blocks/Finance/AccountDetail.ascx
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx
@@ -69,6 +69,8 @@
                             <Rock:DataTextBox ID="tbPublicName" runat="server"
                                 SourceTypeName="Rock.Model.FinancialAccount, Rock" PropertyName="PublicName" />
                             <Rock:CampusPicker ID="cpCampus" runat="server" Label="Campus" />
+                            <Rock:DataTextBox ID="tbUrl" runat="server"
+                                SourceTypeName="Rock.Model.FinancialAccount, Rock" PropertyName="Url" />
                         </div>
                         <div class="col-md-6">                
                             <Rock:DataTextBox ID="tbGLCode" runat="server"

--- a/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
@@ -86,6 +86,7 @@ namespace RockWeb.Blocks.Finance
             account.ParentAccountId = apParentAccount.SelectedValueAsInt();
             account.AccountTypeValueId = ddlAccountType.SelectedValueAsInt();
             account.PublicName = tbPublicName.Text;
+            account.Url = tbUrl.Text;
             account.CampusId = cpCampus.SelectedValueAsInt();
 
             account.GlCode = tbGLCode.Text;
@@ -184,6 +185,7 @@ namespace RockWeb.Blocks.Finance
             apParentAccount.SetValue( account.ParentAccount );
             ddlAccountType.SetValue( account.AccountTypeValueId );
             tbPublicName.Text = account.PublicName;
+            tbUrl.Text = account.Url;
             cpCampus.SelectedCampusId = account.CampusId;
 
             tbGLCode.Text = account.GlCode;


### PR DESCRIPTION
This adds a textbox allowing a user to edit the Url attribute of a FinancialAccount. NewSpring plans to use the Url attribute to specify an image for the account and would like to be able to manage this from the Rock interface.