### PR TITLE
Adjust the FileSystem provider to return a path outside of IIS contexts

### DIFF
--- a/Rock/Storage/Provider/FileSystem.cs
+++ b/Rock/Storage/Provider/FileSystem.cs
@@ -61,7 +61,6 @@ namespace Rock.Storage.Provider
                     }
                 }
             }
-
         }
 
         /// <summary>
@@ -119,7 +118,9 @@ namespace Rock.Storage.Provider
             {
                 return string.Empty;
             }
-            return System.Web.Hosting.HostingEnvironment.MapPath( relativePath );
+
+            // allows a fallback for non-IIS environments
+            return System.Web.Hosting.HostingEnvironment.MapPath( relativePath ) ?? relativePath;
         }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace Rock.Storage.Provider
         /// </summary>
         /// <param name="binaryFile">The binary file.</param>
         /// <returns></returns>
-        private string GetRelativePath ( BinaryFile binaryFile )
+        private string GetRelativePath( BinaryFile binaryFile )
         {
             if ( binaryFile != null && !string.IsNullOrWhiteSpace( binaryFile.FileName ) )
             {
@@ -158,6 +159,5 @@ namespace Rock.Storage.Provider
 
             return string.Empty;
         }
-
     }
 }


### PR DESCRIPTION
Fixes #1471 (see discussion there).  When trying to unit test the file storage provider, `HostingEnvironment.MapPath` would return NULL since it's not run in IIS context.  CreateDirectory then throws an exception because the path isn't valid.

This keeps the current behavior inside IIS environments, but returns the relative path otherwise.  

Confirmed working with an assortment of 50 docs/pdf's and a relative path of `~/` and `~/App_Data/Files`.  

*Note*: when using an absolute path for unit testing outside IIS, `C:\inetpub\wwwroot\App_Data\Files/[fileGuid]` gets written into the BinaryFile.StorageEntitySettings, and GetFile returns an error.