### PR TITLE
Fix dynamic google maps loading

### DIFF
--- a/RockWeb/Scripts/Rock/Controls/util.js
+++ b/RockWeb/Scripts/Rock/Controls/util.js
@@ -16,7 +16,7 @@
                     $.ajaxSetup({ cache: true });
                     var src = apiSrc + '&callback=Rock.controls.util.googleMapsIsLoaded';
                     $('head').prepend("<script id='googleMapsApi' src='" + src + "' />");
-                } else {
+                } else if (typeof google == 'object' && typeof google.maps == 'object') {
                     this.googleMapsIsLoaded();
                 }
             }


### PR DESCRIPTION
Fixes issues where the loading event would be incorrectly triggered during
the loading of the maps api.

Example:
1. Script A calls `loadGoogleMapsApi`
2. Rock appends google maps script to head
3. Browser begans loading process
4. Script B calls `loadGoogleMapsApi`
5. API is still loading, but Rock fires the loaded event anyway
6. Script B errors as google is undefined