### PR TITLE
[EN] Adds an option to display the discount code used during Event Registration

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -561,6 +561,7 @@
     <Compile Include="Utility\DebugHelper.cs" />
     <Compile Include="Utility\ExtensionMethods\ColorExtensions.cs" />
     <Compile Include="Utility\ExtensionMethods\DecimalExtensions.cs" />
+    <Compile Include="Utility\ExtensionMethods\GridExtensions.cs" />
     <Compile Include="Utility\ExtensionMethods\StringHumanizerExtensions.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\NotNullJsonConverter.cs" />

--- a/Rock/Utility/ExtensionMethods/GridExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/GridExtensions.cs
@@ -26,7 +26,7 @@ namespace Rock
         /// Gets the grid column that matches the header text.
         /// </summary>
         /// <param name="dataControlFieldCollection">The data control field collection.</param>
-        /// <see cref="http://stackoverflow.com/a/22005731/1853867" />
+        /// <see href="http://stackoverflow.com/a/22005731/1853867" />
         /// <param name="headerText">The header text.</param>
         /// <returns></returns>
         public static DataControlField GetColumnByHeaderText( this DataControlFieldCollection dataControlFieldCollection, string headerText )

--- a/Rock/Utility/ExtensionMethods/GridExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/GridExtensions.cs
@@ -1,0 +1,47 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Web.UI.WebControls;
+
+namespace Rock
+{
+    public static partial class ExtensionMethods
+    {
+        #region Grid Extensions
+
+        /// <summary>
+        /// Gets the grid column that matches the header text.
+        /// </summary>
+        /// <param name="dataControlFieldCollection">The data control field collection.</param>
+        /// <see cref="http://stackoverflow.com/a/22005731/1853867" />
+        /// <param name="headerText">The header text.</param>
+        /// <returns></returns>
+        public static DataControlField GetColumnByHeaderText( this DataControlFieldCollection dataControlFieldCollection, string headerText )
+        {
+            foreach ( DataControlField column in dataControlFieldCollection )
+            {
+                if ( column.HeaderText == headerText )
+                {
+                    return column;
+                }
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx
@@ -166,14 +166,14 @@
                                         </ItemTemplate>
                                     </Rock:RockTemplateField>
                                     <Rock:DateTimeField DataField="CreatedDateTime" HeaderText="When" SortExpression="CreatedDateTime" />
-                                    <Rock:RockTemplateField HeaderText="Total Cost" ItemStyle-HorizontalAlign="Right" SortExpression="TotalCost">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lCost" runat="server" CssClass="label label-info"></asp:Label>
-                                        </ItemTemplate>
-                                    </Rock:RockTemplateField>
                                     <Rock:RockTemplateField HeaderText="Discount Code" ItemStyle-HorizontalAlign="Center" SortExpression="DiscountCode" Visible="false">
                                         <ItemTemplate>
                                             <asp:Label ID="lDiscount" runat="server" CssClass="label" />
+                                        </ItemTemplate>
+                                    </Rock:RockTemplateField>
+                                    <Rock:RockTemplateField HeaderText="Total Cost" ItemStyle-HorizontalAlign="Right" SortExpression="TotalCost">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lCost" runat="server" CssClass="label label-info"></asp:Label>
                                         </ItemTemplate>
                                     </Rock:RockTemplateField>
                                     <Rock:RockTemplateField HeaderText="Balance Due" ItemStyle-HorizontalAlign="Right" SortExpression="BalanceDue">

--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx
@@ -1,7 +1,7 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="RegistrationInstanceDetail.ascx.cs" Inherits="RockWeb.Blocks.Event.RegistrationInstanceDetail" %>
 
 <script type="text/javascript">
-    Sys.Application.add_load( function () {
+    Sys.Application.add_load(function () {
         $('.js-follow-status').tooltip();
     });
 </script>
@@ -11,7 +11,7 @@
 
         <div class="wizard">
             <div class="wizard-item complete">
-                <asp:LinkButton ID="lbWizardTemplate" runat="server" OnClick="lbTemplate_Click" CausesValidation="false" >
+                <asp:LinkButton ID="lbWizardTemplate" runat="server" OnClick="lbTemplate_Click" CausesValidation="false">
                     <%-- Placeholder needed for bug. See: http://stackoverflow.com/questions/5539327/inner-image-and-text-of-asplinkbutton-disappears-after-postback--%>
                     <asp:PlaceHolder runat="server">
                         <div class="wizard-item-icon">
@@ -108,11 +108,8 @@
                                 <asp:LinkButton ID="btnSendPaymentReminder" runat="server" Text="Send Payment Reminder" CssClass="btn btn-link" OnClick="btnSendPaymentReminder_Click" Visible="false" />
                             </span>
                         </div>
-
                     </fieldset>
-
                 </div>
-
             </div>
 
             <asp:Panel ID="pnlTabs" runat="server" Visible="false">
@@ -124,7 +121,7 @@
                     <li id="liRegistrants" runat="server">
                         <asp:LinkButton ID="lbRegistrants" runat="server" Text="Registrants" OnClick="lbTab_Click" />
                     </li>
-                    <li id="liPayments" runat="server" >
+                    <li id="liPayments" runat="server">
                         <asp:LinkButton ID="lbPayments" runat="server" Text="Payments" OnClick="lbTab_Click" />
                     </li>
                     <li id="liLinkage" runat="server">
@@ -137,7 +134,7 @@
 
                 <asp:Panel ID="pnlRegistrations" runat="server" Visible="false" CssClass="panel panel-block">
                     <div class="panel-heading">
-                        <h1 class="panel-title"><i class="fa fa-user"></i> Registrations</h1>
+                        <h1 class="panel-title"><i class="fa fa-user"></i>Registrations</h1>
                     </div>
                     <div class="panel-body">
                         <Rock:ModalAlert ID="mdRegistrationsGridWarning" runat="server" />
@@ -154,10 +151,10 @@
                                 <Rock:RockTextBox ID="tbRegistrationRegistrantFirstName" runat="server" Label="Registrant First Name" />
                                 <Rock:RockTextBox ID="tbRegistrationRegistrantLastName" runat="server" Label="Registrant Last Name" />
                             </Rock:GridFilter>
-                            <Rock:Grid ID="gRegistrations" runat="server" DisplayType="Full" AllowSorting="true" OnRowSelected="gRegistrations_RowSelected" RowItemText="Registration" 
-                                PersonIdField="PersonAlias.PersonId" CssClass="js-grid-registration" ExportSource="ColumnOutput" >
+                            <Rock:Grid ID="gRegistrations" runat="server" DisplayType="Full" AllowSorting="true" OnRowSelected="gRegistrations_RowSelected" RowItemText="Registration"
+                                PersonIdField="PersonAlias.PersonId" CssClass="js-grid-registration" ExportSource="ColumnOutput">
                                 <Columns>
-                                    <Rock:SelectField ItemStyle-Width="48px"/>
+                                    <Rock:SelectField ItemStyle-Width="48px" />
                                     <Rock:RockTemplateField HeaderText="Registered By">
                                         <ItemTemplate>
                                             <asp:Literal ID="lRegisteredBy" runat="server"></asp:Literal>
@@ -172,6 +169,11 @@
                                     <Rock:RockTemplateField HeaderText="Total Cost" ItemStyle-HorizontalAlign="Right" SortExpression="TotalCost">
                                         <ItemTemplate>
                                             <asp:Label ID="lCost" runat="server" CssClass="label label-info"></asp:Label>
+                                        </ItemTemplate>
+                                    </Rock:RockTemplateField>
+                                    <Rock:RockTemplateField HeaderText="Discount Code" ItemStyle-HorizontalAlign="Center" SortExpression="DiscountCode" Visible="false">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lDiscount" runat="server" CssClass="label" />
                                         </ItemTemplate>
                                     </Rock:RockTemplateField>
                                     <Rock:RockTemplateField HeaderText="Balance Due" ItemStyle-HorizontalAlign="Right" SortExpression="BalanceDue">
@@ -189,7 +191,7 @@
 
                 <asp:Panel ID="pnlRegistrants" runat="server" Visible="false" CssClass="panel panel-block">
                     <div class="panel-heading">
-                        <h1 class="panel-title"><i class="fa fa-users"></i> Registrants</h1>
+                        <h1 class="panel-title"><i class="fa fa-users"></i>Registrants</h1>
                     </div>
                     <div class="panel-body">
                         <Rock:ModalAlert ID="mdRegistrantsGridWarning" runat="server" />
@@ -203,7 +205,7 @@
                             </Rock:GridFilter>
                             <Rock:Grid ID="gRegistrants" runat="server" DisplayType="Full" AllowSorting="true" OnRowSelected="gRegistrants_RowSelected" RowItemText="Registrant" PersonIdField="PersonId" ExportSource="ColumnOutput">
                                 <Columns>
-                                    <Rock:SelectField ItemStyle-Width="48px"/>
+                                    <Rock:SelectField ItemStyle-Width="48px" />
                                     <Rock:RockTemplateField HeaderText="Registrant" SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName">
                                         <ItemTemplate>
                                             <asp:Literal ID="lRegistrant" runat="server"></asp:Literal>
@@ -222,7 +224,7 @@
 
                 <asp:Panel ID="pnlPayments" runat="server" Visible="false" CssClass="panel panel-block">
                     <div class="panel-heading">
-                        <h1 class="panel-title"><i class="fa fa-credit-card"></i> Payments</h1>
+                        <h1 class="panel-title"><i class="fa fa-credit-card"></i>Payments</h1>
                     </div>
                     <div class="panel-body">
                         <Rock:ModalAlert ID="mdPaymentsGridWarning" runat="server" />
@@ -230,15 +232,15 @@
                             <Rock:GridFilter ID="fPayments" runat="server" OnDisplayFilterValue="fPayments_DisplayFilterValue">
                                 <Rock:DateRangePicker ID="drpPaymentDateRange" runat="server" Label="Date Range" />
                             </Rock:GridFilter>
-                            <Rock:Grid ID="gPayments" runat="server" DisplayType="Full" AllowSorting="true" RowItemText="Payment" OnRowSelected="gPayments_RowSelected" ExportSource="ColumnOutput" >
+                            <Rock:Grid ID="gPayments" runat="server" DisplayType="Full" AllowSorting="true" RowItemText="Payment" OnRowSelected="gPayments_RowSelected" ExportSource="ColumnOutput">
                                 <Columns>
-                                    <Rock:RockBoundField DataField="AuthorizedPersonAlias.Person.FullNameReversed" HeaderText="Person" 
+                                    <Rock:RockBoundField DataField="AuthorizedPersonAlias.Person.FullNameReversed" HeaderText="Person"
                                         SortExpression="AuthorizedPersonAlias.Person.LastName,AuthorizedPersonAlias.Person.NickName" />
-                                    <Rock:RockBoundField DataField="TransactionDateTime" HeaderText="Date / Time" SortExpression="TransactionDateTime" />                
+                                    <Rock:RockBoundField DataField="TransactionDateTime" HeaderText="Date / Time" SortExpression="TransactionDateTime" />
                                     <Rock:CurrencyField DataField="TotalAmount" HeaderText="Amount" SortExpression="TotalAmount" />
                                     <Rock:RockBoundField DataField="FinancialPaymentDetail.CurrencyAndCreditCardType" HeaderText="Payment Method" />
                                     <Rock:RockBoundField DataField="FinancialPaymentDetail.AccountNumberMasked" HeaderText="Account" />
-                                    <Rock:RockBoundField DataField="TransactionCode" HeaderText="Transaction Code" SortExpression="TransactionCode" ColumnPriority="DesktopSmall" />                
+                                    <Rock:RockBoundField DataField="TransactionCode" HeaderText="Transaction Code" SortExpression="TransactionCode" ColumnPriority="DesktopSmall" />
                                     <Rock:RockTemplateFieldUnselected HeaderText="Registrar">
                                         <ItemTemplate>
                                             <asp:Literal ID="lRegistrar" runat="server" />
@@ -257,7 +259,7 @@
 
                 <asp:Panel ID="pnlLinkages" runat="server" Visible="false" CssClass="panel panel-block">
                     <div class="panel-heading">
-                        <h1 class="panel-title"><i class="fa fa-link"></i> Linkages</h1>
+                        <h1 class="panel-title"><i class="fa fa-link"></i>Linkages</h1>
                     </div>
                     <div class="panel-body">
                         <Rock:ModalAlert ID="mdLinkagesGridWarning" runat="server" />
@@ -291,7 +293,7 @@
 
                 <asp:Panel ID="pnlGroupPlacement" runat="server" Visible="false" CssClass="panel panel-block">
                     <div class="panel-heading">
-                        <h1 class="panel-title"><i class="fa fa-link"></i> Group Placement</h1>
+                        <h1 class="panel-title"><i class="fa fa-link"></i>Group Placement</h1>
                     </div>
                     <div class="panel-body">
                         <div class="row">
@@ -317,10 +319,7 @@
                         </div>
                     </div>
                 </asp:Panel>
-
             </asp:Panel>
-
         </asp:Panel>
-
     </ContentTemplate>
 </asp:UpdatePanel>

--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
@@ -50,6 +50,7 @@ namespace RockWeb.Blocks.Event
     [LinkedPage( "Content Item Page", "The page for viewing details about a content channel item", true, "", "", 5 )]
     [LinkedPage( "Transaction Detail Page", "The page for viewing details about a payment", true, "", "", 6 )]
     [LinkedPage( "Payment Reminder Page", "The page for manually sending payment reminders.", false, "", "", 7 )]
+    [BooleanField( "Display Discount Codes", "Display the discount code used with a payment", false, "", 8 )]
     public partial class RegistrationInstanceDetail : Rock.Web.UI.RockBlock, IDetailBlock
     {
         #region Fields
@@ -616,6 +617,14 @@ namespace RockWeb.Blocks.Event
                 {
                     lCost.Visible = _instanceHasCost || discountedCost > 0.0M;
                     lCost.Text = discountedCost.FormatAsCurrency();
+                }
+
+                var discountCode = registration.DiscountCode;
+                var lDiscount = e.Row.FindControl( "lDiscount" ) as Label;
+                if ( lDiscount != null )
+                {
+                    lDiscount.Visible = _instanceHasCost && !string.IsNullOrEmpty( discountCode );
+                    lDiscount.Text = discountCode;
                 }
 
                 var lBalance = e.Row.FindControl( "lBalance" ) as Label;
@@ -2005,6 +2014,12 @@ namespace RockWeb.Blocks.Event
                                 d.EntityTypeId.Value == registrationEntityType.Id &&
                                 registrationIds.Contains( d.EntityId.Value ) )
                             .ToList();
+                    }
+
+                    var discountCodeHeader = gRegistrations.Columns.GetColumnByHeaderText( "Discount Code" );
+                    if ( discountCodeHeader != null )
+                    {
+                        discountCodeHeader.Visible = GetAttributeValue( "DisplayDiscountCodes" ).AsBoolean();
                     }
 
                     gRegistrations.DataBind();

--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
@@ -42,15 +42,14 @@ namespace RockWeb.Blocks.Event
     [DisplayName( "Registration Instance Detail" )]
     [Category( "Event" )]
     [Description( "Template block for editing an event registration instance." )]
-
     [AccountField( "Default Account", "The default account to use for new registration instances", false, "2A6F9E5F-6859-44F1-AB0E-CE9CF6B08EE5", "", 0 )]
     [LinkedPage( "Registration Page", "The page for editing registration and registrant information", true, "", "", 1 )]
     [LinkedPage( "Linkage Page", "The page for editing registration linkages", true, "", "", 2 )]
-    [LinkedPage( "Calendar Item Page", "The page to view calendar item details", true, "", "", 3)]
-    [LinkedPage( "Group Detail Page", "The page for viewing details about a group", true, "", "", 4)]
+    [LinkedPage( "Calendar Item Page", "The page to view calendar item details", true, "", "", 3 )]
+    [LinkedPage( "Group Detail Page", "The page for viewing details about a group", true, "", "", 4 )]
     [LinkedPage( "Content Item Page", "The page for viewing details about a content channel item", true, "", "", 5 )]
     [LinkedPage( "Transaction Detail Page", "The page for viewing details about a payment", true, "", "", 6 )]
-    [LinkedPage("Payment Reminder Page", "The page for manually sending payment reminders.", false, "", "", 7)]
+    [LinkedPage( "Payment Reminder Page", "The page for manually sending payment reminders.", false, "", "", 7 )]
     public partial class RegistrationInstanceDetail : Rock.Web.UI.RockBlock, IDetailBlock
     {
         #region Fields
@@ -145,8 +144,8 @@ namespace RockWeb.Blocks.Event
             gPayments.DataKeyNames = new string[] { "Id" };
             gPayments.Actions.ShowAdd = false;
             gPayments.RowDataBound += gPayments_RowDataBound;
-            gPayments.GridRebind += gPayments_GridRebind; 
-            
+            gPayments.GridRebind += gPayments_GridRebind;
+
             fLinkages.ApplyFilterClick += fLinkages_ApplyFilterClick;
             gLinkages.DataKeyNames = new string[] { "Id" };
             gLinkages.Actions.ShowAdd = true;
@@ -180,7 +179,7 @@ namespace RockWeb.Blocks.Event
             }
         });
     });
-    
+
     $('table.js-grid-registration a.grid-delete-button').click(function( e ){
         e.preventDefault();
         var $hfHasPayments = $(this).closest('tr').find('input.js-has-payments').first();
@@ -220,15 +219,19 @@ namespace RockWeb.Blocks.Event
                         case 1:
                             ActiveTab = "lbRegistrations";
                             break;
+
                         case 2:
                             ActiveTab = "lbRegistrants";
                             break;
+
                         case 3:
                             ActiveTab = "lbPayments";
                             break;
+
                         case 4:
                             ActiveTab = "lbLinkage";
                             break;
+
                         case 5:
                             ActiveTab = "lbGroupPlacement";
                             break;
@@ -288,7 +291,6 @@ namespace RockWeb.Blocks.Event
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void Block_BlockUpdated( object sender, EventArgs e )
         {
-
         }
 
         #endregion
@@ -347,7 +349,6 @@ namespace RockWeb.Blocks.Event
                         mdDeleteWarning.Show( "You are not authorized to delete this registration instance.", ModalAlertType.Information );
                         return;
                     }
-
                 }
             }
         }
@@ -386,7 +387,6 @@ namespace RockWeb.Blocks.Event
             {
                 var service = new RegistrationInstanceService( rockContext );
 
-
                 int? RegistrationInstanceId = hfRegistrationInstanceId.Value.AsIntegerOrNull();
                 if ( RegistrationInstanceId.HasValue )
                 {
@@ -418,7 +418,7 @@ namespace RockWeb.Blocks.Event
             }
 
             // show send payment reminder link
-            if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PaymentReminderPage" ) ) && ((instance.RegistrationTemplate.SetCostOnInstance.HasValue && instance.RegistrationTemplate.SetCostOnInstance == true && instance.Cost.HasValue && instance.Cost.Value > 0) || instance.RegistrationTemplate.Cost > 0) )
+            if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PaymentReminderPage" ) ) && ( ( instance.RegistrationTemplate.SetCostOnInstance.HasValue && instance.RegistrationTemplate.SetCostOnInstance == true && instance.Cost.HasValue && instance.Cost.Value > 0 ) || instance.RegistrationTemplate.Cost > 0 ) )
             {
                 btnSendPaymentReminder.Visible = true;
             }
@@ -556,12 +556,11 @@ namespace RockWeb.Blocks.Event
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
-        void gRegistrations_RowDataBound( object sender, GridViewRowEventArgs e )
+        protected void gRegistrations_RowDataBound( object sender, GridViewRowEventArgs e )
         {
             var registration = e.Row.DataItem as Registration;
             if ( registration != null )
             {
-
                 // Set the processor value
                 var lRegisteredBy = e.Row.FindControl( "lRegisteredBy" ) as Literal;
                 if ( lRegisteredBy != null )
@@ -604,7 +603,7 @@ namespace RockWeb.Blocks.Event
                 bool hasPayments = payments.Any();
                 decimal totalPaid = hasPayments ? payments.Select( p => p.Amount ).DefaultIfEmpty().Sum() : 0.0m;
 
-                var hfHasPayments = e.Row.FindControl( "hfHasPayments") as HiddenFieldWithClass;
+                var hfHasPayments = e.Row.FindControl( "hfHasPayments" ) as HiddenFieldWithClass;
                 if ( hfHasPayments != null )
                 {
                     hfHasPayments.Value = hasPayments.ToString();
@@ -653,7 +652,7 @@ namespace RockWeb.Blocks.Event
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        void gRegistrations_AddClick( object sender, EventArgs e )
+        protected void gRegistrations_AddClick( object sender, EventArgs e )
         {
             NavigateToLinkedPage( "RegistrationPage", "RegistrationId", 0, "RegistrationInstanceId", hfRegistrationInstanceId.ValueAsInt() );
         }
@@ -673,7 +672,7 @@ namespace RockWeb.Blocks.Event
                 {
                     int registrationInstanceId = registration.RegistrationInstanceId;
 
-                    if ( !UserCanEdit && 
+                    if ( !UserCanEdit &&
                         !registration.IsAuthorized( Authorization.EDIT, this.CurrentPerson ) &&
                         !registration.IsAuthorized( Authorization.ADMINISTRATE, this.CurrentPerson ) )
                     {
@@ -765,8 +764,8 @@ namespace RockWeb.Blocks.Event
                                     }
 
                                     break;
-                                } 
-                            
+                                }
+
                             case RegistrationPersonFieldType.Birthdate:
                                 {
                                     var drpBirthdateFilter = phRegistrantFormFieldFilters.FindControl( "drpBirthdateFilter" ) as DateRangePicker;
@@ -937,7 +936,7 @@ namespace RockWeb.Blocks.Event
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
-        void gRegistrants_RowDataBound( object sender, GridViewRowEventArgs e )
+        private void gRegistrants_RowDataBound( object sender, GridViewRowEventArgs e )
         {
             var registrant = e.Row.DataItem as RegistrationRegistrant;
             if ( registrant != null )
@@ -992,7 +991,7 @@ namespace RockWeb.Blocks.Event
                         }
                     }
                 }
-                
+
                 // Set the Fees
                 var lFees = e.Row.FindControl( "lFees" ) as Literal;
                 if ( lFees != null )
@@ -1010,7 +1009,6 @@ namespace RockWeb.Blocks.Event
                         lFees.Text = feeDesc.AsDelimited( "<br/>" );
                     }
                 }
-
             }
         }
 
@@ -1020,7 +1018,7 @@ namespace RockWeb.Blocks.Event
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        void gRegistrants_AddClick( object sender, EventArgs e )
+        private void gRegistrants_AddClick( object sender, EventArgs e )
         {
             NavigateToLinkedPage( "RegistrationPage", "RegistrationId", 0, "RegistrationInstanceId", hfRegistrationInstanceId.ValueAsInt() );
         }
@@ -1098,7 +1096,6 @@ namespace RockWeb.Blocks.Event
         /// <param name="e">The e.</param>
         protected void fPayments_DisplayFilterValue( object sender, GridFilter.DisplayFilterValueArgs e )
         {
-
             switch ( e.Key )
             {
                 case "Date Range":
@@ -1139,19 +1136,19 @@ namespace RockWeb.Blocks.Event
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
-        void gPayments_RowDataBound( object sender, GridViewRowEventArgs e )
+        private void gPayments_RowDataBound( object sender, GridViewRowEventArgs e )
         {
             var transaction = e.Row.DataItem as FinancialTransaction;
-            var lRegistrar = e.Row.FindControl("lRegistrar") as Literal;
-            var lRegistrants = e.Row.FindControl("lRegistrants") as Literal;
+            var lRegistrar = e.Row.FindControl( "lRegistrar" ) as Literal;
+            var lRegistrants = e.Row.FindControl( "lRegistrants" ) as Literal;
 
             if ( transaction != null && lRegistrar != null && lRegistrants != null )
             {
                 var registrars = new List<string>();
                 var registrants = new List<string>();
 
-                var registrationIds = transaction.TransactionDetails.Select( d => d.EntityId).ToList();
-                foreach( var registration in PaymentRegistrations
+                var registrationIds = transaction.TransactionDetails.Select( d => d.EntityId ).ToList();
+                foreach ( var registration in PaymentRegistrations
                     .Where( r => registrationIds.Contains( r.Id ) ) )
                 {
                     if ( registration.PersonAlias != null && registration.PersonAlias.Person != null )
@@ -1161,7 +1158,7 @@ namespace RockWeb.Blocks.Event
                         string url = LinkedPageUrl( "RegistrationPage", qryParams );
                         registrars.Add( string.Format( "<a href='{0}'>{1}</a>", url, registration.PersonAlias.Person.FullName ) );
 
-                        foreach( var registrant in registration.Registrants )
+                        foreach ( var registrant in registration.Registrants )
                         {
                             if ( registrant.PersonAlias != null && registrant.PersonAlias.Person != null )
                             {
@@ -1238,7 +1235,7 @@ namespace RockWeb.Blocks.Event
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
-        void gLinkages_RowDataBound( object sender, GridViewRowEventArgs e )
+        protected void gLinkages_RowDataBound( object sender, GridViewRowEventArgs e )
         {
             if ( e.Row.RowType == DataControlRowType.DataRow )
             {
@@ -1297,7 +1294,7 @@ namespace RockWeb.Blocks.Event
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        void gLinkages_AddClick( object sender, EventArgs e )
+        protected void gLinkages_AddClick( object sender, EventArgs e )
         {
             NavigateToLinkedPage( "LinkagePage", "LinkageId", 0, "RegistrationInstanceId", hfRegistrationInstanceId.ValueAsInt() );
         }
@@ -1363,11 +1360,11 @@ namespace RockWeb.Blocks.Event
         {
             int? parentGroupId = gpGroupPlacementParentGroup.SelectedValueAsInt();
 
-            SetUserPreference( string.Format( "ParentGroup_{0}_{1}", BlockId, hfRegistrationInstanceId.Value),
+            SetUserPreference( string.Format( "ParentGroup_{0}_{1}", BlockId, hfRegistrationInstanceId.Value ),
                 parentGroupId.HasValue ? parentGroupId.Value.ToString() : "", true );
 
             var groupPickerField = gGroupPlacements.Columns.OfType<GroupPickerField>().FirstOrDefault();
-            if (groupPickerField != null )
+            if ( groupPickerField != null )
             {
                 groupPickerField.RootGroupId = parentGroupId;
             }
@@ -1375,10 +1372,15 @@ namespace RockWeb.Blocks.Event
             BindGroupPlacementGrid();
         }
 
+        /// <summary>
+        /// Handles the Click event of the lbPlaceInGroup control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbPlaceInGroup_Click( object sender, EventArgs e )
         {
             var col = gGroupPlacements.Columns.OfType<GroupPickerField>().FirstOrDefault();
-            if (col != null )
+            if ( col != null )
             {
                 var placements = new Dictionary<int, List<int>>();
 
@@ -1392,7 +1394,7 @@ namespace RockWeb.Blocks.Event
                         if ( groupId.HasValue )
                         {
                             int registrantId = (int)gGroupPlacements.DataKeys[row.RowIndex].Value;
-                            placements.AddOrIgnore( groupId.Value, new List<int>());
+                            placements.AddOrIgnore( groupId.Value, new List<int>() );
                             placements[groupId.Value].Add( registrantId );
                         }
                     }
@@ -1412,7 +1414,7 @@ namespace RockWeb.Blocks.Event
                     // Get any groups that were selected
                     var groupIds = placements.Keys.ToList();
                     foreach ( var group in new GroupService( rockContext )
-                        .Queryable("GroupType").AsNoTracking()
+                        .Queryable( "GroupType" ).AsNoTracking()
                         .Where( g => groupIds.Contains( g.Id ) ) )
                     {
                         foreach ( int registrantId in placements[group.Id] )
@@ -1445,7 +1447,7 @@ namespace RockWeb.Blocks.Event
 
             BindGroupPlacementGrid();
         }
-        
+
         #endregion
 
         #endregion
@@ -1511,7 +1513,7 @@ namespace RockWeb.Blocks.Event
                     registrationInstance.IsActive = true;
                     registrationInstance.RegistrationTemplateId = parentTemplateId ?? 0;
 
-                    Guid? accountGuid = GetAttributeValue( "DefaultAccount").AsGuidOrNull();
+                    Guid? accountGuid = GetAttributeValue( "DefaultAccount" ).AsGuidOrNull();
                     if ( accountGuid.HasValue )
                     {
                         var account = new FinancialAccountService( rockContext ).Get( accountGuid.Value );
@@ -1536,7 +1538,7 @@ namespace RockWeb.Blocks.Event
 
                 FollowingsHelper.SetFollowing( registrationInstance, pnlFollowing, this.CurrentPerson );
 
-                // render UI based on Authorized 
+                // render UI based on Authorized
                 bool readOnly = false;
 
                 bool canEdit = UserCanEdit ||
@@ -1575,7 +1577,7 @@ namespace RockWeb.Blocks.Event
                 }
 
                 // show send payment reminder link
-                if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PaymentReminderPage" ) ) && ((registrationInstance.RegistrationTemplate.SetCostOnInstance.HasValue && registrationInstance.RegistrationTemplate.SetCostOnInstance == true && registrationInstance.Cost.HasValue && registrationInstance.Cost.Value > 0) || registrationInstance.RegistrationTemplate.Cost > 0 ))
+                if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PaymentReminderPage" ) ) && ( ( registrationInstance.RegistrationTemplate.SetCostOnInstance.HasValue && registrationInstance.RegistrationTemplate.SetCostOnInstance == true && registrationInstance.Cost.HasValue && registrationInstance.Cost.Value > 0 ) || registrationInstance.RegistrationTemplate.Cost > 0 ) )
                 {
                     btnSendPaymentReminder.Visible = true;
                 }
@@ -1764,11 +1766,16 @@ namespace RockWeb.Blocks.Event
             }
         }
 
-        private void SetHasPayments ( int registrationInstanceId, RockContext rockContext )
+        /// <summary>
+        /// Sets whether the registration has payments.
+        /// </summary>
+        /// <param name="registrationInstanceId">The registration instance identifier.</param>
+        /// <param name="rockContext">The rock context.</param>
+        private void SetHasPayments( int registrationInstanceId, RockContext rockContext )
         {
             var registrationIdQry = new RegistrationService( rockContext )
                 .Queryable().AsNoTracking()
-                .Where( r => 
+                .Where( r =>
                     r.RegistrationInstanceId == registrationInstanceId &&
                     !r.IsTemporary )
                 .Select( r => r.Id );
@@ -1824,7 +1831,7 @@ namespace RockWeb.Blocks.Event
                     var qry = new RegistrationService( rockContext )
                         .Queryable( "PersonAlias.Person,Registrants.PersonAlias.Person,Registrants.Fees.RegistrationTemplateFee" )
                         .AsNoTracking()
-                        .Where( r => 
+                        .Where( r =>
                             r.RegistrationInstanceId == instanceId.Value &&
                             !r.IsTemporary );
 
@@ -1923,7 +1930,6 @@ namespace RockWeb.Blocks.Event
                             } )
                             .ToList();
 
-
                         var ids = new List<int>();
 
                         if ( ddlRegistrationPaymentStatus.SelectedValue == "Paid in Full" )
@@ -1949,7 +1955,7 @@ namespace RockWeb.Blocks.Event
                     {
                         // If sorting by Total Cost or Balance Due, the database query needs to be run first without ordering,
                         // and then ordering needs to be done in memory since TotalCost and BalanceDue are not databae fields.
-                        if ( sortProperty.Property == "TotalCost")
+                        if ( sortProperty.Property == "TotalCost" )
                         {
                             if ( sortProperty.Direction == SortDirection.Ascending )
                             {
@@ -1980,7 +1986,6 @@ namespace RockWeb.Blocks.Event
                     {
                         gRegistrations.SetLinqDataSource( qry.OrderByDescending( r => r.CreatedDateTime ) );
                     }
-
 
                     // Get all the payments for any registrations being displayed on the current page.
                     // This is used in the RowDataBound event but queried now so that each row does
@@ -2090,7 +2095,7 @@ namespace RockWeb.Blocks.Event
 
                     if ( RegistrantFields != null )
                     {
-                        // Filter by any selected 
+                        // Filter by any selected
                         foreach ( var personFieldType in RegistrantFields
                             .Where( f =>
                                 f.FieldSource == RegistrationFieldSource.PersonField &&
@@ -2117,7 +2122,6 @@ namespace RockWeb.Blocks.Event
                                                         m.Group.CampusId.Value == campusId ) );
                                             }
                                         }
-
 
                                         break;
                                     }
@@ -2349,9 +2353,9 @@ namespace RockWeb.Blocks.Event
 
                             // Get all the group member ids and the group id in current page of query results
                             var groupMemberIds = new List<int>();
-                            GroupLinks = new Dictionary<int,string>();
-                            foreach( var groupMember in currentPageRegistrants
-                                .Where( m => 
+                            GroupLinks = new Dictionary<int, string>();
+                            foreach ( var groupMember in currentPageRegistrants
+                                .Where( m =>
                                     m.GroupMember != null &&
                                     m.GroupMember.Group != null )
                                 .Select( m => m.GroupMember ) )
@@ -2390,13 +2394,12 @@ namespace RockWeb.Blocks.Event
                                 }
                             }
 
-                            // If there are any attributes that were selected to be displayed, we're going 
-                            // to try and read all attribute values in one query and then put them into a 
-                            // custom grid ObjectList property so that the AttributeField columns don't need 
+                            // If there are any attributes that were selected to be displayed, we're going
+                            // to try and read all attribute values in one query and then put them into a
+                            // custom grid ObjectList property so that the AttributeField columns don't need
                             // to do the LoadAttributes and querying of values for each row/column
                             if ( personAttributesIds.Any() || groupMemberAttributesIds.Any() || registrantAttributeIds.Any() )
                             {
-
                                 // Query the attribute values for all rows and attributes
                                 var attributeValues = new AttributeValueService( rockContext )
                                     .Queryable( "Attribute" ).AsNoTracking()
@@ -2428,14 +2431,14 @@ namespace RockWeb.Blocks.Event
                                     .ForEach( a => attributes
                                         .Add( a.Id.ToString() + a.Key, a ) );
 
-                                // Initialize the grid's object list 
+                                // Initialize the grid's object list
                                 gRegistrants.ObjectList = new Dictionary<string, object>();
 
                                 // Loop through each of the current page's registrants and build an attribute
                                 // field object for storing attributes and the values for each of the registrants
                                 foreach ( var registrant in currentPageRegistrants )
                                 {
-                                    // Create a row attribute object 
+                                    // Create a row attribute object
                                     var attributeFieldObject = new AttributeFieldObject();
 
                                     // Add the attributes to the attribute object
@@ -2572,7 +2575,7 @@ namespace RockWeb.Blocks.Event
             }
 
             // Remove any of the dynamic attribute fields on group placements grid
-            foreach( var column in gGroupPlacements.Columns
+            foreach ( var column in gGroupPlacements.Columns
                 .OfType<AttributeField>()
                 .ToList() )
             {
@@ -2664,11 +2667,11 @@ namespace RockWeb.Blocks.Event
                                     birthdateField2.DataField = dataFieldExpression;
                                     birthdateField2.HeaderText = "Birthdate";
                                     birthdateField2.SortExpression = dataFieldExpression;
-                                    gGroupPlacements.Columns.Add( birthdateField2 ); 
-                                    
+                                    gGroupPlacements.Columns.Add( birthdateField2 );
+
                                     break;
                                 }
-                            
+
                             case RegistrationPersonFieldType.Gender:
                                 {
                                     var ddlGenderFilter = new RockDropDownList();
@@ -2692,7 +2695,7 @@ namespace RockWeb.Blocks.Event
                                     gGroupPlacements.Columns.Add( genderField2 );
                                     break;
                                 }
-                            
+
                             case RegistrationPersonFieldType.MaritalStatus:
                                 {
                                     var ddlMaritalStatusFilter = new RockDropDownList();
@@ -2740,7 +2743,6 @@ namespace RockWeb.Blocks.Event
                                 }
                         }
                     }
-
                     else if ( field.Attribute != null )
                     {
                         var attribute = field.Attribute;
@@ -2799,7 +2801,6 @@ namespace RockWeb.Blocks.Event
                             gRegistrants.Columns.Add( boundField );
                             gGroupPlacements.Columns.Add( boundField2 );
                         }
-
                     }
                 }
             }
@@ -2851,7 +2852,7 @@ namespace RockWeb.Blocks.Event
                     // Get all the registrations for this instance
                     PaymentRegistrations = new RegistrationService( rockContext )
                         .Queryable( "PersonAlias.Person,Registrants.PersonAlias.Person" ).AsNoTracking()
-                        .Where( r => 
+                        .Where( r =>
                             r.RegistrationInstanceId == instanceId.Value &&
                             !r.IsTemporary )
                         .ToList();
@@ -2984,6 +2985,10 @@ namespace RockWeb.Blocks.Event
 
         #region Group Placement Tab
 
+        /// <summary>
+        /// Binds the group placement grid.
+        /// </summary>
+        /// <param name="isExporting">if set to <c>true</c> [is exporting].</param>
         private void BindGroupPlacementGrid( bool isExporting = false )
         {
             int? groupId = gpGroupPlacementParentGroup.SelectedValueAsInt();
@@ -3002,7 +3007,7 @@ namespace RockWeb.Blocks.Event
 
                     if ( groupId.HasValue )
                     {
-                        var validGroupIds = new GroupService( rockContext).GetAllDescendents( groupId.Value )
+                        var validGroupIds = new GroupService( rockContext ).GetAllDescendents( groupId.Value )
                             .Select( g => g.Id )
                             .ToList();
 
@@ -3029,7 +3034,7 @@ namespace RockWeb.Blocks.Event
                                 f.PersonFieldType.HasValue &&
                                 f.PersonFieldType.Value == RegistrationPersonFieldType.Campus );
 
-                        // Get all the registrant attributes selected 
+                        // Get all the registrant attributes selected
                         var registrantAttributes = RegistrantFields
                             .Where( f =>
                                 f.Attribute != null &&
@@ -3038,7 +3043,7 @@ namespace RockWeb.Blocks.Event
                             .ToList();
                         registrantAttributeIds = registrantAttributes.Select( a => a.Id ).Distinct().ToList();
 
-                        // Get all the person attributes selected 
+                        // Get all the person attributes selected
                         var personAttributes = RegistrantFields
                             .Where( f =>
                                 f.Attribute != null &&
@@ -3094,9 +3099,9 @@ namespace RockWeb.Blocks.Event
 
                             // Get all the group member ids and the group id in current page of query results
                             var groupMemberIds = new List<int>();
-                            GroupLinks = new Dictionary<int,string>();
-                            foreach( var groupMember in currentPageRegistrants
-                                .Where( m => 
+                            GroupLinks = new Dictionary<int, string>();
+                            foreach ( var groupMember in currentPageRegistrants
+                                .Where( m =>
                                     m.GroupMember != null &&
                                     m.GroupMember.Group != null )
                                 .Select( m => m.GroupMember ) )
@@ -3135,13 +3140,12 @@ namespace RockWeb.Blocks.Event
                                 }
                             }
 
-                            // If there are any attributes that were selected to be displayed, we're going 
-                            // to try and read all attribute values in one query and then put them into a 
-                            // custom grid ObjectList property so that the AttributeField columns don't need 
+                            // If there are any attributes that were selected to be displayed, we're going
+                            // to try and read all attribute values in one query and then put them into a
+                            // custom grid ObjectList property so that the AttributeField columns don't need
                             // to do the LoadAttributes and querying of values for each row/column
                             if ( personAttributesIds.Any() || groupMemberAttributesIds.Any() || registrantAttributeIds.Any() )
                             {
-
                                 // Query the attribute values for all rows and attributes
                                 var attributeValues = new AttributeValueService( rockContext )
                                     .Queryable( "Attribute" ).AsNoTracking()
@@ -3173,14 +3177,14 @@ namespace RockWeb.Blocks.Event
                                     .ForEach( a => attributes
                                         .Add( a.Id.ToString() + a.Key, a ) );
 
-                                // Initialize the grid's object list 
+                                // Initialize the grid's object list
                                 gGroupPlacements.ObjectList = new Dictionary<string, object>();
 
                                 // Loop through each of the current page's registrants and build an attribute
                                 // field object for storing attributes and the values for each of the registrants
                                 foreach ( var registrant in currentPageRegistrants )
                                 {
-                                    // Create a row attribute object 
+                                    // Create a row attribute object
                                     var attributeFieldObject = new AttributeFieldObject();
 
                                     // Add the attributes to the attribute object
@@ -3226,9 +3230,6 @@ namespace RockWeb.Blocks.Event
                     gGroupPlacements.DataBind();
                 }
             }
-
-
-
         }
 
         #endregion
@@ -3269,6 +3270,5 @@ namespace RockWeb.Blocks.Event
         }
 
         #endregion
-
     }
 }


### PR DESCRIPTION
Our student and care ministry wanted to be able to see/sort the discount code used for a registration.  This adds an option to display that next to the Total Cost.  Viewing that column is turned off by default.