### PR TITLE
+ Made Metric Partitions accessible via Lava (fixes #1644)

### DIFF
--- a/Rock/Model/Metric.cs
+++ b/Rock/Model/Metric.cs
@@ -186,6 +186,7 @@ namespace Rock.Model
         /// <value>
         /// The metric partitions.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<MetricPartition> MetricPartitions { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Part of #1644 mentioned editing the Group Picker to filter by GroupType.  This would apply when your MetricPartition is EntityType `Group`, EntityTypeQualifierColumn is `GroupTypeId`, and EntityTypeQualifier is a GroupTypeId.  

The automatically generated control that displays on [MetricValueDetail](https://github.com/SparkDevNetwork/Rock/blob/develop/RockWeb/Blocks/Reporting/MetricValueDetail.ascx#L38) should limit the list of Groups to the specified GroupType.