### PR TITLE
Fix lava error when referencing a null database value

### DIFF
--- a/RockWeb/App_Code/Global.asax.cs
+++ b/RockWeb/App_Code/Global.asax.cs
@@ -255,6 +255,7 @@ namespace RockWeb
                     Template.NamingConvention = new DotLiquid.NamingConventions.CSharpNamingConvention();
                     Template.FileSystem = new RockWeb.LavaFileSystem();
                     Template.RegisterSafeType( typeof( Enum ), o => o.ToString() );
+                    Template.RegisterSafeType( typeof( DBNull ), o => null );
                     Template.RegisterFilter( typeof( Rock.Lava.RockFilters ) );
 
                     // add call back to keep IIS process awake at night and to provide a timer for the queued transactions


### PR DESCRIPTION
This fixes the `Liquid syntax error: Object '' is invalid because it is neither a built-in type nor implements ILiquidizable` exception that gets thrown when getting a null DB value in, for example, the DynamicData block.