### PR TITLE
Make the new family control to add a person match the edit family control to add a person

### DIFF
--- a/Rock/Web/UI/Controls/NewFamily/Members.cs
+++ b/Rock/Web/UI/Controls/NewFamily/Members.cs
@@ -108,12 +108,16 @@ namespace Rock.Web.UI.Controls
             Controls.Add( _lbAddGroupMember );
             _lbAddGroupMember.ID = this.ID + "_btnAddGroupMember";
             _lbAddGroupMember.Click += lbAddGroupMember_Click;
-            _lbAddGroupMember.AddCssClass( "add btn btn-sm btn-action" );
+            _lbAddGroupMember.AddCssClass( "add btn btn-xs btn-action" );
             _lbAddGroupMember.CausesValidation = false;
 
             var iAddFilter = new HtmlGenericControl( "i" );
-            iAddFilter.AddCssClass("fa fa-plus-circle");
+            iAddFilter.AddCssClass("fa fa-user");
             _lbAddGroupMember.Controls.Add( iAddFilter );
+
+            var spanAddFilter = new HtmlGenericControl("span");
+            spanAddFilter.InnerHtml = " Add Person";
+            _lbAddGroupMember.Controls.Add( spanAddFilter );
         }
 
         /// <summary>


### PR DESCRIPTION
We noticed that users were often overlooking the "Add Person" control on the "Add Family" page.  I made a change to make that control resemble the control used on the "Edit Family" page.

It looks like this:
![image](https://cloud.githubusercontent.com/assets/8700223/12565309/fab9d6ac-c381-11e5-88c1-64567b673b90.png)
