### PR TITLE
- Added security to the SearchField control to limit the SearchComponents people can view.

### DIFF
--- a/Rock/Web/UI/Controls/SearchField.cs
+++ b/Rock/Web/UI/Controls/SearchField.cs
@@ -24,7 +24,6 @@ using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
 
 using Rock;
-using Rock.Model;
 using Rock.Security;
 
 namespace Rock.Web.UI.Controls
@@ -64,19 +63,16 @@ namespace Rock.Web.UI.Controls
             var rockPage = this.Page as RockPage;
             if ( rockPage != null )
             {
-                var currentPerson = rockPage.CurrentPerson;
-                if ( currentPerson != null )
+                foreach ( KeyValuePair<int, Lazy<Rock.Search.SearchComponent, Rock.Extension.IComponentData>> service in Rock.Search.SearchContainer.Instance.Components )
                 {
-                    foreach ( KeyValuePair<int, Lazy<Rock.Search.SearchComponent, Rock.Extension.IComponentData>> service in Rock.Search.SearchContainer.Instance.Components )
+                    var searchComponent = service.Value.Value;
+                    if ( searchComponent.IsAuthorized( Authorization.VIEW, rockPage.CurrentPerson ) )
                     {
-                        if ( service.Value.Value.IsAuthorized( Authorization.VIEW, currentPerson ) )
+                        if ( !searchComponent.AttributeValues.ContainsKey( "Active" ) || bool.Parse( searchComponent.AttributeValues["Active"].Value ) )
                         {
-                            if ( !service.Value.Value.AttributeValues.ContainsKey( "Active" ) || bool.Parse( service.Value.Value.AttributeValues["Active"].Value ) )
-                            {
-                                searchExtensions.Add( service.Key.ToString(), Tuple.Create<string, string>( service.Value.Value.SearchLabel, service.Value.Value.ResultUrl ) );
-                                if ( string.IsNullOrWhiteSpace( hfFilter.Value ) )
-                                    hfFilter.Value = service.Key.ToString();
-                            }
+                            searchExtensions.Add( service.Key.ToString(), Tuple.Create<string, string>( searchComponent.SearchLabel, searchComponent.ResultUrl ) );
+                            if ( string.IsNullOrWhiteSpace( hfFilter.Value ) )
+                                hfFilter.Value = service.Key.ToString();
                         }
                     }
                 }


### PR DESCRIPTION
Currently, even though an administrator can limit security on a SearchComponent, anyone is able to view and search by it. This code change uses the SearchComponents' security settings to dictate who can actually view them, while adding .12 milliseconds to the page's load time. Below are two examples of users with the SearchComponents they can search by:

Admin Admin, a user with view access to the BusinessName SearchComponent:
![image](https://cloud.githubusercontent.com/assets/5482014/14266134/efc8bab2-fa7a-11e5-9e7f-a7acd629040c.png)

Ted Decker, a user without view access to the BusinessName SearchComponent:
![image](https://cloud.githubusercontent.com/assets/5482014/14266153/180a1a16-fa7b-11e5-9ee8-669b876fa8d8.png)