### PR TITLE
#1528 - Plugin Migration now extends DbMigration.

### DIFF
--- a/Rock/Plugin/Migration.cs
+++ b/Rock/Plugin/Migration.cs
@@ -15,16 +15,21 @@
 // </copyright>
 //
 using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Data.Entity.Migrations;
+using System.Data.Entity.Migrations.Model;
+using System.Data.Entity.Migrations.Sql;
+using System.Data.Entity.SqlServer;
 using System.Data.SqlClient;
-using System.Text;
+using System.Reflection;
 
 namespace Rock.Plugin
 {
     /// <summary>
     /// Class for defining a plugin migration
     /// </summary>
-    public abstract class Migration : Rock.Data.IMigration
+    public abstract class Migration : DbMigration, Rock.Data.IMigration
     {
         /// <summary>
         /// Gets or sets the SQL connection.
@@ -45,12 +50,12 @@ namespace Rock.Plugin
         /// <summary>
         /// The commands to run to migrate plugin to the specific version
         /// </summary>
-        public abstract void Up();
+        public override abstract void Up();
 
         /// <summary>
         /// The commands to undo a migration from a specific version
         /// </summary>
-        public abstract void Down();
+        public override abstract void Down();
 
         /// <summary>
         /// Gets the rock migration helper.
@@ -88,6 +93,32 @@ namespace Rock.Plugin
             else
             {
                 throw new NullReferenceException( "The Plugin Migration requires valid SqlConnection and SqlTransaction values when executing SQL" );
+            }
+        }
+
+        /// <summary>
+        /// Run the migration operations.  This iterates through the DbMigrations operations list and actually applies them.
+        /// </summary>
+        public void RunMigration()
+        {
+            var prop = this.GetType().GetProperty("Operations", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (prop != null)
+            {
+                IEnumerable<MigrationOperation> operations = prop.GetValue(this) as IEnumerable<MigrationOperation>;
+                foreach (var operation in operations)
+                {
+                    if (operation is AddForeignKeyOperation && ((AddForeignKeyOperation)operation).PrincipalColumns.Count == 0)
+                    {
+                        // In Rock, the principal column should always be the Id.  This isn't always the case . . . .
+                        ((AddForeignKeyOperation)operation).PrincipalColumns.Add("Id");
+                    }
+                }
+                var generator = new SqlServerMigrationSqlGenerator();
+                var statements = generator.Generate(operations, SqlConnection.ServerVersion.AsInteger() > 10 ? "2008" : "2005");
+                foreach (MigrationStatement item in statements)
+                {
+                    Sql(item.Sql);
+                }
             }
         }
     }

--- a/RockWeb/App_Code/Global.asax.cs
+++ b/RockWeb/App_Code/Global.asax.cs
@@ -16,7 +16,6 @@
 //
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Configuration;
 using System.Data.Entity;
 using System.Data.SqlClient;
@@ -31,8 +30,6 @@ using System.Web.Caching;
 using System.Web.Http;
 using System.Web.Optimization;
 using System.Web.Routing;
-using dotless.Core;
-using dotless.Core.configuration;
 using DotLiquid;
 using Quartz;
 using Quartz.Impl;
@@ -44,7 +41,6 @@ using Rock.Jobs;
 using Rock.Model;
 using Rock.Plugin;
 using Rock.Transactions;
-using Rock.Utility;
 using Rock.Web.Cache;
 using Rock.Web.UI;
 
@@ -128,7 +124,7 @@ namespace RockWeb
         {
             try
             {
-                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+              var stopwatch = System.Diagnostics.Stopwatch.StartNew();
                 LogMessage( APP_LOG_FILENAME, "Application Starting..." ); 
                 
                 if ( System.Web.Hosting.HostingEnvironment.IsDevelopmentEnvironment )
@@ -618,6 +614,7 @@ namespace RockWeb
                                                     migration.SqlConnection = con;
                                                     migration.SqlTransaction = sqlTxn;
                                                     migration.Up();
+                                                    migration.RunMigration();
                                                     sqlTxn.Commit();
                                                     transactionActive = false;
 


### PR DESCRIPTION
- Adding a RunMigration method which takes the operations from DbMigration and applies them using the standard Sql method.
- Calling RunMigration from Global.asax.cs when a plugin migration is run.