### PR TITLE
API Transactions by Giving Group

### DIFF
--- a/Rock.Rest/Controllers/FinancialTransactionsController.Partial.cs
+++ b/Rock.Rest/Controllers/FinancialTransactionsController.Partial.cs
@@ -317,29 +317,25 @@ namespace Rock.Rest.Controllers
         }
 
         /// <summary>
-        /// Gets the contribution transactions.
+        /// Gets transactions by people with the supplied givingId.
         /// </summary>
-        /// <param name="groupId">The group unique identifier.</param>
+        /// <param name="givingId">The giving ID.</param>
         /// <returns></returns>
         /// <exception cref="System.Web.Http.HttpResponseException"></exception>
         [Authenticate, Secured]
         [HttpGet]
         [EnableQuery]
-        [System.Web.Http.Route( "api/FinancialTransactions/GetTransactionsForGivingGroup/{personId}" )]
-        public IQueryable<FinancialTransaction> GetTransactionsForGivingGroup( int personId )
+        [System.Web.Http.Route( "api/FinancialTransactions/GetByGivingId/{givingId}" )]
+        public IQueryable<FinancialTransaction> GetByGivingId( string givingId )
         {
-            var rockContext = new RockContext();
-            var personService = new PersonService( rockContext );
-            var person = personService.Get( personId );
-
-            if ( person == null )
+            if ( string.IsNullOrWhiteSpace( givingId ) || !( givingId.StartsWith( "P" ) || givingId.StartsWith( "G" ) ) )
             {
                 var response = new HttpResponseMessage( HttpStatusCode.BadRequest );
-                response.Content = new StringContent( "Person was not found" );
+                response.Content = new StringContent( "The supplied givingId is not valid" );
                 throw new HttpResponseException( response );
             }
 
-            return Get().Where( t => t.AuthorizedPersonAlias.Person.GivingId == person.GivingId );
+            return Get().Where( t => t.AuthorizedPersonAlias.Person.GivingId == givingId );
         }
 
         /// <summary>

--- a/Rock/Model/FinancialTransaction.cs
+++ b/Rock/Model/FinancialTransaction.cs
@@ -224,6 +224,7 @@ namespace Rock.Model
         /// <value>
         /// The authorized person alias.
         /// </value>
+        [DataMember]
         public virtual PersonAlias AuthorizedPersonAlias { get; set; }
 
         /// <summary>


### PR DESCRIPTION
- Add endpoint to get a person's giving group's transactions.  This mimics the TransactionList block functionality with a person context (https://github.com/SparkDevNetwork/Rock/blob/develop/RockWeb/Blocks/Finance/TransactionList.ascx.cs#L906)
- Add `DataMember` to AuthorizedPersonAlias to allow `$expand` ODATA operation