### PR TITLE
Fixes #1593 - No longer log values of sensitive attributes in person history.

### DIFF
--- a/Rock/Field/FieldType.cs
+++ b/Rock/Field/FieldType.cs
@@ -152,7 +152,18 @@ namespace Rock.Field
             // by default, get the formatted condensed value that would be displayed to the user
             return FormatValue( parentControl, value, configurationValues, true );
         }
-
+        
+        /// <summary>
+        /// Setting to determine whether the value from this control is sensitive.  This is used for determining
+        /// whether or not the value of this attribute is logged when changed.
+        /// </summary>
+        /// <returns>
+        ///   <c>false</c> By default, any field is not sensitive.
+        /// </returns>
+        public virtual bool IsSensitive()
+        {
+            return false;
+        }
         #endregion
 
         #region Edit Control

--- a/Rock/Field/IFieldType.cs
+++ b/Rock/Field/IFieldType.cs
@@ -103,6 +103,15 @@ namespace Rock.Field
         /// <returns></returns>
         object SortValue( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues );
 
+        /// <summary>
+        /// Setting to determine whether the value from this control is sensitive.  This is used for determining
+        /// whether or not the value of this attribute is logged when changed.
+        /// </summary>
+        /// <returns>
+        ///   <c>false</c> By default, any field is not sensitive.
+        /// </returns>
+        bool IsSensitive();
+
         #endregion
 
         #region Edit Control

--- a/Rock/Field/Types/EncryptedTextFieldType.cs
+++ b/Rock/Field/Types/EncryptedTextFieldType.cs
@@ -44,6 +44,18 @@ namespace Rock.Field.Types
             return base.FormatValue( parentControl, Encryption.DecryptString( value ), configurationValues, condensed );
         }
 
+        /// <summary>
+        /// Setting to determine whether the value from this control is sensitive.  This is used for determining
+        /// whether or not the value of this attribute is logged when changed.
+        /// </summary>
+        /// <returns>
+        ///   <c>false</c> By default, any field is not sensitive.
+        /// </returns>
+        public override bool IsSensitive()
+        {
+            return true;
+        }
+
         #endregion
 
         #region Edit Control

--- a/Rock/Model/History.cs
+++ b/Rock/Model/History.cs
@@ -204,7 +204,8 @@ namespace Rock.Model
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="newValue">The new value.</param>
-        public static void EvaluateChange( List<string> historyMessages, string propertyName, string oldValue, string newValue )
+        /// <param name="isSensitive">Indicator of whether the values are sensitive in nature and should not be logged.</param>
+        public static void EvaluateChange( List<string> historyMessages, string propertyName, string oldValue, string newValue, bool isSensitive = false )
         {
             if ( !string.IsNullOrWhiteSpace( oldValue ) )
             {
@@ -212,17 +213,39 @@ namespace Rock.Model
                 {
                     if ( oldValue.Trim() != newValue.Trim() )
                     {
-                        historyMessages.Add( string.Format( "Modified <span class='field-name'>{0}</span> value from <span class='field-value'>{1}</span> to <span class='field-value'>{2}</span>.", propertyName, oldValue, newValue ) );
+                        if ( isSensitive )
+                        {
+                            historyMessages.Add( string.Format( "Modified <span class='field-name'>{0}</span> value (Sensitive attribute values are not logged in history).", propertyName ) );
+                        }
+                        else
+                        {
+                            historyMessages.Add( string.Format( "Modified <span class='field-name'>{0}</span> value from <span class='field-value'>{1}</span> to <span class='field-value'>{2}</span>.", propertyName, oldValue, newValue ) );
+
+                        }
                     }
                 }
                 else
                 {
-                    historyMessages.Add( string.Format( "Deleted <span class='field-name'>{0}</span> value of <span class='field-value'>{1}</span>.", propertyName, oldValue ) );
+                    if ( isSensitive )
+                    {
+                        historyMessages.Add( string.Format( "Deleted <span class='field-name'>{0}</span> value (Sensitive attribute values are not logged in history).", propertyName ) );
+                    }
+                    else
+                    {
+                        historyMessages.Add( string.Format( "Deleted <span class='field-name'>{0}</span> value of <span class='field-value'>{1}</span>.", propertyName, oldValue ) );
+                    }
                 }
             }
             else if ( !string.IsNullOrWhiteSpace( newValue ) )
             {
-                historyMessages.Add( string.Format( "Added <span class='field-name'>{0}</span> value of <span class='field-value'>{1}</span>.", propertyName, newValue ) );
+                if ( isSensitive )
+                {
+                    historyMessages.Add( string.Format( "Added <span class='field-name'>{0}</span> value (Sensitive attribute values are not logged in history).", propertyName ) );
+                }
+                else
+                { 
+                    historyMessages.Add( string.Format( "Added <span class='field-name'>{0}</span> value of <span class='field-value'>{1}</span>.", propertyName, newValue ) );
+                }
             }
         }
 
@@ -233,11 +256,13 @@ namespace Rock.Model
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="newValue">The new value.</param>
-        public static void EvaluateChange( List<string> historyMessages, string propertyName, int? oldValue, int? newValue )
+        /// <param name="isSensitive">Indicator of whether the values are sensitive in nature and should not be logged.</param>
+        public static void EvaluateChange( List<string> historyMessages, string propertyName, int? oldValue, int? newValue, bool isSensitive = false)
         {
             EvaluateChange( historyMessages, propertyName,
                 oldValue.HasValue ? oldValue.Value.ToString() : string.Empty,
-                newValue.HasValue ? newValue.Value.ToString() : string.Empty );
+                newValue.HasValue ? newValue.Value.ToString() : string.Empty,
+                isSensitive );
         }
 
         /// <summary>
@@ -247,11 +272,13 @@ namespace Rock.Model
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="newValue">The new value.</param>
-        public static void EvaluateChange( List<string> historyMessages, string propertyName, decimal? oldValue, decimal? newValue )
+        /// <param name="isSensitive">Indicator of whether the values are sensitive in nature and should not be logged.</param>
+        public static void EvaluateChange( List<string> historyMessages, string propertyName, decimal? oldValue, decimal? newValue, bool isSensitive = false )
         {
             EvaluateChange( historyMessages, propertyName,
                 oldValue.HasValue ? oldValue.Value.ToString("N2") : string.Empty,
-                newValue.HasValue ? newValue.Value.ToString("N2") : string.Empty );
+                newValue.HasValue ? newValue.Value.ToString("N2") : string.Empty,
+                isSensitive );
         }
 
         /// <summary>
@@ -262,7 +289,8 @@ namespace Rock.Model
         /// <param name="oldValue">The old value.</param>
         /// <param name="newValue">The new value.</param>
         /// <param name="includeTime">if set to <c>true</c> [include time].</param>
-        public static void EvaluateChange( List<string> historyMessages, string propertyName, DateTime? oldValue, DateTime? newValue, bool includeTime = false )
+        /// <param name="isSensitive">Indicator of whether the values are sensitive in nature and should not be logged.</param>
+        public static void EvaluateChange( List<string> historyMessages, string propertyName, DateTime? oldValue, DateTime? newValue, bool includeTime = false, bool isSensitive = false )
         {
             string oldStringValue = string.Empty;
             if ( oldValue.HasValue )
@@ -276,7 +304,7 @@ namespace Rock.Model
                 newStringValue = includeTime ? newValue.Value.ToString() : newValue.Value.ToShortDateString();
             }
 
-            EvaluateChange( historyMessages, propertyName, oldStringValue, newStringValue );
+            EvaluateChange( historyMessages, propertyName, oldStringValue, newStringValue, isSensitive );
         }
 
         /// <summary>
@@ -286,11 +314,13 @@ namespace Rock.Model
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="oldValue">if set to <c>true</c> [old value].</param>
         /// <param name="newValue">if set to <c>true</c> [new value].</param>
-        public static void EvaluateChange( List<string> historyMessages, string propertyName, bool? oldValue, bool? newValue )
+        /// <param name="isSensitive">Indicator of whether the values are sensitive in nature and should not be logged.</param>
+        public static void EvaluateChange( List<string> historyMessages, string propertyName, bool? oldValue, bool? newValue, bool isSensitive = false )
         {
             EvaluateChange( historyMessages, propertyName,
                 oldValue.HasValue ? oldValue.Value.ToString() : string.Empty,
-                newValue.HasValue ? newValue.Value.ToString() : string.Empty );
+                newValue.HasValue ? newValue.Value.ToString() : string.Empty, 
+                isSensitive );
         }
 
         /// <summary>
@@ -300,11 +330,12 @@ namespace Rock.Model
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="newValue">The new value.</param>
-        public static void EvaluateChange( List<string> historyMessages, string propertyName, Enum oldValue, Enum newValue )
+        /// <param name="isSensitive">Indicator of whether the values are sensitive in nature and should not be logged.</param>
+        public static void EvaluateChange( List<string> historyMessages, string propertyName, Enum oldValue, Enum newValue, bool isSensitive = false )
         {
             string oldStringValue = oldValue != null ? oldValue.ConvertToString() : string.Empty;
             string newStringValue = newValue != null ? newValue.ConvertToString() : string.Empty;
-            EvaluateChange( historyMessages, propertyName, oldStringValue, newStringValue );
+            EvaluateChange( historyMessages, propertyName, oldStringValue, newStringValue, isSensitive );
         }
 
         #endregion

--- a/Rock/Workflow/Action/People/SetPersonAttribute.cs
+++ b/Rock/Workflow/Action/People/SetPersonAttribute.cs
@@ -116,7 +116,7 @@ namespace Rock.Workflow.Action
                                                     formattedNewValue = attribute.FieldType.Field.FormatValue( null, updateValue, attribute.QualifierValues, false );
                                                 }
 
-                                                History.EvaluateChange( changes, attribute.Name, formattedOriginalValue, formattedNewValue );
+                                                History.EvaluateChange( changes, attribute.Name, formattedOriginalValue, formattedNewValue, attribute.FieldType.Field.IsSensitive() );
                                                 if ( changes.Any() )
                                                 {
                                                     HistoryService.SaveChanges( rockContext, typeof( Person ), 

--- a/RockWeb/Blocks/Crm/PersonDetail/AttributeValues.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/AttributeValues.ascx.cs
@@ -253,7 +253,8 @@ namespace RockWeb.Blocks.Crm.PersonDetail
                                         formattedNewValue = attribute.FieldType.Field.FormatValue( null, newValue, attribute.QualifierValues, false );
                                     }
 
-                                    History.EvaluateChange( changes, attribute.Name, formattedOriginalValue, formattedNewValue );
+                                    
+                                    History.EvaluateChange( changes, attribute.Name, formattedOriginalValue, formattedNewValue, attribute.FieldType.Field.IsSensitive());
                                 }
                             }
                         }


### PR DESCRIPTION
- Adding a setting in FieldType which allows for specifying that a field type is sensitive
- Checking the sensitive setting when logging attribute value in the person history to make sure we don't log values for sensitive field types.