### PR TITLE
Fixed nav from showing text selection cursor

### DIFF
--- a/RockWeb/Themes/Rock/Styles/theme.less
+++ b/RockWeb/Themes/Rock/Styles/theme.less
@@ -692,6 +692,7 @@ body#splash {
     margin-top: 24px;
     display: inline-block;
     width: 100%;
+    cursor: default;
 
     & > li {
       text-align: center;


### PR DESCRIPTION
Fixed so side nav no longer shows the text selection cursor on on non-clickable headers (and the font awesome icons in IE/Edge)