### PR TITLE
Hotfix connection connected status workflow trigger

### DIFF
--- a/Rock/Transactions/ConnectionRequestChangeTransaction.cs
+++ b/Rock/Transactions/ConnectionRequestChangeTransaction.cs
@@ -161,7 +161,7 @@ namespace Rock.Transactions
                                             }
                                         case ConnectionWorkflowTriggerType.RequestConnected:
                                             {
-                                                if ( State == EntityState.Modified && ConnectionState == global::ConnectionState.Inactive )
+                                                if ( State == EntityState.Modified && ConnectionState == global::ConnectionState.Connected )
                                                 {
                                                     LaunchWorkflow( rockContext, connectionWorkflow, "Request Completed" );
                                                 }


### PR DESCRIPTION
When Workflow trigger is Request Connected,  check connection state is equal to 'connected', not 'inactive'
