### PR TITLE
[EN] Adds a block option to Attendance History to set DidAttend by default

### DIFF
--- a/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
@@ -297,6 +297,7 @@ namespace RockWeb.Blocks.Checkin
             if ( string.IsNullOrEmpty( filterValue ) && filterAttendance )
             {
                 filterValue = "1";
+                rFilter.SaveUserPreference( "Attended", ddlDidAttend.SelectedValue );
             }
 
 

--- a/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
@@ -297,7 +297,7 @@ namespace RockWeb.Blocks.Checkin
             if ( string.IsNullOrEmpty( filterValue ) && filterAttendance )
             {
                 filterValue = "1";
-                rFilter.SaveUserPreference( "Attended", ddlDidAttend.SelectedValue );
+                rFilter.SaveUserPreference( "Attended", filterValue );
             }
 
 

--- a/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
@@ -192,7 +192,7 @@ namespace RockWeb.Blocks.Checkin
                         e.Value = "Did Not Attend";
                     }
                     else
-                    {   
+                    {
                         e.Value = null;
                     }
 
@@ -297,7 +297,6 @@ namespace RockWeb.Blocks.Checkin
             if ( string.IsNullOrEmpty( filterValue ) && filterAttendance )
             {
                 filterValue = "1";
-                //rFilter.
             }
 
 

--- a/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
@@ -24,6 +24,7 @@ using System.Web.UI.WebControls;
 
 using Rock;
 using Rock.Data;
+using Rock.Attribute;
 using Rock.Model;
 using Rock.Web.Cache;
 using Rock.Web.UI;
@@ -37,6 +38,7 @@ namespace RockWeb.Blocks.Checkin
     [DisplayName( "Attendance History" )]
     [Category( "Checkin" )]
     [Description( "Block for displaying the attendance history of a person or a group." )]
+    [BooleanField( "Filter Attendance By Default", "Sets the default display of Attended to Did Attend instead of [All]", false)]
     [ContextAware]
     public partial class AttendanceHistoryList : RockBlock
     {
@@ -190,7 +192,7 @@ namespace RockWeb.Blocks.Checkin
                         e.Value = "Did Not Attend";
                     }
                     else
-                    {
+                    {   
                         e.Value = null;
                     }
 
@@ -290,7 +292,16 @@ namespace RockWeb.Blocks.Checkin
 
             spSchedule.SetValue( rFilter.GetUserPreference( "Schedule" ).AsIntegerOrNull() );
 
-            ddlDidAttend.SetValue( rFilter.GetUserPreference( "Attended" ) );
+            string filterValue = rFilter.GetUserPreference( "Attended" );
+            var filterAttendance = GetAttributeValue( "FilterAttendanceByDefault" ).AsBoolean();
+            if ( string.IsNullOrEmpty( filterValue ) && filterAttendance )
+            {
+                filterValue = "1";
+                //rFilter.
+            }
+
+
+            ddlDidAttend.SetValue( filterValue );
         }
 
         private List<GroupTypePath> _groupTypePaths;


### PR DESCRIPTION
The only issue here is with the Grid Filter: I want to set the default value to DidAttend and have that visible *without* having to set the user preference, because if a user's preference is [All] then it gets reset to [Did Attend] on the next visit to the page.

However, since the [Grid Filter only reads from user preferences](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock/Web/UI/Controls/Grid/GridFilter.cs#L227) to display values, I can only override the user preference to have it visible.  

If I don't override the user's preference then the history is filtered without any clear visible indication (which as a user, I would consider a bug).