### PR TITLE
[EN] Better Ages on the Person Profile for Newborns and Infants

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -1010,6 +1010,30 @@ namespace Rock.Model
         }
 
         /// <summary>
+        /// Returns a formatted age in years, months, or days.
+        /// </summary>
+        /// <returns></returns>
+        public string FormatAge()
+        {
+            if (Age > 0)
+            {
+                return Age + (Age == 1 ? " yr old " : " yrs old ");
+            }
+            var today = RockDateTime.Today;
+            if (BirthMonth != null && BirthMonth < today.Month)
+            {
+                int months = today.Month - BirthMonth.Value;
+                return months + (months == 1 ? " mnth old " : " mnths old ");
+            }
+            if (BirthDay != null)
+            {
+                int days = today.Day - BirthDay.Value;
+                return days + (days == 1 ? " day old " : " days old ");
+            }
+            return string.Empty;
+        }
+
+        /// <summary>
         /// Gets the next birth day.
         /// </summary>
         /// <value>

--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -1009,21 +1009,28 @@ namespace Rock.Model
             return null;
         }
 
+
         /// <summary>
-        /// Returns a formatted age in years, months, or days.
+        /// Formats the age with unit (year, month, day) suffix depending on the age of the individual. 
         /// </summary>
+        /// <param name="condensed">if set to <c>true</c> age in years is returned without a unit suffix.</param>
         /// <returns></returns>
-        public string FormatAge()
+        public string FormatAge( bool condensed = false)
         {
-            if (Age > 0)
+            var age = Age;
+            if (age != null && age > 0 )
             {
-                return Age + (Age == 1 ? " yr old " : " yrs old ");
+                if (condensed)
+                {
+                    return age.ToString();
+                }
+                return age  + (age == 1 ? " yr old " : " yrs old ");
             }
             var today = RockDateTime.Today;
             if (BirthMonth != null && BirthMonth < today.Month)
             {
                 int months = today.Month - BirthMonth.Value;
-                return months + (months == 1 ? " mnth old " : " mnths old ");
+                return months + (months == 1 ? " mo old " : " mos old ");
             }
             if (BirthDay != null)
             {

--- a/RockWeb/Blocks/Crm/PersonDetail/Bio.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/Bio.ascx.cs
@@ -160,16 +160,7 @@ Because the contents of this setting will be rendered inside a &lt;ul&gt; elemen
 
                     if ( Person.BirthDate.HasValue )
                     {
-                        string ageText = ( Person.BirthYear.HasValue && Person.BirthYear != DateTime.MinValue.Year ) ?
-                            string.Format( "{0} yrs old ", Person.BirthDate.Value.Age() ) : string.Empty;
-                        if (Person.BirthDate.Value.Year != DateTime.MinValue.Year)
-                        {
-                            lAge.Text = string.Format("{0}<small>({1})</small><br/>", ageText, Person.BirthDate.Value.ToShortDateString());
-                        } else
-                        {
-                            lAge.Text = string.Format("{0}<small>({1})</small><br/>", ageText, Person.BirthDate.Value.ToMonthDayString());
-                        }
-                        
+                        lAge.Text = string.Format("{0}<small>({1})</small><br/>", Person.FormatAge(), Person.BirthYear != DateTime.MinValue.Year ? Person.BirthDate.Value.ToShortDateString() : Person.BirthDate.Value.ToMonthDayString());
                     }
 
                     lGender.Text = Person.Gender.ToString();

--- a/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
@@ -407,7 +407,7 @@ namespace RockWeb.Blocks.Crm.PersonDetail
             if ( gm != null )
             {
                 return _IsFamilyGroupType ?
-                    ( gm.Person.Age.HasValue ? gm.Person.Age.Value.ToString( "N0" ) : "" ) :
+                    ( gm.Person.FormatAge() ) :
                     gm.GroupRole.Name;
             }
             return string.Empty;

--- a/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
@@ -407,7 +407,7 @@ namespace RockWeb.Blocks.Crm.PersonDetail
             if ( gm != null )
             {
                 return _IsFamilyGroupType ?
-                    ( gm.Person.FormatAge() ) :
+                    ( gm.Person.FormatAge(true) ) :
                     gm.GroupRole.Name;
             }
             return string.Empty;


### PR DESCRIPTION
The current ages for any child under the age of 1 just appear as 0 which doesn't provide meaningful information. If a family visitor wanted to know the age of the child they'd have to do the maths themselves. This pull request adds a new method to the Person model for getting a string with a formatted age.

E.G. 12 yrs old, 6 mnths old, 14 days old

Comparison images below.

![withoutdateformatchange](https://cloud.githubusercontent.com/assets/8703222/14162649/c57f6d02-f6e5-11e5-805f-307eb3e181e8.png)
![withdateformatchange](https://cloud.githubusercontent.com/assets/8703222/14162707/6269e55c-f6e6-11e5-8912-e4fc9a0a86f8.png)