### PR TITLE
Add a test username endpoint by query string

### DIFF
--- a/Rock.Rest/Controllers/UserLoginsController.Partial.cs
+++ b/Rock.Rest/Controllers/UserLoginsController.Partial.cs
@@ -42,6 +42,18 @@ namespace Rock.Rest.Controllers
         }
 
         /// <summary>
+        /// Tests if a username is available
+        /// </summary>
+        /// <param name="username"></param>
+        /// <returns></returns>
+        [HttpGet]
+        [System.Web.Http.Route( "api/userlogins/available" )]
+        public bool AvailableByQueryString( string username )
+        {
+            return Available( username );
+        }
+
+        /// <summary>
         /// Posts the specified value.
         /// POST using <see cref="Rock.Model.UserLoginWithPlainTextPassword"/> and set PlainTextPassword to set a password.
         /// </summary>


### PR DESCRIPTION
We were running into issues with checking the availability of a username that had a `.pl` in it.  We think this was because it looks like a file extension.  For example `phil.plex` would cause the API call to fail.  This endpoint seems to fix the issue by passing the username as a query string.