### PR TITLE
Update the default date range for Group Attendance to 3 months instead of a year

### DIFF
--- a/RockWeb/Blocks/Groups/GroupAttendanceList.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupAttendanceList.ascx.cs
@@ -356,15 +356,15 @@ namespace RockWeb.Blocks.Groups
             string dateRangePreference = rFilter.GetUserPreference( MakeKeyUniqueToGroup( "Date Range" ) );
             if ( string.IsNullOrWhiteSpace( dateRangePreference ) )
             {
-                // set the dateRangePreference to force rFilter_DisplayFilterValue to show our default one year limit
+                // set the dateRangePreference to force rFilter_DisplayFilterValue to show our default three month limit
                 dateRangePreference = ",";
                 rFilter.SaveUserPreference( MakeKeyUniqueToGroup( "Date Range" ), "Date Range", dateRangePreference );
             }
 
             var dateRange = DateRangePicker.CalculateDateRangeFromDelimitedValues( dateRangePreference );
 
-            // if there is no start date, default to a year ago to minimize the chance of loading too much data
-            drpDates.LowerValue = dateRange.Start ?? RockDateTime.Today.AddYears( -1 );
+            // if there is no start date, default to three months ago to minimize the chance of loading too much data
+            drpDates.LowerValue = dateRange.Start ?? RockDateTime.Today.AddMonths( -3 );
             drpDates.UpperValue = dateRange.End;
 
             if ( _group != null )

--- a/RockWeb/Blocks/Groups/GroupAttendanceList.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupAttendanceList.ascx.cs
@@ -20,22 +20,20 @@ using System.ComponentModel;
 using System.Data.Entity;
 using System.Linq;
 using System.Web.UI.WebControls;
-
 using Rock;
 using Rock.Attribute;
 using Rock.Data;
 using Rock.Model;
 using Rock.Security;
+using Rock.Web.Cache;
 using Rock.Web.UI;
 using Rock.Web.UI.Controls;
-using Rock.Web.Cache;
 
 namespace RockWeb.Blocks.Groups
 {
     [DisplayName( "Group Attendance List" )]
     [Category( "Groups" )]
     [Description( "Lists all the scheduled occurrences for a given group." )]
-
     [LinkedPage( "Detail Page", "", true, "", "", 0 )]
     [BooleanField( "Allow Add", "Should block support adding new attendance dates outside of the group's configured schedule and group type's exclusion dates?", true, "", 1 )]
     [BooleanField( "Allow Campus Filter", "Should block add an option to allow filtering attendance counts and percentage by campus?", false, "", 2 )]
@@ -86,13 +84,12 @@ namespace RockWeb.Blocks.Groups
 
             _allowCampusFilter = GetAttributeValue( "AllowCampusFilter" ).AsBoolean();
             bddlCampus.Visible = _allowCampusFilter;
-            if (_allowCampusFilter )
+            if ( _allowCampusFilter )
             {
                 bddlCampus.DataSource = CampusCache.All();
                 bddlCampus.DataBind();
                 bddlCampus.Items.Insert( 0, new ListItem( "All Campuses", "0" ) );
             }
-
         }
 
         /// <summary>
@@ -205,7 +202,12 @@ namespace RockWeb.Blocks.Groups
             }
         }
 
-        void gOccurrences_RowDataBound( object sender, GridViewRowEventArgs e )
+        /// <summary>
+        /// Handles the RowDataBound event of the gOccurrences control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
+        protected void gOccurrences_RowDataBound( object sender, GridViewRowEventArgs e )
         {
             if ( e.Row.RowType == System.Web.UI.WebControls.DataControlRowType.DataRow )
             {
@@ -232,7 +234,7 @@ namespace RockWeb.Blocks.Groups
         {
             // The iCalendar date format is returned as UTC kind date, so we need to manually format it instead of using 'o'
             string occurrenceDate = ( (DateTime)e.RowKeyValues["Date"] ).ToString( "yyyy-MM-ddTHH:mm:ss" );
-            var qryParams = new Dictionary<string, string> { 
+            var qryParams = new Dictionary<string, string> {
                 { "GroupId", _group.Id.ToString() },
                 { "Date", occurrenceDate },
             };
@@ -260,8 +262,8 @@ namespace RockWeb.Blocks.Groups
         /// <exception cref="System.NotImplementedException"></exception>
         protected void gOccurrences_Add( object sender, EventArgs e )
         {
-            var qryParams = new Dictionary<string, string> { 
-                { "GroupId", _group.Id.ToString() } 
+            var qryParams = new Dictionary<string, string> {
+                { "GroupId", _group.Id.ToString() }
             };
 
             if ( ddlSchedule.Visible && ddlSchedule.SelectedValue != "0" )
@@ -280,7 +282,6 @@ namespace RockWeb.Blocks.Groups
 
             NavigateToLinkedPage( "DetailPage", qryParams );
         }
-
 
         /// <summary>
         /// Handles the Delete event of the gOccurrences control.
@@ -303,11 +304,11 @@ namespace RockWeb.Blocks.Groups
                             a.GroupId == _group.Id &&
                             a.StartDateTime >= startDate &&
                             a.StartDateTime < endDate );
-                    
+
                     int? scheduleId = e.RowKeyValues["ScheduleId"] as int?;
                     if ( scheduleId.HasValue )
                     {
-                        qry = qry.Where( a => 
+                        qry = qry.Where( a =>
                             a.ScheduleId.HasValue &&
                             a.ScheduleId.Value == scheduleId.Value );
                     }
@@ -315,12 +316,12 @@ namespace RockWeb.Blocks.Groups
                     int? locationId = e.RowKeyValues["LocationId"] as int?;
                     if ( locationId.HasValue )
                     {
-                        qry = qry.Where( a => 
+                        qry = qry.Where( a =>
                             a.LocationId.HasValue &&
                             a.LocationId.Value == locationId.Value );
                     }
 
-                    foreach( var attendance in qry )
+                    foreach ( var attendance in qry )
                     {
                         attendanceService.Delete( attendance );
                     }
@@ -331,7 +332,7 @@ namespace RockWeb.Blocks.Groups
 
             BindGrid();
         }
-        
+
         /// <summary>
         /// Handles the GridRebind event of the gOccurrences control.
         /// </summary>
@@ -350,7 +351,7 @@ namespace RockWeb.Blocks.Groups
         /// <summary>
         /// Binds the filter.
         /// </summary>
-        private void BindFilter()
+        protected void BindFilter()
         {
             string dateRangePreference = rFilter.GetUserPreference( MakeKeyUniqueToGroup( "Date Range" ) );
             if ( string.IsNullOrWhiteSpace( dateRangePreference ) )
@@ -512,6 +513,5 @@ namespace RockWeb.Blocks.Groups
         }
 
         #endregion
-
-}
+    }
 }


### PR DESCRIPTION
This change optimizes performance on the Group Attendance list.  With the default range of a year, one of our larger groups has to calculate 971 attendances.  With this change, only 32 attendances are calculated.

Users can still update the date range filter to a longer/shorter period of time if needed, and that change will be saved to their preferences.