### PR TITLE
Updated FormatAge to work properly for persons less than 1 year old.

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -1009,32 +1009,53 @@ namespace Rock.Model
             return null;
         }
 
-
         /// <summary>
         /// Formats the age with unit (year, month, day) suffix depending on the age of the individual. 
         /// </summary>
         /// <param name="condensed">if set to <c>true</c> age in years is returned without a unit suffix.</param>
         /// <returns></returns>
-        public string FormatAge( bool condensed = false)
+        public string FormatAge(bool condensed = false)
         {
             var age = Age;
-            if (age != null && age > 0 )
+            if (age != null)
             {
                 if (condensed)
                 {
                     return age.ToString();
                 }
-                return age  + (age == 1 ? " yr old " : " yrs old ");
+                if (age > 0)
+                {
+                    return age + (age == 1 ? " yr old " : " yrs old ");
+                }
             }
+
             var today = RockDateTime.Today;
-            if (BirthMonth != null && BirthMonth < today.Month)
+            if (BirthYear != null && BirthMonth != null)
             {
                 int months = today.Month - BirthMonth.Value;
-                return months + (months == 1 ? " mo old " : " mos old ");
+                if (BirthYear < today.Year)
+                {
+                    months = months + 12;
+                }
+                if (BirthDay > today.Day)
+                {
+                    months--;
+                }
+                if (months > 0)
+                {
+                    return months + (months == 1 ? " mo old " : " mos old ");
+                }
             }
-            if (BirthDay != null)
+
+            if (BirthYear != null && BirthMonth != null && BirthDay != null)
             {
                 int days = today.Day - BirthDay.Value;
+                if (days < 0)
+                {
+                    // Add the number of days in the birth month
+                    var birthMonth = new DateTime(BirthYear.Value, BirthMonth.Value, 1);
+                    days = days + birthMonth.AddMonths(1).AddDays(-1).Day;
+                }
                 return days + (days == 1 ? " day old " : " days old ");
             }
             return string.Empty;


### PR DESCRIPTION
Also updated the condensed option to return 0 rather than empty string if the age is less than 1.

Currently, when the current year is later than the birth year, but the age is 0, FormatAge would skip the month logic and go to the day logic. Example: Birthday 9/20/15, current day 5/24/16, FormatAge shows age as 4 days. Didn't test old functionality if the current day was before the birthday too but I suspect it would either return a negative number of days or just a blank. 

This new code has been tested with a range of birth dates and current dates and should produce correct results for all cases.