### PR TITLE
Added ability to group event occurrences in the calendar by event

### DIFF
--- a/RockWeb/Blocks/Event/CalendarLava.ascx.cs
+++ b/RockWeb/Blocks/Event/CalendarLava.ascx.cs
@@ -385,11 +385,18 @@ namespace RockWeb.Blocks.Event
                             Location = eventItemOccurrence.Campus != null ? eventItemOccurrence.Campus.Name : "All Campuses",
                             Description = eventItemOccurrence.EventItem.Description,
                             Summary = eventItemOccurrence.EventItem.Summary,
+                            OccurrenceNote = eventItemOccurrence.Note.SanitizeHtml(),
                             DetailPage = String.IsNullOrWhiteSpace( eventItemOccurrence.EventItem.DetailsUrl ) ? null : eventItemOccurrence.EventItem.DetailsUrl
                         } );
                     }
                 }
             }
+
+            var eventSummaries = eventOccurrenceSummaries
+                .OrderBy( e => e.DateTime )
+                .GroupBy( e => e.Name )
+                .Select( e => e.ToList() )
+                .ToList();
 
             eventOccurrenceSummaries = eventOccurrenceSummaries
                 .OrderBy( e => e.DateTime )
@@ -399,6 +406,7 @@ namespace RockWeb.Blocks.Event
             var mergeFields = new Dictionary<string, object>();
             mergeFields.Add( "TimeFrame", ViewMode );
             mergeFields.Add( "DetailsPage", LinkedPageUrl( "DetailsPage", null ) );
+            mergeFields.Add( "EventItems", eventSummaries );
             mergeFields.Add( "EventItemOccurrences", eventOccurrenceSummaries );
             mergeFields.Add( "CurrentPerson", CurrentPerson );
 
@@ -573,7 +581,7 @@ namespace RockWeb.Blocks.Event
         /// <summary>
         /// A class to store event item occurrence data for liquid
         /// </summary>
-        [DotLiquid.LiquidType( "EventItemOccurrence", "DateTime", "Name", "Date", "Time", "Location", "Description", "Summary", "DetailPage" )]
+        [DotLiquid.LiquidType( "EventItemOccurrence", "DateTime", "Name", "Date", "Time", "Location", "Description", "Summary", "OccurrenceNote", "DetailPage" )]
         public class EventOccurrenceSummary
         {
             public EventItemOccurrence EventItemOccurrence { get; set; }
@@ -584,6 +592,7 @@ namespace RockWeb.Blocks.Event
             public String Location { get; set; }
             public String Summary { get; set; }
             public String Description { get; set; }
+            public String OccurrenceNote { get; set; }
             public String DetailPage { get; set; }
         }
 

--- a/RockWeb/Themes/Flat/Assets/Lava/CalendarGroupedOccurrence.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/CalendarGroupedOccurrence.lava
@@ -1,0 +1,76 @@
+  {% assign eventItemCount = EventItems | Size %}
+
+  {% if eventItemCount == 0 %}
+  <div class="panel panel-default margin-t-md">
+    <div class="margin-all-md"> There are no events in this time frame.</div>
+  </div>
+  {% endif %}
+
+  {% for eventItem in EventItems %}
+  {% assign firstOccurrence = eventItem | First %}
+  <div class="panel panel-default margin-t-md">
+    <div class="panel-heading clearfix">
+		<h2 class="panel-title pull-left">
+			{{ firstOccurrence.Name }}
+		</h2>
+		<br/>
+		{{firstOccurrence.Summary}}
+    </div>
+    <div class="panel-body">
+		<div class="row">
+			<div class="col-md-2">
+				<b>Date</b>
+			</div>
+			<div class="col-md-2">       
+				<b>Time</b>
+			</div>
+			<div class="col-md-2">
+				 <b>Location</b>
+			</div>
+			<div class="col-md-4">
+			  <b>Summary</b>
+			</div>
+		</div>
+		{% for eventItemOccurrence in eventItem %}
+		<div class="row">
+			<div class="col-md-2">
+				{% if eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveStartDate != eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveEndDate %}
+					{{ eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveStartDate  | Date: 'MMM d' }} -  {{ eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveEndDate  | Date: 'MMM d'}}
+				{% else %}
+					{{ eventItemOccurrence.Date | Date: 'MMM d'}}
+				{% endif %}
+			</div>
+			<div class="col-md-2">       
+				{{ eventItemOccurrence.Time}}
+			</div>
+			<div class="col-md-2">
+				 {{ eventItemOccurrence.Location}}
+			</div>
+			<div class="col-md-4">
+			  {{eventItemOccurrence.OccurrenceNote}}
+			</div>
+			<div class="col-md-2">
+				{% if eventItemOccurrence.DetailPage != null %}
+				<a href="{{ firstOccurrence.DetailPage }}">
+				  <i> View <i class="fa fa-chevron-right"></i> </i>
+				</a>
+				{% else %}
+				<a href="{{ DetailsPage }}?EventOccurrenceId={{ eventItemOccurrence.EventItemOccurrence.Id }}">
+					View <i class="fa fa-chevron-right"></i>
+				</a>
+				{% endif %}
+			</div>
+		</div>
+		<br/>
+		{% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+
+<script type="text/javascript">
+
+  $( document ).ready(function() {
+  $('.js-group-item').tooltip();
+  });
+
+</script>

--- a/RockWeb/Themes/Rock/Assets/Lava/CalendarGroupedOccurrence.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/CalendarGroupedOccurrence.lava
@@ -1,0 +1,76 @@
+  {% assign eventItemCount = EventItems | Size %}
+
+  {% if eventItemCount == 0 %}
+  <div class="panel panel-default margin-t-md">
+    <div class="margin-all-md"> There are no events in this time frame.</div>
+  </div>
+  {% endif %}
+
+  {% for eventItem in EventItems %}
+  {% assign firstOccurrence = eventItem | First %}
+  <div class="panel panel-default margin-t-md">
+    <div class="panel-heading clearfix">
+		<h2 class="panel-title pull-left">
+			{{ firstOccurrence.Name }}
+		</h2>
+		<br/>
+		{{firstOccurrence.Summary}}
+    </div>
+    <div class="panel-body">
+		<div class="row">
+			<div class="col-md-2">
+				<b>Date</b>
+			</div>
+			<div class="col-md-2">       
+				<b>Time</b>
+			</div>
+			<div class="col-md-2">
+				 <b>Location</b>
+			</div>
+			<div class="col-md-4">
+			  <b>Summary</b>
+			</div>
+		</div>
+		{% for eventItemOccurrence in eventItem %}
+		<div class="row">
+			<div class="col-md-2">
+				{% if eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveStartDate != eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveEndDate %}
+					{{ eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveStartDate  | Date: 'MMM d' }} -  {{ eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveEndDate  | Date: 'MMM d'}}
+				{% else %}
+					{{ eventItemOccurrence.Date | Date: 'MMM d'}}
+				{% endif %}
+			</div>
+			<div class="col-md-2">       
+				{{ eventItemOccurrence.Time}}
+			</div>
+			<div class="col-md-2">
+				 {{ eventItemOccurrence.Location}}
+			</div>
+			<div class="col-md-4">
+			  {{eventItemOccurrence.OccurrenceNote}}
+			</div>
+			<div class="col-md-2">
+				{% if eventItemOccurrence.DetailPage != null %}
+				<a href="{{ firstOccurrence.DetailPage }}">
+				  <i> View <i class="fa fa-chevron-right"></i> </i>
+				</a>
+				{% else %}
+				<a href="{{ DetailsPage }}?EventOccurrenceId={{ eventItemOccurrence.EventItemOccurrence.Id }}">
+					View <i class="fa fa-chevron-right"></i>
+				</a>
+				{% endif %}
+			</div>
+		</div>
+		<br/>
+		{% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+
+<script type="text/javascript">
+
+  $( document ).ready(function() {
+  $('.js-group-item').tooltip();
+  });
+
+</script>

--- a/RockWeb/Themes/Stark/Assets/Lava/CalendarGroupedOccurrence.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/CalendarGroupedOccurrence.lava
@@ -1,0 +1,76 @@
+  {% assign eventItemCount = EventItems | Size %}
+
+  {% if eventItemCount == 0 %}
+  <div class="panel panel-default margin-t-md">
+    <div class="margin-all-md"> There are no events in this time frame.</div>
+  </div>
+  {% endif %}
+
+  {% for eventItem in EventItems %}
+  {% assign firstOccurrence = eventItem | First %}
+  <div class="panel panel-default margin-t-md">
+    <div class="panel-heading clearfix">
+		<h2 class="panel-title pull-left">
+			{{ firstOccurrence.Name }}
+		</h2>
+		<br/>
+		{{firstOccurrence.Summary}}
+    </div>
+    <div class="panel-body">
+		<div class="row">
+			<div class="col-md-2">
+				<b>Date</b>
+			</div>
+			<div class="col-md-2">       
+				<b>Time</b>
+			</div>
+			<div class="col-md-2">
+				 <b>Location</b>
+			</div>
+			<div class="col-md-4">
+			  <b>Summary</b>
+			</div>
+		</div>
+		{% for eventItemOccurrence in eventItem %}
+		<div class="row">
+			<div class="col-md-2">
+				{% if eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveStartDate != eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveEndDate %}
+					{{ eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveStartDate  | Date: 'MMM d' }} -  {{ eventItemOccurrence.EventItemOccurrence.Schedule.EffectiveEndDate  | Date: 'MMM d'}}
+				{% else %}
+					{{ eventItemOccurrence.Date | Date: 'MMM d'}}
+				{% endif %}
+			</div>
+			<div class="col-md-2">       
+				{{ eventItemOccurrence.Time}}
+			</div>
+			<div class="col-md-2">
+				 {{ eventItemOccurrence.Location}}
+			</div>
+			<div class="col-md-4">
+			  {{eventItemOccurrence.OccurrenceNote}}
+			</div>
+			<div class="col-md-2">
+				{% if eventItemOccurrence.DetailPage != null %}
+				<a href="{{ firstOccurrence.DetailPage }}">
+				  <i> View <i class="fa fa-chevron-right"></i> </i>
+				</a>
+				{% else %}
+				<a href="{{ DetailsPage }}?EventOccurrenceId={{ eventItemOccurrence.EventItemOccurrence.Id }}">
+					View <i class="fa fa-chevron-right"></i>
+				</a>
+				{% endif %}
+			</div>
+		</div>
+		<br/>
+		{% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+
+<script type="text/javascript">
+
+  $( document ).ready(function() {
+  $('.js-group-item').tooltip();
+  });
+
+</script>


### PR DESCRIPTION
We've run into an issue at our church where events with 4-8 occurrences in the same month would clutter the calendar page. This problem could be fixed by grouping occurrences together under the events that they're tied to. The code below implements this. It adds a new 'EventItems' lava object that contains arrays of occurrences, grouped by their EventItems. Users can use either the existing EventItemOccurrences object in their lava files to keep the existing behaviour, or use the new EventItems object along with the new CalendarGroupedOccurrence.lava file to group occurrences together. 

Additionally, it exposes the occurrences' notes to Lava.

Below are screenshots of the same occurrences using the existing lava file and the new lava file.

**Using existing Calendar.lava**
![image](https://cloud.githubusercontent.com/assets/5482014/13998960/1646ffa6-f0f7-11e5-9f44-c3856e62c6ab.png)

**Using new CalendarGroupedOccurrence.lava**
![image](https://cloud.githubusercontent.com/assets/5482014/13998986/3c70df62-f0f7-11e5-8b2b-60ff9947a1e9.png)