### PR TITLE
Left String Extension - Return null if the string is null

### DIFF
--- a/Rock/Utility/ExtensionMethods/StringExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/StringExtensions.cs
@@ -186,7 +186,11 @@ namespace Rock
         /// <returns></returns>
         public static string Left( this string str, int length )
         {
-            if ( str.Length <= length )
+            if ( str == null )
+            {
+                return null;
+            }                
+            else if ( str.Length <= length )
             {
                 return str;
             }


### PR DESCRIPTION
Many of the string extensions, such as SplitCase (https://github.com/SparkDevNetwork/Rock/blob/develop/Rock/Utility/ExtensionMethods/StringExtensions.cs#L71) return null when the context string is null.  I expect that `Left` should do the same thing.  Currently it throws a null reference exception.