### PR TITLE
[EN] Remove hardcoded attribute keys from Filter Groups By Age and fix edge case

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -545,6 +545,7 @@
     <Compile Include="Transactions\SendPaymentReciepts.cs" />
     <Compile Include="Transactions\UpdatePaymentStatusTransaction.cs" />
     <Compile Include="Utility\DebugHelper.cs" />
+    <Compile Include="Utility\ExtensionMethods\DecimalExtensions.cs" />
     <Compile Include="Utility\ExtensionMethods\StringHumanizerExtensions.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\NotNullJsonConverter.cs" />

--- a/Rock/Utility/ExtensionMethods/DecimalExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/DecimalExtensions.cs
@@ -1,0 +1,55 @@
+﻿// <copyright>
+// Copyright 2013 by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+
+namespace Rock
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public static partial class ExtensionMethods
+    {
+        /// <summary>
+        /// Returns the number of digits following the decimal place. 5.68 would return 2. 17.9998 would return 4.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public static int GetDecimalPrecision( this decimal value )
+        {
+            return BitConverter.GetBytes( decimal.GetBits( value )[3] )[2];
+        }
+
+        /// <summary>
+        /// Returns the floor (round down) value with the given decimal precision
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public static decimal? Floor( this decimal? value, int precision = 0 )
+        {
+            if ( !value.HasValue )
+            {
+                return null;
+            }
+
+            var shiftFactor = Convert.ToDecimal( Math.Pow( 10, precision ) );
+            var shiftedValue = value.Value * shiftFactor;
+            var shiftedFloor = Math.Floor( shiftedValue );
+            var unshiftedFloor = shiftedFloor / shiftFactor;
+            return unshiftedFloor;
+        }
+    }
+}

--- a/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
@@ -29,12 +29,13 @@ namespace Rock.Workflow.Action.CheckIn
     /// <summary>
     /// Removes (or excludes) the groups for each selected family member that are not specific to their age.
     /// </summary>
+    [ActionCategory( "Check-In" )]
     [Description( "Removes (or excludes) the groups for each selected family member that are not specific to their age." )]
     [Export( typeof( ActionComponent ) )]
     [ExportMetadata( "ComponentName", "Filter Groups By Age" )]
     [BooleanField( "Remove", "Select 'Yes' if groups should be be removed.  Select 'No' if they should just be marked as excluded.", true, "", 0 )]
     [BooleanField( "Age Required", "Select 'Yes' if groups with an age filter should be removed/excluded when person does not have an age.", true, "", 1 )]
-    [AttributeField( "9BBFDA11-0D22-40D5-902F-60ADFBC88987", "Group Age Range Attribute", "Select the attribute used to define the age range of the group", true, false, "43511B8F-71D9-423A-85BF-D1CD08C1998E", order: 2 )]
+    [AttributeField( Rock.SystemGuid.EntityType.GROUP, "Group Age Range Attribute", "Select the attribute used to define the age range of the group", true, false, "43511B8F-71D9-423A-85BF-D1CD08C1998E", order: 2 )]
     public class FilterGroupsByAge : CheckInActionComponent
     {
         /// <summary>


### PR DESCRIPTION
This removes the dependency that "AgeRange" will always be the key for a group age range attribute.

Also fixes an edge case related to #1385 by adding a Decimal GetPrecision extension. The issue is for an age of 5.97, which MidpointRounding causes to round up to the nearest even number (6).