### PR TITLE
When assigned placement group is not in the drop down list

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
@@ -1330,6 +1330,9 @@ namespace RockWeb.Blocks.Connection
                 }
                 catch
                 {
+                    // Group not in list, let's add it. It must have been assigned elsewhere.
+                    ddlPlacementGroup.Items.Add( new ListItem( String.Format( "{0} ({1})", connectionRequest.AssignedGroup.Name, connectionRequest.AssignedGroup.Campus != null ? connectionRequest.AssignedGroup.Campus.Name : "No Campus" ), connectionRequest.AssignedGroup.Id.ToString().ToUpper() ) );
+                    ddlPlacementGroup.SelectedValue = connectionRequest.AssignedGroupId.ToString();
 
                 }
             }


### PR DESCRIPTION
This adds the assigned placement group to the dropdown list if it is missing.

I didn't want the assigned placement group unset if the connection request was opened and edited, if it wasn't in the dropdown list.

There are two scenarios that this could be used.
1.) A connection request was opened;  the opportunity type is edited, eliminating the placement group from the list; the connection request is edited afterwards.
2.) A custom workflow action is used to set the placement group.

In our case we will be doing scenario 2, because we need more logic for selecting placement groups beyond a simple drop down.  (We have lots of home groups, and we want to select them based on geolocation).

