### PR TITLE
New AsDictionary String Extension methods

### DIFF
--- a/Rock/Utility/ExtensionMethods/StringExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/StringExtensions.cs
@@ -287,6 +287,49 @@ namespace Rock
         }
 
         /// <summary>
+        /// Attempts to convert string to an dictionary using the |/comma and ^ delimter Key/Value syntax.  Returns an empty dictionary if unsuccessful.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <returns></returns>
+        [System.Diagnostics.DebuggerStepThrough()]
+        public static System.Collections.Generic.Dictionary<string, string> AsDictionary(this string str)
+        {
+            var dictionary = new System.Collections.Generic.Dictionary<string, string>();
+            string[] nameValues = str.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            // If we haven't found any pipes, check for commas
+            if (nameValues.Count() == 1)
+            {
+                nameValues = str.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            foreach (string nameValue in nameValues)
+            {
+                string[] nameAndValue = nameValue.Split(new char[] { '^' }, 2);
+                if (nameAndValue.Count() == 2)
+                {
+                    dictionary[nameAndValue[0]] = nameAndValue[1];
+                }
+            }
+            return dictionary;
+        }
+
+        /// <summary>
+        /// Attempts to convert string to an dictionary using the |/comma and ^ delimter Key/Value syntax.  Returns null if unsuccessful.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <returns></returns>
+        [System.Diagnostics.DebuggerStepThrough()]
+        public static System.Collections.Generic.Dictionary<string, string> AsDictionaryOrNull(this string str)
+        {
+            var dictionary = AsDictionary(str);
+            if (dictionary.Count() > 0)
+            {
+                return dictionary;
+            }
+            return null;
+        }
+
+
+        /// <summary>
         /// Attempts to convert string to integer.  Returns 0 if unsuccessful.
         /// </summary>
         /// <param name="str">The STR.</param>

--- a/Rock/Utility/ExtensionMethods/StringExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/StringExtensions.cs
@@ -287,7 +287,7 @@ namespace Rock
         }
 
         /// <summary>
-        /// Attempts to convert string to an dictionary using the |/comma and ^ delimter Key/Value syntax.  Returns an empty dictionary if unsuccessful.
+        /// Attempts to convert string to an dictionary using the |/comma and ^ delimiter Key/Value syntax.  Returns an empty dictionary if unsuccessful.
         /// </summary>
         /// <param name="str">The string.</param>
         /// <returns></returns>
@@ -313,7 +313,7 @@ namespace Rock
         }
 
         /// <summary>
-        /// Attempts to convert string to an dictionary using the |/comma and ^ delimter Key/Value syntax.  Returns null if unsuccessful.
+        /// Attempts to convert string to an dictionary using the |/comma and ^ delimiter Key/Value syntax.  Returns null if unsuccessful.
         /// </summary>
         /// <param name="str">The string.</param>
         /// <returns></returns>


### PR DESCRIPTION
This adds AsDictionary and AsDictionaryOrNull to the string extensions.  The methods attempt to convert string to an dictionary using the |/comma and ^ delimiter Key/Value syntax.