### PR TITLE
Registration - NickName is null and throws a null reference exception

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -1438,6 +1438,11 @@ namespace RockWeb.Blocks.Event
 
             if ( newRegistrar )
             {
+                if( CurrentPerson != null && CurrentPerson.NickName == null )
+                {
+                    CurrentPerson.NickName = CurrentPerson.FirstName;
+                }
+
                 // If the 'your name' value equals the currently logged in person, use their person alias id
                 if ( CurrentPerson != null &&
                 ( CurrentPerson.NickName.Trim().Equals( registration.FirstName.Trim(), StringComparison.OrdinalIgnoreCase ) ||


### PR DESCRIPTION
`CurrentPerson.NickName` is null in our registration scenario and causes a null reference exception on the `CurrentPerson.NickName.Trim()` within the `if` statement.

Because `NickName` is not a required field, I opted to assign it to the value of `FirstName` - though there are many other ways this null reference exception could be remedied.