### PR TITLE
Upgrade google analytics tracker to latest

### DIFF
--- a/RockWeb/Assets/Misc/GoogleAnalytics.txt
+++ b/RockWeb/Assets/Misc/GoogleAnalytics.txt
@@ -1,8 +1,7 @@
-﻿        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', '{0}']);
-        _gaq.push(['_trackPageview']);
-        (function () {{
-            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-        }})();
+      (function(i,s,o,g,r,a,m){{i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){{
+      (i[r].q=i[r].q||[]).push(arguments)}},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      }})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '{0}', 'auto');
+      ga('send', 'pageview');


### PR DESCRIPTION
> Universal Analytics is the new operating standard for Google Analytics; however, many sites and applications still use outdated tracking libraries to send data to Google Analytics.

> It is strongly recommended that you upgrade to use a Universal Analytics tracking library such as analytics.js or the latest mobile SDKs for Android and iOS. Non-Universal Analytics libraries, including ga.js or v1.x of the mobile SDKs, will be deprecated sometime in the near future.

— https://developers.google.com/analytics/devguides/collection/upgrade/

Also see: https://support.google.com/analytics/answer/2790010?hl=en