### PR TITLE
Changed grid filter to advanced mode.

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
@@ -867,8 +867,8 @@ namespace RockWeb.Blocks.Event
                         {
                             try
                             {
-                                var values = attribute.FieldType.Field.GetFilterValues( filterControl, field.Attribute.QualifierValues, Rock.Reporting.FilterMode.SimpleFilter );
-                                fRegistrants.SaveUserPreference( attribute.Key, attribute.Name, attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.SimpleFilter ).ToJson() );
+                                var values = attribute.FieldType.Field.GetFilterValues( filterControl, field.Attribute.QualifierValues, Rock.Reporting.FilterMode.AdvancedFilter );
+                                fRegistrants.SaveUserPreference( attribute.Key, attribute.Name, attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.AdvancedFilter ).ToJson() );
                             }
                             catch { }
                         }
@@ -2342,7 +2342,7 @@ namespace RockWeb.Blocks.Event
                                 var filterControl = phRegistrantFormFieldFilters.FindControl( "filter_" + attribute.Id.ToString() );
                                 if ( filterControl != null )
                                 {
-                                    var filterValues = attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.SimpleFilter );
+                                    var filterValues = attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.AdvancedFilter );
                                     var expression = attribute.FieldType.Field.AttributeFilterExpression( attribute.QualifierValues, filterValues, parameterExpression );
                                     if ( expression != null )
                                     {
@@ -2376,7 +2376,7 @@ namespace RockWeb.Blocks.Event
                                 var filterControl = phRegistrantFormFieldFilters.FindControl( "filter_" + attribute.Id.ToString() );
                                 if ( filterControl != null )
                                 {
-                                    var filterValues = attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.SimpleFilter );
+                                    var filterValues = attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.AdvancedFilter );
                                     var expression = attribute.FieldType.Field.AttributeFilterExpression( attribute.QualifierValues, filterValues, parameterExpression );
                                     if ( expression != null )
                                     {
@@ -2410,7 +2410,7 @@ namespace RockWeb.Blocks.Event
                                 var filterControl = phRegistrantFormFieldFilters.FindControl( "filter_" + attribute.Id.ToString() );
                                 if ( filterControl != null )
                                 {
-                                    var filterValues = attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.SimpleFilter );
+                                    var filterValues = attribute.FieldType.Field.GetFilterValues( filterControl, attribute.QualifierValues, Rock.Reporting.FilterMode.AdvancedFilter );
                                     var expression = attribute.FieldType.Field.AttributeFilterExpression( attribute.QualifierValues, filterValues, parameterExpression );
                                     if ( expression != null )
                                     {
@@ -2887,7 +2887,7 @@ namespace RockWeb.Blocks.Event
                     else if ( field.Attribute != null )
                     {
                         var attribute = field.Attribute;
-                        var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
+                        var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.AdvancedFilter );
                         if ( control != null )
                         {
                             if ( control is IRockControl )


### PR DESCRIPTION
Switching to advanced filter mode fixes an issue where some registration attributes do not show a valid filter attached to it.