### PR TITLE
Added additional references to ModalDialog controls

### DIFF
--- a/Rock/Web/UI/Controls/ModalDialog.cs
+++ b/Rock/Web/UI/Controls/ModalDialog.cs
@@ -196,7 +196,39 @@ namespace Rock.Web.UI.Controls
             set
             {
                 EnsureChildControls();
-                _cancelLink.Visible= value;
+                _cancelLink.Visible = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [close link visible].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [close link visible]; otherwise, <c>false</c>.
+        /// </value>
+        public bool CloseLinkVisible
+        {
+            get
+            {
+                EnsureChildControls();
+                return _closeLink.Visible;
+            }
+            set
+            {
+                EnsureChildControls();
+                _closeLink.Visible = value;
+            }
+        }
+
+        /// <summary>
+        /// Header panel control
+        /// </summary>
+        public Panel Header
+        {
+            get
+            {
+                EnsureChildControls();
+                return _headerPanel;
             }
         }
 
@@ -217,6 +249,18 @@ namespace Rock.Web.UI.Controls
             {
                 EnsureChildControls();
                 return _contentPanel;
+            }
+        }
+
+        /// <summary>
+        /// Footer panel control
+        /// </summary>
+        public Panel Footer
+        {
+            get
+            {
+                EnsureChildControls();
+                return _footerPanel;
             }
         }
 


### PR DESCRIPTION
Added public reference for modal header and footer controls
Added public reference for close link visibility

The ability to add controls to the footer and header, such as additional buttons or add highlight labels, has been a continued need in our work. These changes would give developers additional control over the modal dialog.