### PR TITLE
Update the check-in manager to exclude people who have checked out

### DIFF
--- a/RockWeb/Blocks/CheckIn/Manager/Locations.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Manager/Locations.ascx.cs
@@ -239,6 +239,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                         a.DidAttend.HasValue &&
                         a.DidAttend.Value &&
                         a.StartDateTime > today &&
+                        !a.EndDateTime.HasValue &&
                         activeScheduleIds.Contains( a.ScheduleId.Value ) &&
                         groupIds.Contains( a.GroupId.Value ) )
                     .Select( a =>
@@ -545,6 +546,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                                     .Where( a =>
                                         a.StartDateTime > dayStart &&
                                         a.StartDateTime < now &&
+                                        !a.EndDateTime.HasValue &&
                                         a.LocationId.HasValue &&
                                         a.LocationId.Value == itemId.Value &&
                                         a.PersonAlias != null &&
@@ -840,6 +842,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                             a.LocationId.HasValue &&
                             a.StartDateTime > dayStart &&
                             a.StartDateTime < now &&
+                            !a.EndDateTime.HasValue &&
                             a.DidAttend.HasValue &&
                             a.DidAttend.Value &&
                             groupIds.Contains( a.GroupId.Value ) &&
@@ -1232,6 +1235,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                             .Where( a =>
                                 a.StartDateTime > dayStart &&
                                 a.StartDateTime < now &&
+                                !a.EndDateTime.HasValue &&
                                 a.LocationId.HasValue &&
                                 a.LocationId == locationItem.Id &&
                                 a.DidAttend.HasValue &&

--- a/RockWeb/Blocks/CheckIn/Manager/Locations.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Manager/Locations.ascx.cs
@@ -35,12 +35,11 @@ using Rock.Web.UI.Controls;
 namespace RockWeb.Blocks.CheckIn.Manager
 {
     /// <summary>
-    /// Template block for developers to use to start a new block.
+    /// Block used to view current check-in counts and locations
     /// </summary>
     [DisplayName( "Locations" )]
     [Category( "Check-in > Manager" )]
     [Description( "Block used to view current check-in counts and locations." )]
-
     [CustomRadioListField( "Navigation Mode", "Navigation and attendance counts can be grouped and displayed either by 'Group Type > Group Type (etc) > Group > Location' or by 'location > location (etc).'  Select the navigation heirarchy that is most appropriate for your organization.", "T^Group Type,L^Location,", true, "T", "", 0, "Mode" )]
     [GroupTypeField( "Check-in Type", "The Check-in Area to display.  This value can also be overridden through the URL query string key (e.g. when navigated to from the Check-in Type selection block).", true, "", "", 1, "GroupTypeTemplate", Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE )]
     [LinkedPage( "Person Page", "The page used to display a selected person's details.", order: 2 )]
@@ -50,15 +49,16 @@ namespace RockWeb.Blocks.CheckIn.Manager
     {
         #region Fields
 
-
         private string _configuredMode = "L";
-    
+
         #endregion
 
         #region Properties
 
         public string CurrentCampusId { get; set; }
+
         public string CurrentNavPath { get; set; }
+
         public NavigationData NavData { get; set; }
 
         #endregion
@@ -123,7 +123,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
             var campusEntityType = EntityTypeCache.Read( "Rock.Model.Campus" );
             var campusContext = RockPage.GetCurrentContext( campusEntityType ) as Campus;
             CampusCache campus = null;
-            if (campusContext != null)
+            if ( campusContext != null )
             {
                 campus = CampusCache.Read( campusContext );
             }
@@ -139,7 +139,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                     NavData = GetNavigationData( campus );
                     CurrentCampusId = campus.Id.ToString();
 
-                    if (Page.IsPostBack)
+                    if ( Page.IsPostBack )
                     {
                         CurrentNavPath = string.Empty;
                         BuildNavigationControls();
@@ -195,6 +195,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
 
             return base.SaveViewState();
         }
+
         #endregion
 
         #region Events
@@ -203,7 +204,6 @@ namespace RockWeb.Blocks.CheckIn.Manager
         {
             using ( var rockContext = new RockContext() )
             {
-
                 // Get all the schedules that allow checkin
                 var schedules = new ScheduleService( rockContext )
                     .Queryable().AsNoTracking()
@@ -223,7 +223,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                     }
                 }
 
-                // Get a list of all the groups that we're concerned about 
+                // Get a list of all the groups that we're concerned about
                 var groupIds = NavData.Groups.Select( g => g.Id ).ToList();
 
                 // Get a list of all the people that are currently checked in
@@ -345,7 +345,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
-        void rptNavItems_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        protected void rptNavItems_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
             var navItem = e.Item.DataItem as NavigationItem;
             if ( navItem != null )
@@ -358,8 +358,8 @@ namespace RockWeb.Blocks.CheckIn.Manager
                 }
 
                 var tgl = e.Item.FindControl( "tglRoom" ) as Toggle;
-                if (tgl != null)
-                {   
+                if ( tgl != null )
+                {
                     var loc = navItem as NavigationLocation;
                     if ( loc != null )
                     {
@@ -380,7 +380,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
-        void rptPeople_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        protected void rptPeople_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
             var person = e.Item.DataItem as PersonResult;
             if ( person != null )
@@ -392,7 +392,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                 }
 
                 var img = e.Item.FindControl( "imgPerson" ) as Literal;
-                if (img != null)
+                if ( img != null )
                 {
                     img.Text = Rock.Model.Person.GetPhotoImageTag( person.PhotoId, null, person.Gender, 50, 50 );
                 }
@@ -402,7 +402,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                 {
                     if ( person.LastCheckin.HasValue )
                     {
-                        if (person.CheckedInNow)
+                        if ( person.CheckedInNow )
                         {
                             lStatus.Text = "<span class='badge badge-success'>Checked In</span><br/>";
                         }
@@ -435,7 +435,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="PostBackEventArgs"/> instance containing the event data.</param>
-        void upnlContent_OnPostBack( object sender, PostBackEventArgs e )
+        protected void upnlContent_OnPostBack( object sender, PostBackEventArgs e )
         {
             tbSearch.Text = string.Empty;
 
@@ -473,7 +473,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
         {
             var tgl = sender as Toggle;
             int? id = tgl.Attributes["data-key"].AsIntegerOrNull();
-            if (id.HasValue)
+            if ( id.HasValue )
             {
                 using ( var rockContext = new RockContext() )
                 {
@@ -566,7 +566,6 @@ namespace RockWeb.Blocks.CheckIn.Manager
                                 NavData = GetNavigationData( CampusCache.Read( campusId.Value ) );
                             }
                             BuildNavigationControls();
-
                         }
                     }
                 }
@@ -582,7 +581,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
             return CampusCache.All().FirstOrDefault();
         }
 
-        private string BuildCurrentPath(int? groupTypeId, int? locationId, int? groupId)
+        private string BuildCurrentPath( int? groupTypeId, int? locationId, int? groupId )
         {
             NavigationGroupType groupType = groupTypeId.HasValue ? NavData.GroupTypes.Where( t => t.Id == groupTypeId.Value ).FirstOrDefault() : null;
             NavigationLocation location = locationId.HasValue ? NavData.Locations.Where( l => l.Id == locationId.Value ).FirstOrDefault() : null;
@@ -666,14 +665,15 @@ namespace RockWeb.Blocks.CheckIn.Manager
     var data = eval($('#{1}').val());
     var options = {2};
     $.plot( $('#{0}'), data, options );
-", 
-                pnlChart.ClientID, hfChartData.ClientID, 
-                JsonConvert.SerializeObject( 
-                    options, 
-                    Formatting.Indented, 
-                    new JsonSerializerSettings() { 
-                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore, 
-                        NullValueHandling = NullValueHandling.Ignore 
+",
+                pnlChart.ClientID, hfChartData.ClientID,
+                JsonConvert.SerializeObject(
+                    options,
+                    Formatting.Indented,
+                    new JsonSerializerSettings()
+                    {
+                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                        NullValueHandling = NullValueHandling.Ignore
                     } ) );
 
             ScriptManager.RegisterStartupScript( pnlChart, pnlChart.GetType(), "chart", script, true );
@@ -751,10 +751,10 @@ namespace RockWeb.Blocks.CheckIn.Manager
                         .ToList();
                     var groupIds = groups.Select( g => g.Id ).ToList();
 
-                    foreach( var group in groups )
+                    foreach ( var group in groups )
                     {
                         var childGroupIds = groups
-                            .Where( g => 
+                            .Where( g =>
                                 g.ParentGroupId.HasValue &&
                                 g.ParentGroupId.Value == group.Id )
                             .Select( g => g.Id )
@@ -904,7 +904,6 @@ namespace RockWeb.Blocks.CheckIn.Manager
             }
 
             return null;
-
         }
 
         public GroupType GetParentPurposeGroupType( GroupType groupType, Guid purposeGuid )
@@ -1007,11 +1006,11 @@ namespace RockWeb.Blocks.CheckIn.Manager
             var navGroup = NavData.Groups.FirstOrDefault( g => g.Id == groupId );
             if ( navGroup != null )
             {
-                if (!navGroup.RecentPersonIds.ContainsKey(time))
+                if ( !navGroup.RecentPersonIds.ContainsKey( time ) )
                 {
                     navGroup.RecentPersonIds.Add( time, new List<int>() );
                 }
-                navGroup.RecentPersonIds[time] = navGroup.RecentPersonIds[time].Union(personIds).ToList();
+                navGroup.RecentPersonIds[time] = navGroup.RecentPersonIds[time].Union( personIds ).ToList();
 
                 if ( current )
                 {
@@ -1052,11 +1051,11 @@ namespace RockWeb.Blocks.CheckIn.Manager
             {
                 if ( !navLocation.RecentPersonIds.ContainsKey( time ) )
                 {
-                    navLocation.RecentPersonIds.Add( time, new List<int>()  );
+                    navLocation.RecentPersonIds.Add( time, new List<int>() );
                 }
-                navLocation.RecentPersonIds[time]  = navLocation.RecentPersonIds[time].Union( personIds ).ToList();
+                navLocation.RecentPersonIds[time] = navLocation.RecentPersonIds[time].Union( personIds ).ToList();
 
-                if (current)
+                if ( current )
                 {
                     navLocation.CurrentPersonIds = navLocation.CurrentPersonIds.Union( personIds ).ToList();
                 }
@@ -1084,11 +1083,11 @@ namespace RockWeb.Blocks.CheckIn.Manager
                 var pathParts = CurrentNavPath.Split( new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries );
                 int numParts = pathParts.Length;
 
-                NavigationItem item = NavData.GetItem( pathParts[numParts-1] );
-                while (item == null && numParts > 1)
+                NavigationItem item = NavData.GetItem( pathParts[numParts - 1] );
+                while ( item == null && numParts > 1 )
                 {
                     numParts--;
-                    item = NavData.GetItem( pathParts[numParts-1] );
+                    item = NavData.GetItem( pathParts[numParts - 1] );
                 }
                 CurrentNavPath = pathParts.Take( numParts ).ToList().AsDelimited( "|" );
 
@@ -1117,7 +1116,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                         {
                             // Add child group types
                             NavData.GroupTypes
-                                .Where( t => t.ParentId.Equals(itemId) )
+                                .Where( t => t.ParentId.Equals( itemId ) )
                                 .ToList().ForEach( t => navItems.Add( t ) );
 
                             // Add child groups
@@ -1160,19 +1159,18 @@ namespace RockWeb.Blocks.CheckIn.Manager
 
                             break;
                         }
-
                 }
 
                 // Get chart data
                 Dictionary<DateTime, List<int>> chartCounts = null;
-                if (item != null)
+                if ( item != null )
                 {
                     chartCounts = item.RecentPersonIds;
                 }
                 else
                 {
                     chartCounts = new Dictionary<DateTime, List<int>>();
-                    foreach(var navItem in navItems)
+                    foreach ( var navItem in navItems )
                     {
                         foreach ( var kv in navItem.RecentPersonIds )
                         {
@@ -1187,7 +1185,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
 
                 var chartData = new List<string>();
 
-                TimeSpan baseSpan = new TimeSpan( new DateTime(1970, 1, 1).Ticks );
+                TimeSpan baseSpan = new TimeSpan( new DateTime( 1970, 1, 1 ).Ticks );
                 foreach ( var kv in chartCounts.OrderBy( c => c.Key ) )
                 {
                     DateTime offsetTime = kv.Key.Subtract( baseSpan );
@@ -1195,7 +1193,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                     chartData.Add( string.Format( "[{0}, {1}]", ticks, kv.Value.Count() ) );
                 }
                 hfChartData.Value = string.Format( "[ [ {0} ] ]", chartData.AsDelimited( ", " ) );
-                pnlChart.Attributes["onClick"] = upnlContent.GetPostBackEventReference("R");
+                pnlChart.Attributes["onClick"] = upnlContent.GetPostBackEventReference( "R" );
 
                 pnlNavHeading.Visible = item != null;
                 if ( item != null )
@@ -1208,7 +1206,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
                     lNavHeading.Text = item.Name;
 
                     var locationItem = item as NavigationLocation;
-                    if (locationItem != null && locationItem.HasGroups)
+                    if ( locationItem != null && locationItem.HasGroups )
                     {
                         tglHeadingRoom.Visible = true;
                         tglHeadingRoom.Checked = locationItem.IsActive;
@@ -1279,10 +1277,8 @@ namespace RockWeb.Blocks.CheckIn.Manager
                 rptNavItems.DataBind();
 
                 RegisterStartupScript();
-
             }
-
-}
+        }
 
         #endregion
 
@@ -1294,8 +1290,11 @@ namespace RockWeb.Blocks.CheckIn.Manager
         public class NavigationData
         {
             public List<NavigationLocation> Locations { get; set; }
+
             public List<NavigationGroupType> GroupTypes { get; set; }
+
             public List<NavigationGroup> Groups { get; set; }
+
             public NavigationData()
             {
                 Locations = new List<NavigationLocation>();
@@ -1303,37 +1302,37 @@ namespace RockWeb.Blocks.CheckIn.Manager
                 Groups = new List<NavigationGroup>();
             }
 
-            public NavigationItem GetItem (string itemKey)
+            public NavigationItem GetItem( string itemKey )
             {
                 NavigationItem item = null;
 
                 if ( itemKey.Length > 1 )
                 {
                     string itemType = itemKey.Left( 1 );
-                    
+
                     int? itemId = itemKey.Length > 1 ? itemKey.Substring( 1 ).AsIntegerOrNull() : null;
-                    if (itemId.HasValue)
+                    if ( itemId.HasValue )
                     {
-                    switch ( itemType )
-                    {
-                        case "L":
-                            {
-                                item = Locations.Where( l => l.Id == itemId ).FirstOrDefault();
-                                break;
-                            }
+                        switch ( itemType )
+                        {
+                            case "L":
+                                {
+                                    item = Locations.Where( l => l.Id == itemId ).FirstOrDefault();
+                                    break;
+                                }
 
-                        case "T":
-                            {
-                                item = GroupTypes.Where( l => l.Id == itemId ).FirstOrDefault();
-                                break;
-                            }
+                            case "T":
+                                {
+                                    item = GroupTypes.Where( l => l.Id == itemId ).FirstOrDefault();
+                                    break;
+                                }
 
-                        case "G":
-                            {
-                                item = Groups.Where( l => l.Id == itemId ).FirstOrDefault();
-                                break;
-                            }
-                    }
+                            case "G":
+                                {
+                                    item = Groups.Where( l => l.Id == itemId ).FirstOrDefault();
+                                    break;
+                                }
+                        }
                     }
                 }
 
@@ -1345,12 +1344,19 @@ namespace RockWeb.Blocks.CheckIn.Manager
         public abstract class NavigationItem
         {
             public int? ParentId { get; set; }
+
             public int Id { get; set; }
+
             public string Name { get; set; }
+
             public int Order { get; set; }
+
             public List<int> CurrentPersonIds { get; set; }
+
             public int CurrentCount { get { return CurrentPersonIds.Count(); } }
+
             public Dictionary<DateTime, List<int>> RecentPersonIds { get; set; }
+
             public virtual string TypeKey { get { return ""; } }
         }
 
@@ -1358,9 +1364,13 @@ namespace RockWeb.Blocks.CheckIn.Manager
         public class NavigationLocation : NavigationItem
         {
             public override string TypeKey { get { return "L"; } }
+
             public bool IsActive { get; set; }
+
             public List<int> ChildLocationIds { get; set; }
+
             public bool HasGroups { get; set; }
+
             public NavigationLocation( Location location, List<DateTime> chartTimes )
             {
                 Id = location.Id;
@@ -1377,8 +1387,11 @@ namespace RockWeb.Blocks.CheckIn.Manager
         public class NavigationGroupType : NavigationItem
         {
             public override string TypeKey { get { return "T"; } }
+
             public List<int> ChildGroupTypeIds { get; set; }
+
             public List<int> ChildGroupIds { get; set; }
+
             public NavigationGroupType( GroupTypeCache groupType, List<DateTime> chartTimes )
             {
                 Id = groupType.Id;
@@ -1396,9 +1409,13 @@ namespace RockWeb.Blocks.CheckIn.Manager
         public class NavigationGroup : NavigationItem
         {
             public override string TypeKey { get { return "G"; } }
+
             public int GroupTypeId { get; set; }
+
             public List<int> ChildLocationIds { get; set; }
+
             public List<int> ChildGroupIds { get; set; }
+
             public NavigationGroup( Group group, List<DateTime> chartTimes )
             {
                 Id = group.Id;
@@ -1416,14 +1433,23 @@ namespace RockWeb.Blocks.CheckIn.Manager
         public class PersonResult
         {
             public int Id { get; set; }
+
             public Guid Guid { get; set; }
+
             public string Name { get; set; }
+
             public Gender Gender { get; set; }
+
             public int? PhotoId { get; set; }
+
             public DateTime? LastCheckin { get; set; }
+
             public bool CheckedInNow { get; set; }
+
             public string ScheduleGroupNames { get; set; }
+
             public string Age { get; set; }
+
             public bool ShowCancel { get; set; }
 
             public PersonResult()
@@ -1457,5 +1483,5 @@ namespace RockWeb.Blocks.CheckIn.Manager
         }
 
         #endregion
-}
+    }
 }

--- a/RockWeb/Blocks/CheckIn/Manager/Person.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Manager/Person.ascx.cs
@@ -31,7 +31,7 @@ using Rock.Security;
 namespace RockWeb.Blocks.CheckIn.Manager
 {
     /// <summary>
-    /// Template block for developers to use to start a new block.
+    /// Block used to display person and details about recent check-ins
     /// </summary>
     [DisplayName( "Person Profile" )]
     [Category( "Check-in > Manager" )]

--- a/RockWeb/Blocks/CheckIn/Manager/SelectArea.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Manager/SelectArea.ascx.cs
@@ -34,7 +34,7 @@ using Rock.Web.UI.Controls;
 namespace RockWeb.Blocks.CheckIn.Manager
 {
     /// <summary>
-    /// Template block for developers to use to start a new block.
+    /// Block used to select a type of check-in area before managing locations
     /// </summary>
     [DisplayName( "Select Check-In Area" )]
     [Category( "Check-in > Manager" )]


### PR DESCRIPTION
Per https://rockrms.slack.com/archives/check-in/p1448843537000032:
>
David Turner [7:32 PM] 
@mrupsidedown: You have several existing fields on the attendance record that you can use to track this type of information. Which fields you choose sort of depends on how you want attendance to be reported for those people that haven't yet shown up at the classroom.  The existing SaveAttendance action in the out-of-the-box workflow updates the StartDateTime, and DidAttend flags whenever a person checks in.  You could clone this action, and update it so that it does not set one or both of these fields until the child actually shows up at the classroom. And there is already an EndDateTime field that can be used to track when a child "checks out" of the classroom.  In addition to those fields, there is a also a QualiferValueId field that you could use to indicate a custom check-in status for each check-in in this scenario. This field is provided for exactly this type of scenario where a church may need to additionally qualify their attendance records using a custom workflow action or block.

This update excludes people who have an EndDateTime from showing up in the Check-in Manager.

Before:

![screenshot 2016-02-03 16 55 50](https://cloud.githubusercontent.com/assets/1210933/12798706/dc82214e-ca98-11e5-93f6-71c51bea660a.png)

After: 

![screenshot 2016-02-03 17 03 05](https://cloud.githubusercontent.com/assets/1210933/12798703/d5aae11c-ca98-11e5-8aba-eade85de5536.png)
