### PR TITLE
-When sorting notes, order by alerts set to true, rather than not nul…

### DIFF
--- a/Rock/Web/UI/Controls/NoteContainer.cs
+++ b/Rock/Web/UI/Controls/NoteContainer.cs
@@ -720,12 +720,12 @@ namespace Rock.Web.UI.Controls
 
                     if ( SortDirection == ListSortDirection.Descending )
                     {
-                        qry = qry.OrderByDescending( n => n.IsAlert )
+                        qry = qry.OrderByDescending( n => n.IsAlert == true )
                             .ThenByDescending( n => n.CreatedDateTime );
                     }
                     else
                     {
-                        qry = qry.OrderByDescending( n => n.IsAlert )
+                        qry = qry.OrderByDescending( n => n.IsAlert == true )
                             .ThenBy( n => n.CreatedDateTime );
                     }
 


### PR DESCRIPTION
…l. Fixes an issue where notes weren't correctly sorted by time due to NULL vs false being treated different.