### PR TITLE
- Add a DateRange context setter to core

### DIFF
--- a/RockWeb/Blocks/Core/DateRangeContextSetter.ascx
+++ b/RockWeb/Blocks/Core/DateRangeContextSetter.ascx
@@ -1,0 +1,32 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="DateRangeContextSetter.ascx.cs" Inherits="RockWeb.Blocks.Core.DateRangeContextSetter" %>
+
+<asp:UpdatePanel ID="upnlContent" runat="server">
+    <ContentTemplate>
+
+        <ul class="nav navbar-nav contextsetter contextsetter-date">
+            <li class="dropdown">
+
+                <a class="dropdown-toggle navbar-link" href="#" data-toggle="dropdown">
+                    <asp:Literal ID="lCurrentSelection" runat="server" />
+                    <b class="fa fa-caret-down"></b>
+                </a>
+
+                <ul class="dropdown-menu" style="padding:10px">
+                    <Rock:SlidingDateRangePicker ID="drpSlidingDateRange" runat="server" Label="Date Range" EnabledSlidingDateRangeTypes="Previous, Last, Current, DateRange"/>
+
+                    <div class="actions text-right">
+                        <asp:LinkButton ID="btnSelect" runat="server" CssClass="btn btn-primary" ToolTip="Select" OnClick="btnSelect_Click" Text="Select" />
+                    </div>
+                </ul>
+            </li>
+        </ul>
+    </ContentTemplate>
+</asp:UpdatePanel>
+
+<script>
+
+    $('.dropdown-menu:not(a)').click(function (e) {
+        e.stopPropagation();
+    });
+
+</script>

--- a/RockWeb/Blocks/Core/DateRangeContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/DateRangeContextSetter.ascx.cs
@@ -1,0 +1,171 @@
+﻿// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web;
+using System.Web.UI.WebControls;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace RockWeb.Blocks.Core
+{
+    /// <summary>
+    /// Block that can be used to set the default date range context for the site
+    /// </summary>
+    [DisplayName( "Date Range Context Setter" )]
+    [Category( "Core" )]
+    [Description( "Block that can be used to set the default date range for the site." )]
+    [CustomRadioListField( "Context Scope", "The scope of context to set", "Site,Page", true, "Site", order: 0 )]
+    [TextField( "No Date Range Text", "The text to show when there is no date range in the context.", true, "Select Date Range", order: 1 )]
+    [SlidingDateRangeField("Default Date Range","The default range to start with if context and query string have not been set", order: 2 )]
+    [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", order: 3 )]
+    public partial class DateRangeContextSetter : Rock.Web.UI.RockBlock
+    {
+        /// <summary>
+        /// The context preference name
+        /// </summary>
+        protected static string ContextPreferenceName = "context-date-range";
+
+        #region Base Control Methods
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            // repaint the screen after block settings are updated
+            this.BlockUpdated += Block_BlockUpdated;
+            this.AddConfigurationUpdateTrigger( upnlContent );
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            if ( !Page.IsPostBack )
+            {
+                LoadDropdowns();
+            }
+        }
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            LoadDropdowns();
+        }
+
+        /// <summary>
+        /// Loads the schedules
+        /// </summary>
+        private void LoadDropdowns()
+        {
+            var currentRange = RockPage.GetUserPreference( ContextPreferenceName );
+            var dateRangeString = Request.QueryString["SlidingDateRange"];
+            if ( !string.IsNullOrEmpty( dateRangeString ) && currentRange != dateRangeString )
+            {
+                // set context to query string
+                SetDateRangeContext( dateRangeString, false );
+                currentRange = dateRangeString;
+            }
+
+            // if current range is selected, show a tooltip, otherwise show the default
+            var dateRange = SlidingDateRangePicker.CalculateDateRangeFromDelimitedValues( currentRange );
+            if ( dateRange != null && dateRange.Start != null && dateRange.End != null )
+            {
+                lCurrentSelection.Text = dateRange.ToStringAutomatic();
+                drpSlidingDateRange.DelimitedValues = currentRange;
+            }
+            else
+            {
+            	lCurrentSelection.Text = GetAttributeValue( "NoDateRangeText" );
+                drpSlidingDateRange.DelimitedValues = GetAttributeValue( "DefaultDateRange" );
+            }
+        }
+
+        /// <summary>
+        /// Sets the schedule context.
+        /// </summary>
+        /// <param name="queryDateRange">The schedule identifier.</param>
+        /// <param name="refreshPage">if set to <c>true</c> [refresh page].</param>
+        /// <returns></returns>
+        protected void SetDateRangeContext( string dateRangeValues, bool refreshPage = false )
+        {
+            bool pageScope = GetAttributeValue( "ContextScope" ) == "Page";
+            
+            // set context and refresh below with the correct query string if needed
+            RockPage.SetUserPreference( ContextPreferenceName, dateRangeValues, true );
+
+            if ( refreshPage )
+            {
+                // Only redirect if refreshPage is true
+                if ( !string.IsNullOrWhiteSpace( PageParameter( "SlidingDateRange" ) ) || GetAttributeValue( "DisplayQueryStrings" ).AsBoolean() )
+                {
+                    var queryString = HttpUtility.ParseQueryString( Request.QueryString.ToStringSafe() );
+                    queryString.Set( "SlidingDateRange", dateRangeValues );
+                    Response.Redirect( string.Format( "{0}?{1}", Request.Url.AbsolutePath, queryString ), false );
+                }
+                else
+                {
+                    Response.Redirect( Request.RawUrl, false );
+                }
+
+                Context.ApplicationInstance.CompleteRequest();
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Handles the Click event of the btnSelect control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnSelect_Click( object sender, EventArgs e )
+        {
+            // set context here when the user is finished editing
+            var dateRange = drpSlidingDateRange.DelimitedValues;
+            if ( dateRange != null )
+            {
+                SetDateRangeContext( dateRange, true );
+            }
+        }
+
+        #endregion
+
+    }
+}


### PR DESCRIPTION
@azturner @edmistj I built this block for the dashboards we're using and matched it to the Analytics work you've been doing.

<img width="504" alt="screenshot 2015-12-03 17 18 10" src="https://cloud.githubusercontent.com/assets/1210933/11576233/3361cb40-99e3-11e5-9626-6d0723d6edc2.png">

Two deviations from the other context blocks:
- Stores the date range in the current user's preferences (requires the user to be logged in)
- padding: 10px currently hardcoded in the block but should be added to theme.css

If you don't want this in core feel free to close it.