### PR TITLE
Fix issues with ProcessPayments downloading transactions 

### DIFF
--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -508,10 +508,10 @@ namespace Rock.Model
                     ( totalReversals == 1 ? "payment was" : "payments were" ) );
             }
 
-            if (totalStatusChanges > 0)
+            if ( totalStatusChanges > 0 )
             {
                 sb.AppendFormat( "<li>{0} {1} previously downloaded but had a change of status.</li>", totalStatusChanges.ToString( "N0" ),
-                    ( totalAlreadyDownloaded == 1 ? "payment was" : "payments were" ) );
+                    ( totalStatusChanges == 1 ? "payment was" : "payments were" ) );
             }
 
             foreach ( var batchItem in batchSummary )

--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -393,6 +393,7 @@ namespace Rock.Model
                                 {
                                     transactionDetail = new FinancialTransactionDetail();
                                     transactionDetail.AccountId = defaultAccount.Id;
+                                    transaction.TransactionDetails.Add(transactionDetail);
                                 }
                                 if ( transactionDetail != null )
                                 {

--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -239,6 +239,7 @@ namespace Rock.Model
             int totalNoScheduledTransaction = 0;
             int totalAdded = 0;
             int totalReversals = 0;
+            int totalStatusChanges = 0;
 
             var batches = new List<FinancialBatch>();
             var batchSummary = new Dictionary<Guid, List<Decimal>>();
@@ -451,6 +452,13 @@ namespace Rock.Model
                         else
                         {
                             totalAlreadyDownloaded++;
+
+                            foreach( var txn in txns.Where( t => t.Status != payment.Status || t.StatusMessage != payment.StatusMessage ) )
+                            {
+                                txn.Status = payment.Status;
+                                txn.StatusMessage = payment.StatusMessage;
+                                totalStatusChanges++;
+                            }
                         }
                     }
                     else
@@ -498,6 +506,12 @@ namespace Rock.Model
             {
                 sb.AppendFormat( "<li>{0} {1} added as a reversal to a previous transaction.</li>", totalReversals.ToString( "N0" ),
                     ( totalReversals == 1 ? "payment was" : "payments were" ) );
+            }
+
+            if (totalStatusChanges > 0)
+            {
+                sb.AppendFormat( "<li>{0} {1} previously downloaded but had a change of status.</li>", totalStatusChanges.ToString( "N0" ),
+                    ( totalAlreadyDownloaded == 1 ? "payment was" : "payments were" ) );
             }
 
             foreach ( var batchItem in batchSummary )

--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -393,7 +393,7 @@ namespace Rock.Model
                                 {
                                     transactionDetail = new FinancialTransactionDetail();
                                     transactionDetail.AccountId = defaultAccount.Id;
-                                    transaction.TransactionDetails.Add(transactionDetail);
+                                    transaction.TransactionDetails.Add( transactionDetail );
                                 }
                                 if ( transactionDetail != null )
                                 {


### PR DESCRIPTION
Fixes two immediate issues:

- [x] Downloaded payments that didn't match a ScheduledTransactionDetail were being discarded
- [x] Updates the transaction status if it changed since that transaction was last downloaded

Item 2 seems to only affect the NMI gateway ( pending -> completed ) as the other gateways only pull completed transactions.  However, I'd assume other gateways never change a transaction status once it's completed.