### PR TITLE
Adding support for updating/editing FinancialTransaction entity attributes

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx
@@ -79,6 +79,7 @@
                             <Rock:FinancialGatewayPicker ID="gpPaymentGateway" runat="server" Label="Payment Gateway" />
                             <Rock:DataTextBox ID="tbTransactionCode" runat="server" Label="Transaction Code"
                                 SourceTypeName="Rock.Model.FinancialTransaction, Rock" PropertyName="TransactionCode" />
+                            <asp:PlaceHolder ID="phAttributeEdits" runat="server" EnableViewState="false"></asp:PlaceHolder>
                         </div>
                         <div class="col-md-6">
                             <Rock:RockCheckBox ID="cbIsRefund" runat="server" Label="This is a Refund" Text="Yes" AutoPostBack="true" OnCheckedChanged="cbIsRefund_CheckedChanged" />
@@ -109,6 +110,7 @@
                     <div class="row">
                         <div class="col-md-6">
                             <asp:Literal ID="lDetailsLeft" runat="server" />
+                            <asp:PlaceHolder ID="phAttributes" runat="server"></asp:PlaceHolder>
                         </div>
                         <div class="col-md-6">
 

--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
@@ -190,6 +190,18 @@ namespace RockWeb.Blocks.Finance
                 nbErrorMessage.Visible = false;
                 nbRefundError.Visible = false;
                 ShowDialog();
+
+                int? txnId = hfTransactionId.Value.AsIntegerOrNull();
+                if (txnId.HasValue)
+                {
+
+                    var rockContext = new RockContext();
+
+                    var txnService = new FinancialTransactionService(rockContext);
+                    FinancialTransaction txn = txnService.Get(txnId.Value);
+                    txn.LoadAttributes();
+                    Rock.Attribute.Helper.AddEditControls(txn, phAttributeEdits, true, BlockValidationGroup);
+                }
             }
         }
 
@@ -476,6 +488,10 @@ namespace RockWeb.Blocks.Finance
                         binaryFileService.Delete( binaryFile );
                     }
 
+                    // Update any attributes
+                    txn.LoadAttributes(rockContext);
+                    Rock.Attribute.Helper.GetEditValues(phAttributeEdits, txn);
+
                     // If the transaction is associated with a batch, update that batch's history
                     if ( batchId.HasValue )
                     {
@@ -492,6 +508,7 @@ namespace RockWeb.Blocks.Finance
                     }
 
                     rockContext.SaveChanges();
+                    txn.SaveAttributeValues(rockContext);
 
                 } );
 
@@ -1358,6 +1375,9 @@ namespace RockWeb.Blocks.Finance
                         }
                     }
                 }
+
+                txn.LoadAttributes();
+                Helper.AddDisplayControls(txn, Helper.GetAttributeCategories(txn, false, false), phAttributes, null, false);
 
             }
             else


### PR DESCRIPTION
This adds support for being able to update/edit custom attributes on FinancialTransactions. I'm not 100% sure if there needs to be additional discussion about this but this is a feature we need to replace the Project functionality we used in Arena. We have a defined type which contains all the values needed for different projects and just set that as an attribute on the FinancialTransaction record.