### PR TITLE
Person Info Icon in Group Member List

### DIFF
--- a/RockWeb/Blocks/Groups/GroupMemberList.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupMemberList.ascx.cs
@@ -1018,7 +1018,7 @@ namespace RockWeb.Blocks.Groups
                         m.Person.NickName,
                         m.Person.LastName,
                         Name =
-                        ( selectAll ? m.Person.LastName + ", " + m.Person.NickName : ( m.Person.PhotoId.HasValue ? "<i class='fa fa-fw fa-user photo-icon has-photo js-person-popover' personid=" + m.PersonId.ToString() + "></i> " : "<i class='fa fa-fw photo-icon js-person-popover' personid=" + m.PersonId.ToString() + "></i> " ) +
+                        ( selectAll ? m.Person.LastName + ", " + m.Person.NickName : ( "<i class='fa fa-info-circle person-info-icon js-person-popover' personid=" + m.PersonId.ToString() + "></i> " ) +
                         m.Person.NickName + " " + m.Person.LastName
                             + ( hasGroupRequirements && groupMemberIdsThatLackGroupRequirements.Contains( m.Id )
                                 ? " <i class='fa fa-exclamation-triangle text-warning'></i>"

--- a/RockWeb/Styles/_grid.less
+++ b/RockWeb/Styles/_grid.less
@@ -512,6 +512,12 @@ tr.row-highlight {
 
 // 11. Components
 // -------------------------
+
+td .person-info-icon {
+    opacity: 0.6;
+    min-height: 16px;
+}
+
 td .photo-icon {
     opacity: 0.6;
     min-height: 16px;


### PR DESCRIPTION
During our testing we found that if a person didn't have a picture associated with their profile the spacing of their name within the group member list seemed off.  After researching we found that it was because there was no image associated with the person's profile, however when you hovered there was a popover that would display additional information about that person.

This change removes the check for a photo and replaces the photo icon with an info icon so that it's clear to the user that they can hover on the icon for more information about that person.