### PR TITLE
Add new person to group from API error

### DIFF
--- a/Rock/Model/PersonService.Partial.cs
+++ b/Rock/Model/PersonService.Partial.cs
@@ -1463,7 +1463,7 @@ namespace Rock.Model
                 History.EvaluateChange( demographicChanges, "Graduation Year", null, person.GraduationYear );
                 History.EvaluateChange( demographicChanges, "Connection Status", string.Empty, DefinedValueCache.GetName( person.ConnectionStatusValueId ) );
                 History.EvaluateChange( demographicChanges, "Email Active", true.ToString(), person.IsEmailActive.ToString() );
-                History.EvaluateChange( demographicChanges, "Record Type", string.Empty, DefinedValueCache.GetName( person.RecordTypeValueId.Value ) );
+                History.EvaluateChange( demographicChanges, "Record Type", string.Empty, DefinedValueCache.GetName( person.RecordTypeValueId ) );
                 if ( person.GivingGroupId.HasValue )
                 {
                     person.GivingGroup = person.GivingGroup ?? groupService.Get( person.GivingGroupId.Value );


### PR DESCRIPTION
I was getting a null reference exception when adding a new person (not in the database yet) to a group.  The problem was that I had not set a RecordTypeId on the person and this code was throwing the exception.  The `DefinedValueCache.GetName` method supports `int?` so I made it pass as-is since `RecordTypeValueId ` is a non-required field.