### PR TITLE
Enabled custom mobile keyboards for mobile devices when using NumberBoxes, UrlLinkBoxes, and EmailBoxes.

### DIFF
--- a/Rock/Web/UI/Controls/EmailBox.cs
+++ b/Rock/Web/UI/Controls/EmailBox.cs
@@ -110,5 +110,16 @@ namespace Rock.Web.UI.Controls
             _regexValidator.ValidationGroup = this.ValidationGroup;
             _regexValidator.RenderControl( writer );
         }
+
+        /// <summary>
+        /// Renders the base control.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        public override void RenderBaseControl( HtmlTextWriter writer )
+        {
+            this.Attributes["type"] = "email";
+
+            base.RenderBaseControl( writer );
+        }
     }
 }

--- a/Rock/Web/UI/Controls/NumberBox.cs
+++ b/Rock/Web/UI/Controls/NumberBox.cs
@@ -168,5 +168,16 @@ namespace Rock.Web.UI.Controls
             _rangeValidator.ValidationGroup = this.ValidationGroup;
             _rangeValidator.RenderControl( writer );
         }
+
+        /// <summary>
+        /// Renders the base control.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        public override void RenderBaseControl( HtmlTextWriter writer )
+        {
+            this.Attributes["type"] = "number";
+
+            base.RenderBaseControl( writer );
+        }
     }
 }

--- a/Rock/Web/UI/Controls/UrlLinkBox.cs
+++ b/Rock/Web/UI/Controls/UrlLinkBox.cs
@@ -111,5 +111,16 @@ namespace Rock.Web.UI.Controls
             _regexValidator.ValidationGroup = this.ValidationGroup;
             _regexValidator.RenderControl( writer );
         }
+
+        /// <summary>
+        /// Renders the base control.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        public override void RenderBaseControl( HtmlTextWriter writer )
+        {
+            this.Attributes["type"] = "url";
+
+            base.RenderBaseControl( writer );
+        }
     }
 }


### PR DESCRIPTION
Currently NumberBox, EmailBox, and UrlLinkBox are all input fields of type 'text'. This code changes their types to be (respectively) 'number', 'email', and 'url'. This would allow mobile users to be presented with a custom virtual keyboard tailored to the data they're entering, rather than the generic alphabet virtual keyboard.

Example virtual keyboards:
http://blog.teamtreehouse.com/using-html5-input-types-to-enhance-the-mobile-browsing-experience