### PR TITLE
Fixes #1427 - Liquid Dashboard Widget summing all LastValue Metrics

### DIFF
--- a/Rock.Rest/Controllers/MetricsController.partial.cs
+++ b/Rock.Rest/Controllers/MetricsController.partial.cs
@@ -94,8 +94,9 @@ namespace Rock.Rest.Controllers
                     var lastMetricValue = qryMeasureValues.OrderByDescending( a => a.MetricValueDateTime ).FirstOrDefault();
                     if ( lastMetricValue != null )
                     {
-                        metricYTDData.LastValue = lastMetricValue.YValue.HasValue ? Math.Round( lastMetricValue.YValue.Value, roundYValues ? 0 : 2 ) : (decimal?)null;
                         metricYTDData.LastValueDate = lastMetricValue.MetricValueDateTime.HasValue ? lastMetricValue.MetricValueDateTime.Value.Date : DateTime.MinValue;
+                        var lastMetricCumulativeValues = qryMeasureValues.Where(a => a.MetricValueDateTime == metricYTDData.LastValueDate);
+                        metricYTDData.LastValue = lastMetricCumulativeValues.Sum(a => a.YValue).HasValue ? Math.Round(lastMetricCumulativeValues.Sum(a => a.YValue).Value, roundYValues ? 0 : 2) : (decimal?)null;
                     }
 
                     decimal? sum = qryMeasureValues.Sum( a => a.YValue );


### PR DESCRIPTION
Updating the LastValue merge variable for the LiquidDashboardWidget to sum all metric values entered for the last value date.