### PR TITLE
Added setting to display the middle name of a person on the bio block.

### DIFF
--- a/RockWeb/Blocks/Crm/PersonDetail/Bio.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/Bio.ascx.cs
@@ -51,6 +51,7 @@ Because the contents of this setting will be rendered inside a &lt;ul&gt; elemen
 ", Rock.Web.UI.Controls.CodeEditorMode.Html, Rock.Web.UI.Controls.CodeEditorTheme.Rock, 200, false, "", "", 2, "Actions" )]
     [LinkedPage( "Business Detail Page", "The page to redirect user to if a business is is requested.", false, "", "", 3 )]
     [BooleanField( "Display Country Code", "When enabled prepends the country code to all phone numbers." )]
+    [BooleanField( "Display Middle Name", "Display the middle name of the person.")]
     public partial class Bio : PersonBlock
     {
         
@@ -276,7 +277,15 @@ Because the contents of this setting will be rendered inside a &lt;ul&gt; elemen
             }
             else
             {
-                nameText = string.Format( "<span class='first-word'>{0}</span> {1}", Person.NickName, Person.LastName );
+                if (GetAttributeValue( "DisplayMiddleName" ).AsBoolean() && !String.IsNullOrWhiteSpace(Person.MiddleName))
+                {
+                    nameText = string.Format( "<span class='first-word'>{0}</span> {1} {2}", Person.NickName, Person.MiddleName, Person.LastName );
+                }
+                else
+                {
+                    nameText = string.Format( "<span class='first-word'>{0}</span> {1}", Person.NickName, Person.LastName );
+                }
+                
 
                 // Add First Name if different from NickName.
                 if ( Person.NickName != Person.FirstName )


### PR DESCRIPTION
By default the setting is set to false.

We had the requirement to display people's middle names for security reasons.  Seems like something that would be nice to have as core functionality.