### PR TITLE
Order Groups and Schedules by name in Context Selectors

### DIFF
--- a/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
@@ -156,8 +156,7 @@ namespace RockWeb.Blocks.Core
 
                 lCurrentSelection.Text = currentGroup != null ? currentGroup.ToString() : GetAttributeValue( "NoGroupText" );
 
-                var groupList = qryGroups.OrderBy( a => a.Order )
-                    .ThenBy( a => a.Name ).ToList()
+                var groupList = qryGroups.OrderBy( a => a.Name ).ToList()
                     .Select( a => new GroupItem() { Name = a.Name, Id = a.Id } )
                     .ToList();
 

--- a/RockWeb/Blocks/Core/ScheduleContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/ScheduleContextSetter.ascx.cs
@@ -41,7 +41,7 @@ namespace RockWeb.Blocks.Core
     [TextField( "Current Item Template", "Lava template for the current item. The only merge field is {{ ScheduleName }}.", true, "{{ ScheduleName }}", order: 2 )]
     [TextField( "Dropdown Item Template", "Lava template for items in the dropdown. The only merge field is {{ ScheduleName }}.", true, "{{ ScheduleName }}", order: 2 )]
     [TextField( "No Schedule Text", "The text to show when there is no schedule in the context.", true, "Select Schedule", order: 3 )]
-    [TextField( "Clear Selection Text", "The text displayed when a schedule can be unselected. This will not display when the text is empty.", true, "", order: 4 )]
+    [TextField( "Clear Selection Text", "The text displayed when a schedule can be unselected. This will not display when the text is empty.", false, "", order: 4 )]
     [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", false, "", order: 5 )]
     public partial class ScheduleContextSetter : Rock.Web.UI.RockBlock
     {
@@ -147,7 +147,7 @@ namespace RockWeb.Blocks.Core
                 schedules.Insert( 0, blankCampus );
             }
 
-            rptSchedules.DataSource = schedules;
+            rptSchedules.DataSource = schedules.OrderBy( s => s.Name ).ToList();
             rptSchedules.DataBind();
         }
 


### PR DESCRIPTION
After getting our production server up, the Order of Groups and Schedules was all over the place.  

We could've changed the order on all our Groups and Schedules but it's easier to have the selector order by Name.

Here's an example of previous behavior:

![image](https://cloud.githubusercontent.com/assets/1210933/12624387/cf79d2c2-c4fc-11e5-8e92-3f25dfd24bed.png)
