### PR TITLE
Change Workflow Action Pickers to use Action Component Name

### DIFF
--- a/Rock.Rest/Controllers/WorkflowActionTypesController.Partial.cs
+++ b/Rock.Rest/Controllers/WorkflowActionTypesController.Partial.cs
@@ -77,7 +77,7 @@ namespace Rock.Rest.Controllers
                             {
                                 var item = new TreeViewItem();
                                 item.Id = entityType.Id.ToString();
-                                item.Name = entityType.FriendlyName;
+                                item.Name = ActionContainer.GetComponentName(entityType.Name);
                                 item.HasChildren = false;
                                 item.IconCssClass = "fa fa-cube";
                                 list.Add( item );

--- a/Rock/Web/UI/Controls/Pickers/WorkflowActionTypePicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/WorkflowActionTypePicker.cs
@@ -54,7 +54,7 @@ namespace Rock.Web.UI.Controls
             if ( entityType != null )
             {
                 ItemId = entityType.Id.ToString();
-                ItemName = entityType.FriendlyName;
+                ItemName = ActionContainer.GetComponentName(entityType.Name);
 
                 var action = ActionContainer.GetComponent( entityType.Name );
                 if ( action != null )
@@ -91,7 +91,7 @@ namespace Rock.Web.UI.Controls
                 foreach( var entityType in theEntityTypes )
                 {
                     ids.Add( entityType.Id.ToString() );
-                    names.Add( entityType.FriendlyName );
+                    names.Add(ActionContainer.GetComponentName(entityType.Name));
 
                     var action = ActionContainer.GetComponent( entityType.Name );
                     if ( action != null )


### PR DESCRIPTION
Previously workflow action pickers were returning the EntityTypeCache Friendly Name (Send Sms), this changes them to use the MEF component name (Send SMS) to match the rest of the workflow UI.