### PR TITLE
Add additional context enhancements to 1.4.0

### DIFF
--- a/RockWeb/Blocks/Core/CampusContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/CampusContextSetter.ascx.cs
@@ -41,6 +41,7 @@ namespace RockWeb.Blocks.Core
     [TextField( "Dropdown Item Template", "Lava template for items in the dropdown. The only merge field is {{ CampusName }}.", true, "{{ CampusName }}", order: 2 )]
     [TextField( "No Campus Text", "The text displayed when no campus context is selected.", true, "Select Campus", order: 3 )]
     [TextField( "Clear Selection Text", "The text displayed when a campus can be unselected. This will not display when the text is empty.", true, "", order: 4 )]
+    [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", false, "", order: 5 )]
     public partial class CampusContextSetter : RockBlock
     {
         #region Base Control Methods
@@ -168,10 +169,10 @@ namespace RockWeb.Blocks.Core
             // set context and refresh below with the correct query string if needed
             RockPage.SetContextCookie( campus, pageScope, false );
 
-            // Only redirect if refreshPage is true, and there already is a query string parameter for campus id
+            // Only redirect if refreshPage is true
             if ( refreshPage )
             {
-                if ( !string.IsNullOrWhiteSpace( PageParameter( "campusId" ) ) )
+                if ( !string.IsNullOrWhiteSpace( PageParameter( "campusId" ) ) || GetAttributeValue( "DisplayQueryStrings" ).AsBoolean() )
                 {
                     var queryString = HttpUtility.ParseQueryString( Request.QueryString.ToStringSafe() );
                     queryString.Set( "campusId", campusId.ToString() );

--- a/RockWeb/Blocks/Core/GroupContextSetter.ascx
+++ b/RockWeb/Blocks/Core/GroupContextSetter.ascx
@@ -5,7 +5,7 @@
 
         <Rock:NotificationBox runat="server" ID="nbSelectGroupTypeWarning" NotificationBoxType="Warning" Text="Select a group type or root group from the block settings" />
 
-        <ul class="nav navbar-nav group-context-setter">
+        <ul class="nav navbar-nav contextsetter group-context-setter">
             <li class="dropdown">
 
                 <a class="dropdown-toggle navbar-link" href="#" data-toggle="dropdown">

--- a/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
@@ -40,6 +40,7 @@ namespace RockWeb.Blocks.Core
     [TextField( "No Group Text", "The text to show when there is no group in the context.", true, "Select Group", order: 2 )]
     [TextField( "Clear Selection Text", "The text displayed when a group can be unselected. This will not display when the text is empty.", true, "", order: 3 )]
     [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", false, "", order: 4 )]
+    [BooleanField( "Include GroupType Children", "Include all children of the grouptype selected", false, "", order: 5 )]
     public partial class GroupContextSetter : RockBlock
     {
         #region Base Control Methods
@@ -110,7 +111,9 @@ namespace RockWeb.Blocks.Core
                 }
             }
 
-            var groupService = new GroupService( new RockContext() );
+            var rockContext = new RockContext();
+            var groupService = new GroupService( rockContext );
+            var groupTypeService = new GroupTypeService( rockContext );
             IQueryable<Group> qryGroups = null;
 
             // if rootGroup is set, use that as the filter.  Otherwise, use GroupType as the filter
@@ -124,7 +127,19 @@ namespace RockWeb.Blocks.Core
             }
             else if ( groupTypeGuid.HasValue )
             {
-                qryGroups = groupService.Queryable().Where( a => a.GroupType.Guid == groupTypeGuid.Value );
+                SetGroupTypeContext( groupTypeGuid );
+
+                if ( GetAttributeValue( "IncludeGroupTypeChildren" ).AsBoolean() )
+                {
+                    var childGroupTypeGuids = groupTypeService.Queryable().Where( t => t.ParentGroupTypes.Select( p => p.Guid ).Contains( groupTypeGuid.Value ) )
+                        .Select( t => t.Guid ).ToList();
+
+                    qryGroups = groupService.Queryable().Where( a => childGroupTypeGuids.Contains( a.GroupType.Guid ) );
+                }
+                else
+                {
+                    qryGroups = groupService.Queryable().Where( a => a.GroupType.Guid == groupTypeGuid.Value );
+                }
             }
 
             // no results
@@ -204,6 +219,33 @@ namespace RockWeb.Blocks.Core
             }
 
             return group;
+        }
+
+        /// <summary>
+        /// Sets the group type context.
+        /// </summary>
+        /// <param name="groupTypeGuid">The group type unique identifier.</param>
+        /// <returns></returns>
+        protected GroupType SetGroupTypeContext( Guid? groupTypeGuid )
+        {
+            bool pageScope = GetAttributeValue( "ContextScope" ) == "Page";
+            var groupTypeService = new GroupTypeService( new RockContext() );
+
+            // check if a grouptype parameter exists to set
+            var groupType = groupTypeService.Get( (Guid)groupTypeGuid );
+
+            if ( groupType == null )
+            {
+                groupType = new GroupType()
+                {
+                    Name = GetAttributeValue( "NoGroupText" ),
+                    Guid = Guid.Empty
+                };
+            }
+
+            RockPage.SetContextCookie( groupType, pageScope, false );
+
+            return groupType;
         }
 
         /// <summary>

--- a/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
@@ -39,6 +39,7 @@ namespace RockWeb.Blocks.Core
     [CustomRadioListField( "Context Scope", "The scope of context to set", "Site,Page", true, "Site", order: 1 )]
     [TextField( "No Group Text", "The text to show when there is no group in the context.", true, "Select Group", order: 2 )]
     [TextField( "Clear Selection Text", "The text displayed when a group can be unselected. This will not display when the text is empty.", true, "", order: 3 )]
+    [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", false, "", order: 4 )]
     public partial class GroupContextSetter : RockBlock
     {
         #region Base Control Methods
@@ -187,8 +188,8 @@ namespace RockWeb.Blocks.Core
 
             if ( refreshPage )
             {
-                // Only redirect if refreshPage is true, and there already is a query string parameter for group id
-                if ( !string.IsNullOrWhiteSpace( PageParameter( "groupId" ) ) )
+                // Only redirect if refreshPage is true
+                if ( !string.IsNullOrWhiteSpace( PageParameter( "groupId" ) ) || GetAttributeValue( "DisplayQueryStrings" ).AsBoolean() )
                 {
                     var queryString = HttpUtility.ParseQueryString( Request.QueryString.ToStringSafe() );
                     queryString.Set( "groupId", groupId.ToString() );

--- a/RockWeb/Blocks/Core/ScheduleContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/ScheduleContextSetter.ascx.cs
@@ -42,6 +42,7 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.ScheduleContextSetter
     [TextField( "Dropdown Item Template", "Lava template for items in the dropdown. The only merge field is {{ ScheduleName }}.", true, "{{ ScheduleName }}", order: 2 )]
     [TextField( "No Schedule Text", "The text to show when there is no schedule in the context.", true, "Select Schedule", order: 3 )]
     [TextField( "Clear Selection Text", "The text displayed when a schedule can be unselected. This will not display when the text is empty.", true, "", order: 4 )]
+    [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", false, "", order: 5 )]
     public partial class ScheduleContextSetter : Rock.Web.UI.RockBlock
     {
         #region Base Control Methods
@@ -175,8 +176,8 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.ScheduleContextSetter
 
             if ( refreshPage )
             {
-                // Only redirect if refreshPage is true, and there already is a query string parameter for schedule id
-                if ( !string.IsNullOrWhiteSpace( PageParameter( "scheduleId" ) ) )
+                // Only redirect if refreshPage is true
+                if ( !string.IsNullOrWhiteSpace( PageParameter( "scheduleId" ) ) || GetAttributeValue( "DisplayQueryStrings" ).AsBoolean() )
                 {
                     var queryString = HttpUtility.ParseQueryString( Request.QueryString.ToStringSafe() );
                     queryString.Set( "scheduleId", scheduleId.ToString() );


### PR DESCRIPTION
- Adds a missing CSS class from GroupContextSetter.ascx
- Adds a block setting to always display query strings on CampusContext, GroupContext, and ScheduleContext
- Sets the GroupType context when a Group is set
- Adds an option to display grandchildren of the base GroupType