### PR TITLE
Attempting to save invalid html in the HtmlContentDetail block now displays a warning message detailing the errors.

### DIFF
--- a/RockWeb/Blocks/Cms/HtmlContentDetail.ascx
+++ b/RockWeb/Blocks/Cms/HtmlContentDetail.ascx
@@ -15,6 +15,7 @@
                         <ContentTemplate>
                             <asp:HiddenField ID="hfVersion" runat="server" />
                             <asp:Panel ID="pnlEdit" runat="server" Visible="false">
+                                <Rock:NotificationBox ID="nbInvalidHtml" runat="server" NotificationBoxType="Warning" Visible="false" />
 
                                 <!-- Approval -->
                                 <asp:UpdatePanel ID="upnlApproval" runat="server">

--- a/RockWeb/Blocks/Cms/HtmlContentDetail.ascx.cs
+++ b/RockWeb/Blocks/Cms/HtmlContentDetail.ascx.cs
@@ -30,6 +30,7 @@ using System.ComponentModel;
 using Rock.Data;
 using Rock.Web.Cache;
 using System.Text;
+using HtmlAgilityPack;
 
 namespace RockWeb.Blocks.Cms
 {
@@ -156,6 +157,27 @@ namespace RockWeb.Blocks.Cms
 
             // get the content depending on which mode we are in (codeeditor or ckeditor)
             string newContent = ceHtml.Visible ? ceHtml.Text : htmlEditor.Text;
+
+            // check if the new content is valid
+            // NOTE: This is a limited check that will only warn of invalid HTML the first 
+            // time a user clicks the save button. Any errors encountered on the second runthrough
+            // are assumed to be intentional.
+            HtmlDocument doc = new HtmlDocument();
+            doc.LoadHtml( newContent );
+            if ( doc.ParseErrors.Count() > 0 && !nbInvalidHtml.Visible )
+            {
+                var reasons = doc.ParseErrors.Select( r => r.Reason ).ToList();
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine( "Warning: The HTML has the following errors:<ul>" );
+                foreach ( var reason in reasons )
+                {
+                    sb.AppendLine( String.Format( "<li>{0}</li>", reason.EncodeHtml() ) );
+                }
+                sb.AppendLine( "</ul> <br/> If you wish to save anyway, click the save button again." );
+                nbInvalidHtml.Text = sb.ToString();
+                nbInvalidHtml.Visible = true;
+                return;
+            }
 
             //// create a new record only in the following situations:
             ////   - this is the first time this htmlcontent block got content (new block and edited for the first time)


### PR DESCRIPTION
The first time a user clicks the 'Save' button a warning box will appear listing any HTML errors should there be any. The warning box will prompt the user to click the 'Save' button again should the errors be intentional, after which the new content will be saved.

![image](https://cloud.githubusercontent.com/assets/5482014/14261098/f9b3fcba-fa63-11e5-89bd-6d0720475c28.png)