### PR TITLE
googleMapsIsLoaded

### DIFF
--- a/RockWeb/Scripts/Rock/Controls/util.js
+++ b/RockWeb/Scripts/Rock/Controls/util.js
@@ -16,6 +16,8 @@
                     $.ajaxSetup({ cache: true });
                     var src = apiSrc + '&callback=Rock.controls.util.googleMapsIsLoaded';
                     $('head').prepend("<script id='googleMapsApi' src='" + src + "' />");
+                } else {
+                    this.googleMapsIsLoaded();
                 }
             }
         };


### PR DESCRIPTION
I'm running into a scenario where I have to dynamically load the google maps API on certain pages. Some blocks (GroupDetailLava.ascx for example) add the google maps API on page load and do not use the rock util for it. The problem I'm having occurs when I am using pages with these blocks. Calling the rock util to load the gmaps api neither loads the api nor fires the loaded event — leaving my scripts waiting for the event.

To fix this I could either 1. check for the gmaps object before trying load in my own scripts, or 2. we could have the util fire the loaded event if the api is already loaded. Here's an implementation of option 2.