### PR TITLE
SendEmail: Use FullName in From field

### DIFF
--- a/Rock/Workflow/Action/Communications/SendEmail.cs
+++ b/Rock/Workflow/Action/Communications/SendEmail.cs
@@ -86,7 +86,7 @@ namespace Rock.Workflow.Action
                                     .FirstOrDefault();
                                 if ( person != null && !string.IsNullOrWhiteSpace( person.Email ) )
                                 {
-                                    from = person.Email;
+                                    from = string.Format("{0} <{1}>", person.FullName, person.Email);
                                 }
                             }
                         }


### PR DESCRIPTION
When the SendEmail action's From attribute is set to a person, it will use the FullName as the display name rather than just the email address: "First Last <Email>"