### PR TITLE
Make campuses not required for EventItemListLava

### DIFF
--- a/RockWeb/Blocks/Event/EventItemListLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemListLava.ascx.cs
@@ -40,7 +40,7 @@ namespace RockWeb.Blocks.Event
     [Description( "Renders calendar items using Lava." )]
 
     [EventCalendarField( "Event Calendar", "The event calendar to be displayed", true, "1", order: 0 )]
-    [CampusesField( "Campuses", "List of which campuses to show occurrences for. This setting will be ignored in the 'Use Campus Context' is enabled.", order: 1 )]
+    [CampusesField( "Campuses", "List of which campuses to show occurrences for. This setting will be ignored in the 'Use Campus Context' is enabled.", required: false, order: 1 )]
     [BooleanField( "Use Campus Context", "Determine if the campus should be read from the campus context of the page.", order: 2 )]
     [LinkedPage( "Details Page", "Detail page for events", order: 3 )]
     [SlidingDateRangeField( "Date Range", "Optional date range to filter the items on. (defaults to next 1000 days)", false, order: 4 )]


### PR DESCRIPTION
2 reasons:
- When using campus context, this field is not necessary.
- When left blank, events for all campuses will show up, even after adding
  a new campus. To do that currently, you would need to add the new campus
  to the selection after adding a campus to Rock.