### PR TITLE
Changed Device Detail block label.

### DIFF
--- a/RockWeb/Blocks/Core/DeviceDetail.ascx.cs
+++ b/RockWeb/Blocks/Core/DeviceDetail.ascx.cs
@@ -443,6 +443,17 @@ namespace RockWeb.Blocks.Core
         {
             var checkinKioskDeviceTypeId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.DEVICE_TYPE_CHECKIN_KIOSK ).Id;
             pnlPrinterSettings.Visible = ( ddlDeviceType.SelectedValue.AsIntegerOrNull() == checkinKioskDeviceTypeId );
+            
+            if (ddlDeviceType.SelectedValue.AsIntegerOrNull() == DefinedValueCache.Read(Rock.SystemGuid.DefinedValue.DEVICE_TYPE_PRINTER).Id)
+            {
+                tbIpAddress.Label = "IP Address/Hostname";
+                tbIpAddress.Help = "What is the IP Address/Hostname of this printer?";
+            }
+            else
+            {
+                tbIpAddress.Label = "IP Address";
+                tbIpAddress.Help = "What is the IP Address of this device?";
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
If a printer can be setup using it's IP Address and DNS hostname, changing the wording on the Label and Help textbox attributes will make these options clear to the user.