### PR TITLE
Attribute Block category wrap

### DIFF
--- a/RockWeb/Blocks/Core/Attributes.ascx
+++ b/RockWeb/Blocks/Core/Attributes.ascx
@@ -37,7 +37,7 @@
                                     </ItemTemplate>
                                 </Rock:RockTemplateField>
                                 <Rock:RockBoundField DataField="Name" HeaderText="Name" SortExpression="Name" ItemStyle-Wrap="false" />
-                                <Rock:RockTemplateField ItemStyle-Wrap="false">
+                                <Rock:RockTemplateField>
                                     <HeaderTemplate>Categories</HeaderTemplate>
                                     <ItemTemplate>
                                         <asp:Literal ID="lCategories" runat="server"></asp:Literal>


### PR DESCRIPTION
Buggy Behavior
---
When text in an attribute grid for categories is longer than expected the text overflows the grid, and grid buttons aren't immediately visible.

![image](https://cloud.githubusercontent.com/assets/3417857/13116760/0da1755e-d56b-11e5-8935-79f795df3509.png)

Fix
---
Removed the ItemStyle-Wrap which now allows the category field to wrap properly, and not overflow the grid.  This pattern is very similar to how the Description field in Defined Types (which is also the third column in the table) handles it's content.
