### PR TITLE
- Added a 'Summary' textbox to the Transaction Matching block.

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionMatching.ascx
+++ b/RockWeb/Blocks/Finance/TransactionMatching.ascx
@@ -92,6 +92,7 @@
                             <%-- note: using disabled instead of readonly so that we can set the postback value in javascript --%>
                             <Rock:CurrencyBox ID="cbTotalAmount" runat="server" Label="Total Amount" CssClass="js-total-amount" Help="Allocates amounts to the above account(s) until the total amount matches what is shown on the transaction image." disabled="disabled" Text="0.00"></Rock:CurrencyBox>
 
+                            <Rock:RockTextBox ID="tbSummary" runat="server" Label="Summary" TextMode="MultiLine" Rows="2" />
                         </div>
                     </div>
 

--- a/RockWeb/Blocks/Finance/TransactionMatching.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionMatching.ascx.cs
@@ -435,6 +435,8 @@ namespace RockWeb.Blocks.Finance
                         }
                     }
 
+                    tbSummary.Text = transactionToMatch.Summary;
+
                     if ( transactionToMatch.Images.Any() )
                     {
                         var primaryImage = transactionToMatch.Images
@@ -704,6 +706,8 @@ namespace RockWeb.Blocks.Finance
                         History.EvaluateChange( changes, accountBox.Label, 0.0M.FormatAsCurrency(), amount.Value.FormatAsCurrency() );
                     }
                 }
+
+                financialTransaction.Summary = tbSummary.Text;
 
                 financialTransaction.ProcessedByPersonAliasId = this.CurrentPersonAlias.Id;
                 financialTransaction.ProcessedDateTime = RockDateTime.Now;


### PR DESCRIPTION
This allows a user to write down notes about a transaction as they're matching it, rather than having to match it and then track it down again to write a note.
![image](https://cloud.githubusercontent.com/assets/5482014/17190900/79f914ae-53fc-11e6-90fb-4bad1d962ef1.png)
