### PR TITLE
Add context object to EventItemListLava block

### DIFF
--- a/RockWeb/Blocks/Event/EventItemListLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemListLava.ascx.cs
@@ -217,6 +217,27 @@ namespace RockWeb.Blocks.Event
             }
 
             var mergeFields = new Dictionary<string, object>();
+
+            var contextObjects = new Dictionary<string, object>();
+            foreach (var contextEntityType in RockPage.GetContextEntityTypes())
+            {
+                var contextEntity = RockPage.GetCurrentContext(contextEntityType);
+                if (contextEntity != null && contextEntity is DotLiquid.ILiquidizable)
+                {
+                    var type = Type.GetType(contextEntityType.AssemblyName ?? contextEntityType.Name);
+                    if (type != null)
+                    {
+                        contextObjects.Add(type.Name, contextEntity);
+                    }
+                }
+
+            }
+
+            if (contextObjects.Any())
+            {
+                mergeFields.Add("Context", contextObjects);
+            }
+
             mergeFields.Add( "DetailsPage", LinkedPageUrl( "DetailsPage", null ) );
             mergeFields.Add( "EventOccurrenceSummaries", eventOccurrenceSummaries );
             mergeFields.Add( "CurrentPerson", CurrentPerson );


### PR DESCRIPTION
Copied directly from HTML content block. For our usage, if there was no campus selected, and use campus context was set on the block, the block would display _all_ of the events, for every campus. With access to the context object we can detect if the campus context has not been set (in the lava template) and prompt the user to select a campus instead.