### PR TITLE
Filters for the Dynamic Data Block

### DIFF
--- a/Rock/Web/UI/Controls/Grid/GridFilter.cs
+++ b/Rock/Web/UI/Controls/Grid/GridFilter.cs
@@ -415,9 +415,11 @@ namespace Rock.Web.UI.Controls
             RockBlock rockBlock = this.RockBlock();
             if ( rockBlock != null && _userPreferences != null )
             {
+                string keyPrefix = string.Format( "grid-filter-{0}-", rockBlock.BlockId );
+
                 foreach ( var userPreference in _userPreferences )
                 {
-                    rockBlock.DeleteUserPreference( userPreference.Key );
+                    rockBlock.DeleteUserPreference( string.Format( "{0}{1}|{2}", keyPrefix, userPreference.Key, userPreference.Name ) );
                 }
 
                 _userPreferences.Clear();

--- a/Rock/Web/UI/Controls/Pickers/DateRangePicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/DateRangePicker.cs
@@ -177,15 +177,14 @@ namespace Rock.Web.UI.Controls
         #region Controls
 
         /// <summary>
-        /// The lower value 
+        /// The lower value
         /// </summary>
         private DatePicker _tbLowerValue;
 
         /// <summary>
-        /// The upper value 
+        /// The upper value
         /// </summary>
         private DatePicker _tbUpperValue;
-
 
         /// <summary>
         /// Gets or sets the class that should be applied to the div that wraps the two date pickers
@@ -222,7 +221,6 @@ namespace Rock.Web.UI.Controls
             // a little javascript to make the daterange picker behave similar to the bootstrap-datepicker demo site's date range picker
             var scriptFormat = @"
 $('#{0}').datepicker({{ format: '{2}', todayHighlight: true }}).on('changeDate', function (ev) {{
-        
     if (ev.date.valueOf() > $('#{1}').data('datepicker').dates[0]) {{
         var newDate = new Date(ev.date)
         newDate.setDate(newDate.getDate() + 1);
@@ -231,7 +229,7 @@ $('#{0}').datepicker({{ format: '{2}', todayHighlight: true }}).on('changeDate',
         // disable date selection in the EndDatePicker that are earlier than the startDate
         $('#{1}').datepicker('setStartDate', ev.date);
     }}
-    
+
     if (event && event.type == 'click') {{
         // close the start date picker and set focus to the end date
         $('#{0}').data('datepicker').hide();
@@ -307,7 +305,7 @@ $('#{3}').find('.input-group-upper .input-group-addon').on('click', function () 
             writer.AddAttribute( "id", this.ClientID );
             foreach ( var styleKey in this.Style.Keys )
             {
-                string styleName = (string)styleKey;
+                string styleName = ( string ) styleKey;
                 writer.AddStyleAttribute( styleName, this.Style[styleName] );
             }
 
@@ -461,6 +459,12 @@ $('#{3}').find('.input-group-upper .input-group-addon').on('click', function () 
             }
         }
 
+        /// <summary>
+        /// Tries to parse the upper and lower DateTime from the delimited string
+        /// </summary>
+        /// <param name="delimited">The delimited value</param>
+        /// <param name="lower">The lower value</param>
+        /// <param name="upper">The upper value</param>
         public static bool TryParse( string delimited, out DateTime lower, out DateTime upper )
         {
             if ( !string.IsNullOrWhiteSpace( delimited ) && delimited.Contains( "," ) )
@@ -514,8 +518,8 @@ $('#{3}').find('.input-group-upper .input-group-addon').on('click', function () 
                     return new DateRange( dates[0].AsDateTime(), dates[1].AsDateTime() );
                 }
             }
-            
-            return new DateRange(null, null);
+
+            return new DateRange( null, null );
         }
     }
 }

--- a/Rock/Web/UI/Controls/Pickers/DateRangePicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/DateRangePicker.cs
@@ -461,6 +461,25 @@ $('#{3}').find('.input-group-upper .input-group-addon').on('click', function () 
             }
         }
 
+        public static bool TryParse( string delimited, out DateTime lower, out DateTime upper )
+        {
+            if ( !string.IsNullOrWhiteSpace( delimited ) && delimited.Contains( "," ) )
+            {
+                var dates = delimited.Split( ',' );
+
+                if ( dates.Length == 2 )
+                {
+                    var success1 = DateTime.TryParse( dates[0], out lower );
+                    var success2 = DateTime.TryParse( dates[1], out upper );
+                    return success1 && success2;
+                }
+            }
+
+            lower = new DateTime();
+            upper = new DateTime();
+            return false;
+        }
+
         /// <summary>
         /// Formats the delimited values for display purposes
         /// </summary>

--- a/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
@@ -488,17 +488,15 @@ namespace RockWeb.Blocks.Reporting
 
                             phContent.Controls.Add( div );
 
-                            if ( useDynamicFilterControls )
+                            GridFilter = new GridFilter()
                             {
-                                GridFilter = new GridFilter()
-                                {
-                                    ID = "gfFilter"
-                                };
+                                ID = "gfFilter"
+                            };
 
-                                div.Controls.Add( GridFilter );
-                                GridFilter.ApplyFilterClick += ApplyFilterClick;
-                                GridFilter.DisplayFilterValue += DisplayFilterValue;
-                            }
+                            div.Controls.Add( GridFilter );
+                            GridFilter.ApplyFilterClick += ApplyFilterClick;
+                            GridFilter.DisplayFilterValue += DisplayFilterValue;
+                            GridFilter.Visible = useDynamicFilterControls;
 
                             var grid = new Grid();
                             div.Controls.Add( grid );
@@ -786,12 +784,15 @@ namespace RockWeb.Blocks.Reporting
         /// <returns></returns>
         private void FilterTable( Grid grid, DataTable dataTable )
         {
-            if ( GridFilter == null )
+            var useDynamicFilterControls = GetAttributeValue( "UseDynamicFilterControls" ).AsBoolean();
+            System.Data.DataView dataView = dataTable.DefaultView;
+
+            if ( !useDynamicFilterControls )
             {
+                dataView.RowFilter = null;
                 return;
             }
 
-            System.Data.DataView dataView = dataTable.DefaultView;
             var query = new List<string>();
 
             foreach ( var control in GridFilter.Controls )

--- a/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
@@ -805,12 +805,12 @@ namespace RockWeb.Blocks.Reporting
 
                     if ( minValue.HasValue )
                     {
-                        query.Add( string.Format( "{0} > #{1}#", colName, minValue.Value ) );
+                        query.Add( string.Format( "{0} >= #{1}#", colName, minValue.Value ) );
                     }
 
                     if ( maxValue.HasValue )
                     {
-                        query.Add( string.Format( "{0} < #{1}#", colName, maxValue.Value.AddDays( 1 ).AddSeconds( -1 ) ) );
+                        query.Add( string.Format( "{0} < #{1}#", colName, maxValue.Value.AddDays( 1 ) ) );
                     }
                 }
                 else if ( control is RockDropDownList )

--- a/RockWeb/web.config
+++ b/RockWeb/web.config
@@ -19,7 +19,7 @@
   </resizer>
   <connectionStrings configSource="web.ConnectionStrings.config"/>
   <system.web>
-    <customErrors mode="Off" defaultRedirect="/Error.aspx" redirectMode="ResponseRewrite"/>
+    <customErrors mode="On" defaultRedirect="/Error.aspx" redirectMode="ResponseRewrite"/>
     <machineKey validationKey="09FC7CE0D57E55DCF18196743CDCDF77E86E8E522D0DDF2AB2663980F987A288B09BE034018539EAF87565AC5CB285B9C827CE0C251B8D1832627B14A7DC7697" decryptionKey="08CA6024B2BC3CA7B61165BAF1398D94212976EC00DAC895B23E4BADEE76386B" validation="SHA1" decryption="AES"/>
     <trace enabled="false"/>
     <trust level="Full"/>
@@ -69,7 +69,7 @@
     <!-- Add a custom handler for 404 errors to load Http404Error page.
             The Http404Error page will check to see if site has a configured 404 page, 
             and if so, will Then redirect to the custom page. -->
-    <httpErrors errorMode="Detailed" existingResponse="Auto">
+    <httpErrors errorMode="Custom" existingResponse="Auto">
       <remove statusCode="404" subStatusCode="-1"/>
       <remove statusCode="500" subStatusCode="-1"/>
       <error statusCode="404" path="/Http404Error.aspx" responseMode="ExecuteURL"/>

--- a/RockWeb/web.config
+++ b/RockWeb/web.config
@@ -19,7 +19,7 @@
   </resizer>
   <connectionStrings configSource="web.ConnectionStrings.config"/>
   <system.web>
-    <customErrors mode="On" defaultRedirect="/Error.aspx" redirectMode="ResponseRewrite"/>
+    <customErrors mode="Off" defaultRedirect="/Error.aspx" redirectMode="ResponseRewrite"/>
     <machineKey validationKey="09FC7CE0D57E55DCF18196743CDCDF77E86E8E522D0DDF2AB2663980F987A288B09BE034018539EAF87565AC5CB285B9C827CE0C251B8D1832627B14A7DC7697" decryptionKey="08CA6024B2BC3CA7B61165BAF1398D94212976EC00DAC895B23E4BADEE76386B" validation="SHA1" decryption="AES"/>
     <trace enabled="false"/>
     <trust level="Full"/>
@@ -69,7 +69,7 @@
     <!-- Add a custom handler for 404 errors to load Http404Error page.
             The Http404Error page will check to see if site has a configured 404 page, 
             and if so, will Then redirect to the custom page. -->
-    <httpErrors errorMode="Custom" existingResponse="Auto">
+    <httpErrors errorMode="Detailed" existingResponse="Auto">
       <remove statusCode="404" subStatusCode="-1"/>
       <remove statusCode="500" subStatusCode="-1"/>
       <error statusCode="404" path="/Http404Error.aspx" responseMode="ExecuteURL"/>


### PR DESCRIPTION
![appliedfilters](https://cloud.githubusercontent.com/assets/8700223/13365744/d9b5bdfe-dca4-11e5-9c86-46d898e9abd1.PNG)
![filtercontrols](https://cloud.githubusercontent.com/assets/8700223/13365747/db83c180-dca4-11e5-92e2-97dca85d64e5.PNG)

- Adds an option to Dynamic Data Block's options that turns filters on or off (off by default to maintain current functionality)

- When enabled, a filter is available for each column within the dynamic data.  Boolean columns are filterable with a drop down list that presents blank (no filter), yes (show only true values), or no (show only false values).  Date columns use a date range picker control.  All other columns use a text box.  String fields filter as a "begins with" filter.  All other fields filter for an exact match of the text box contents.

- Adds `DateRangePicker.TryParse` that mimics the functionality of `DateTime.TryParse` but for delimited values generated from the `DateRangePicker`

- Fixes issue where calling `GridFilter.DeleteUserPreferences` was not actually deleting preferences from the page because the key sent to `RockBlock.DeleteUserPreference` didn't include the prefix

- One issue is when the filter options are first turned on from the dynamic data block options, this error occurs.  It goes away after refreshing the page and never comes back even after a query change

![error](https://cloud.githubusercontent.com/assets/8700223/13365729/cd51857a-dca4-11e5-8138-325d70163aac.PNG)