### PR TITLE
Enhancement - Enables Url Query Filters For My Workflow Block

### DIFF
--- a/RockWeb/Blocks/WorkFlow/MyWorkflows.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/MyWorkflows.ascx.cs
@@ -96,29 +96,26 @@ namespace RockWeb.Blocks.WorkFlow
         /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
         /// </summary>
         /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        /// <remarks>
+        /// Allows you to set query strings to activate filters on My Workflows block
+        /// Will returns the filter values based on query string
+        ///
+        /// Role Filter
+        /// ---------------------
+        /// Initiated By Me = true
+        /// Assigned To Me =  false
+        ///
+        /// Status Filter
+        /// -------------------
+        /// Active Types = true
+        /// All Types = false
+        /// </remarks>
         protected override void OnLoad( EventArgs e )
         {
             base.OnLoad( e );
 
             if ( !Page.IsPostBack )
             {
-                /// <summary>
-                /// Allows you to set query strings to activate filters on My Workflows block
-                /// </summary>
-                /// <returns>
-                /// Returns the filter values based on query string
-                /// </returns>
-                ///
-                /// Role Filter
-                /// ---------------------
-                /// Initiated By Me = true
-                /// Assigned To Me =  false
-                ///
-                /// Status Filter
-                /// -------------------
-                /// Active Types = true
-                /// All Types = false
-
                 bool? queryStatusFilter = Request.QueryString["StatusFilter"].AsBoolean();
                 bool? queryRoleFilter = Request.QueryString["RoleFilter"].AsBoolean();
 
@@ -127,22 +124,17 @@ namespace RockWeb.Blocks.WorkFlow
                 {
                     tglDisplay.Checked = queryStatusFilter.GetValueOrDefault();
                     tglRole.Checked = queryRoleFilter.GetValueOrDefault();
-
-                    StatusFilter = tglDisplay.Checked;
-                    RoleFilter = tglRole.Checked;
-
-                    GetData();
                 }
                 else
                 {
                     tglDisplay.Checked = GetUserPreference( DISPLAY_TOGGLE_SETTING ).AsBoolean();
                     tglRole.Checked = GetUserPreference( ROLE_TOGGLE_SETTING ).AsBoolean();
-
-                    StatusFilter = tglDisplay.Checked;
-                    RoleFilter = tglRole.Checked;
-
-                    GetData();
                 }
+
+                StatusFilter = tglDisplay.Checked;
+                RoleFilter = tglRole.Checked;
+
+                GetData();
             }
         }
 

--- a/RockWeb/Blocks/WorkFlow/MyWorkflows.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/MyWorkflows.ascx.cs
@@ -103,13 +103,49 @@ namespace RockWeb.Blocks.WorkFlow
 
             if ( !Page.IsPostBack )
             {
-                tglDisplay.Checked = GetUserPreference( DISPLAY_TOGGLE_SETTING ).AsBoolean();
-                tglRole.Checked = GetUserPreference( ROLE_TOGGLE_SETTING ).AsBoolean();
-                
-                StatusFilter = tglDisplay.Checked;
-                RoleFilter = tglRole.Checked;
+                /// <summary>
+                /// Allows you to set query strings to activate filters on My Workflows block
+                /// </summary>
+                /// <returns>
+                /// Returns the filter values based on query string
+                /// </returns>
+                /// 
+                /// Role Filter
+                /// ---------------------
+                /// Initiated By Me = true
+                /// Assigned To Me =  false
+                ///
+                /// Status Filter
+                /// -------------------
+                /// Active Types = true
+                /// All Types = false
 
-                GetData();
+                bool? queryStatusFilter = Request.QueryString["StatusFilter"].AsBoolean();
+                bool? queryRoleFilter = Request.QueryString["RoleFilter"].AsBoolean();
+
+                /// If query string values exist then set them
+                if ( queryStatusFilter.HasValue || queryRoleFilter.HasValue )
+                {
+
+                    tglDisplay.Checked = queryStatusFilter.GetValueOrDefault();
+                    tglRole.Checked = queryRoleFilter.GetValueOrDefault();
+
+                    StatusFilter = tglDisplay.Checked;
+                    RoleFilter = tglRole.Checked;
+
+                    GetData();
+
+                }
+                else
+                {
+                    tglDisplay.Checked = GetUserPreference( DISPLAY_TOGGLE_SETTING ).AsBoolean();
+                    tglRole.Checked = GetUserPreference( ROLE_TOGGLE_SETTING ).AsBoolean();
+
+                    StatusFilter = tglDisplay.Checked;
+                    RoleFilter = tglRole.Checked;
+
+                    GetData();
+                }
             }
         }
 

--- a/RockWeb/Blocks/WorkFlow/MyWorkflows.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/MyWorkflows.ascx.cs
@@ -21,16 +21,14 @@ using System.IO;
 using System.Linq;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-
 using Newtonsoft.Json;
-
 using Rock;
+using Rock.Attribute;
 using Rock.Data;
 using Rock.Model;
+using Rock.Security;
 using Rock.Web.Cache;
 using Rock.Web.UI.Controls;
-using Rock.Attribute;
-using Rock.Security;
 
 namespace RockWeb.Blocks.WorkFlow
 {
@@ -40,7 +38,6 @@ namespace RockWeb.Blocks.WorkFlow
     [DisplayName( "My Workflows" )]
     [Category( "WorkFlow" )]
     [Description( "Block to display the workflow types that user is authorized to view, and the activities that are currently assigned to the user." )]
-
     [LinkedPage( "Entry Page", "Page used to enter form information for a workflow." )]
     [LinkedPage( "Detail Page", "Page used to view status of a workflow." )]
     public partial class MyWorkflows : Rock.Web.UI.RockBlock
@@ -55,7 +52,9 @@ namespace RockWeb.Blocks.WorkFlow
         #region Properties
 
         protected bool? StatusFilter { get; set; }
+
         protected bool? RoleFilter { get; set; }
+
         protected int? SelectedWorkflowTypeId { get; set; }
 
         #endregion
@@ -109,7 +108,7 @@ namespace RockWeb.Blocks.WorkFlow
                 /// <returns>
                 /// Returns the filter values based on query string
                 /// </returns>
-                /// 
+                ///
                 /// Role Filter
                 /// ---------------------
                 /// Initiated By Me = true
@@ -126,7 +125,6 @@ namespace RockWeb.Blocks.WorkFlow
                 /// If query string values exist then set them
                 if ( queryStatusFilter.HasValue || queryRoleFilter.HasValue )
                 {
-
                     tglDisplay.Checked = queryStatusFilter.GetValueOrDefault();
                     tglRole.Checked = queryRoleFilter.GetValueOrDefault();
 
@@ -134,7 +132,6 @@ namespace RockWeb.Blocks.WorkFlow
                     RoleFilter = tglRole.Checked;
 
                     GetData();
-
                 }
                 else
                 {
@@ -201,7 +198,7 @@ namespace RockWeb.Blocks.WorkFlow
         protected void rptWorkflowTypes_ItemCommand( object source, RepeaterCommandEventArgs e )
         {
             int? workflowTypeId = e.CommandArgument.ToString().AsIntegerOrNull();
-            if (workflowTypeId.HasValue)
+            if ( workflowTypeId.HasValue )
             {
                 SelectedWorkflowTypeId = workflowTypeId.Value;
             }
@@ -214,7 +211,7 @@ namespace RockWeb.Blocks.WorkFlow
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
-        void rptWorkflowTypes_ItemCreated( object sender, RepeaterItemEventArgs e )
+        protected void rptWorkflowTypes_ItemCreated( object sender, RepeaterItemEventArgs e )
         {
             var lbWorkflowType = e.Item.FindControl( "lbWorkflowType" ) as LinkButton;
             if ( lbWorkflowType != null )
@@ -246,7 +243,7 @@ namespace RockWeb.Blocks.WorkFlow
                 }
             }
         }
-        
+
         /// <summary>
         /// Handles the GridRebind event of the gWorkflows control.
         /// </summary>
@@ -296,13 +293,12 @@ namespace RockWeb.Blocks.WorkFlow
                         !w.CompletedDateTime.HasValue &&
                         w.InitiatorPersonAlias.PersonId == personId )
                     .ToList();
-                   
+
                 workflowTypeIds.ForEach( id =>
                     workflowTypeCounts.Add( id, workflows.Where( w => w.WorkflowTypeId == id ).Count() ) );
             }
             else
             {
-
                 // Get all the active forms for any of the authorized activities
                 var activeForms = new WorkflowActionService( rockContext ).Queryable( "ActionType.ActivityType.WorkflowType, Activity.Workflow" )
                     .Where( a =>
@@ -366,7 +362,7 @@ namespace RockWeb.Blocks.WorkFlow
             if ( SelectedWorkflowTypeId.HasValue )
             {
                 selectedWorkflowType = allWorkflowTypes
-                    .Where( w =>  w.Id == SelectedWorkflowTypeId.Value )
+                    .Where( w => w.Id == SelectedWorkflowTypeId.Value )
                     .FirstOrDefault();
 
                 AddAttributeColumns( selectedWorkflowType );
@@ -384,7 +380,6 @@ namespace RockWeb.Blocks.WorkFlow
             {
                 gWorkflows.Visible = false;
             }
-
         }
 
         private List<int> AuthorizedActivityTypes( List<WorkflowType> allWorkflowTypes )
@@ -408,7 +403,7 @@ namespace RockWeb.Blocks.WorkFlow
             return authorizedActivityTypes;
         }
 
-        protected void AddAttributeColumns( WorkflowType workflowType)
+        protected void AddAttributeColumns( WorkflowType workflowType )
         {
             // Remove attribute columns
             foreach ( var column in gWorkflows.Columns.OfType<AttributeField>().ToList() )
@@ -452,7 +447,5 @@ namespace RockWeb.Blocks.WorkFlow
         }
 
         #endregion
-
     }
-
 }


### PR DESCRIPTION
Overview:
---
This code change allows the My Workflow block to be filtered via query string.

Example:
---
Using the following url [http://localhost:6229/?RoleFilter=false&StatusFilter=true](http://localhost:6229/?RoleFilter=false&StatusFilter=true) on page load (not on a post back) the My Workflow block shows only workflows that are assigned to the current user and active.

Use Case:
---
We are building a notification block which shows the current number of active workflows assigned to the current user.  Now with the help of the url query string when the user clicks on the notification icon the user is taken directly to a page with the My Workflow block already filtered to show only the workflows that are assigned to them and currently active.