### PR TITLE
- Fix issue with check-in "randomly" not allowing check-ins

### DIFF
--- a/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Linq;
 
 using Rock.Attribute;
@@ -85,10 +86,24 @@ namespace Rock.Workflow.Action.CheckIn
 
                             if ( minAgeValue != null )
                             {
-                                double minAge = 0;
-                                if ( double.TryParse( minAgeValue, out minAge ) )
+                                decimal minAge = 0;
+
+                                if ( decimal.TryParse( minAgeValue, out minAge ) )
                                 {
-                                    if ( !age.HasValue || age < minAge )
+                                    decimal? personAgePrecise = null;
+                                    if ( age.HasValue )
+                                    {
+                                        int groupMinAgePrecision = 0;
+                                        var decimalIndex = minAgeValue.IndexOf( NumberFormatInfo.CurrentInfo.NumberDecimalSeparator );
+                                        if ( decimalIndex > 0 )
+                                        {
+                                            groupMinAgePrecision = minAgeValue.Length - decimalIndex - 1;
+                                        }
+
+                                        personAgePrecise = Math.Round( Convert.ToDecimal( age ), groupMinAgePrecision, MidpointRounding.ToEven );
+                                    }
+
+                                    if ( !age.HasValue || personAgePrecise < minAge )
                                     {
                                         if ( remove )
                                         {
@@ -105,10 +120,24 @@ namespace Rock.Workflow.Action.CheckIn
 
                             if ( maxAgeValue != null )
                             {
-                                double maxAge = 0;
-                                if ( double.TryParse( maxAgeValue, out maxAge ) )
+                                decimal maxAge = 0;
+
+                                if ( decimal.TryParse( maxAgeValue, out maxAge ) )
                                 {
-                                    if ( !age.HasValue || age > maxAge )
+                                    decimal? personAgePrecise = null;
+                                    if ( age.HasValue )
+                                    {
+                                        int groupMaxAgePrecision = 0;
+                                        var decimalIndex = maxAgeValue.IndexOf( NumberFormatInfo.CurrentInfo.NumberDecimalSeparator );
+                                        if ( decimalIndex > 0 )
+                                        {
+                                            groupMaxAgePrecision = maxAgeValue.Length - decimalIndex - 1;
+                                        }
+
+                                        personAgePrecise = Math.Round( Convert.ToDecimal( age ), groupMaxAgePrecision, MidpointRounding.ToEven );
+                                    }
+
+                                    if ( !age.HasValue || personAgePrecise > maxAge )
                                     {
                                         if ( remove )
                                         {


### PR DESCRIPTION
See the following;
- https://github.com/SparkDevNetwork/Rock/issues/1281
- http://www.rockrms.com/Rock/Ask/Troubleshooting/Questions/579
- https://github.com/NewSpring/Rock/issues/151

TL;DR in certain edge cases, an AgePrecise of 2.9955191256830603 would get filtered out of a group with an AgeRange of 2.99.  Fixed with PR.

![image](https://cloud.githubusercontent.com/assets/1210933/12901669/e0259f88-ce8a-11e5-9506-f6c8300ddd7c.png)

I tracked down the issue to the AgePrecise value.  Since double is stored as a fractional number in C#, the precision is only limited by the data type and was being calculated with 16 degrees of precision.  Conversely, most of our Groups were using an AgeRange precision of 0 (and usually a max precision of 2).  

In order to consistently compare the ages, I adjusted the local AgePrecise data type to a decimal and limited the precision to whatever the group AgeRange is using.  This means a group can be as flexible as needed for the MinAge *or* the MaxAge:

![image](https://cloud.githubusercontent.com/assets/1210933/12901889/eb862482-ce8b-11e5-92d7-7af87b3b18e3.png)

I'm also using [MidpointRounding.ToEven](https://msdn.microsoft.com/en-us/library/system.midpointrounding%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396) so that a child of 2.9999562 would still be included in a group that allows 2.99.