### PR TITLE
Sort drop down list for placement groups by Name.

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
@@ -1303,7 +1303,7 @@ namespace RockWeb.Blocks.Connection
                                     .ToList();
             }
                 
-            foreach ( var g in groups )
+            foreach ( var g in groups.OrderBy( g => g.Name ) )
             {
                 ddlPlacementGroup.Items.Add( new ListItem( String.Format( "{0} ({1})", g.Name, g.Campus != null ? g.Campus.Name : "No Campus" ), g.Id.ToString().ToUpper() ) );
             }


### PR DESCRIPTION
When the list gets log, it's harder to find the group you want.  Sorting by name makes it easier to scan through the list.