### PR TITLE
+ Adds a block to allow editing of user's account and family from the home page

### DIFF
--- a/Rock/Attribute/AttributeFieldAttribute.cs
+++ b/Rock/Attribute/AttributeFieldAttribute.cs
@@ -17,7 +17,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Web;
+using Rock.Web.Cache;
 
 namespace Rock.Attribute
 {
@@ -29,6 +31,8 @@ namespace Rock.Attribute
     {
         private const string ENTITY_TYPE_KEY = "entitytype";
         private const string ALLOW_MULTIPLE_KEY = "allowmultiple";
+        private const string QUALIFIER_COLUMN_KEY = "qualifierColumn";
+        private const string QUALIFIER_VALUE_KEY = "qualifierValue";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AttributeFieldAttribute" /> class.
@@ -50,6 +54,73 @@ namespace Rock.Attribute
 
             var allowMultipleConfigValue = new Field.ConfigurationValue( allowMultiple.ToString() );
             FieldConfigurationValues.Add( ALLOW_MULTIPLE_KEY, allowMultipleConfigValue );
+
+            if ( string.IsNullOrWhiteSpace( Name ) )
+            {
+                var entityType = Rock.Web.Cache.EntityTypeCache.Read( new Guid( entityTypeGuid ) );
+                name = ( entityType != null ? entityType.Name : "Entity" ) + " Attribute";
+            }
+
+            if ( string.IsNullOrWhiteSpace( Key ) )
+            {
+                Key = Name.Replace( " ", string.Empty );
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AttributeFieldAttribute"/> class.
+        /// </summary>
+        /// <param name="entityTypeGuid">The entity type unique identifier.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="description">The description.</param>
+        /// <param name="entityTypeQualifierColumn">The entity type qualifier column.</param>
+        /// <param name="entityTypeQualifierValue">The entity type qualifier value.</param>
+        /// <param name="required">if set to <c>true</c> [required].</param>
+        /// <param name="allowMultiple">if set to <c>true</c> [allow multiple].</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <param name="category">The category.</param>
+        /// <param name="order">The order.</param>
+        /// <param name="key">The key.</param>
+        public AttributeFieldAttribute( string entityTypeGuid, string entityTypeQualifierColumn, string entityTypeQualifierValue, string name, string description = "", bool required = true, bool allowMultiple = false, string defaultValue = "", string category = "", int order = 0, string key = null )
+            : base( name, description, required, defaultValue, category, order, key, typeof( Rock.Field.Types.AttributeFieldType ).FullName )
+        {
+            var entityTypeConfigValue = new Field.ConfigurationValue( entityTypeGuid );
+            FieldConfigurationValues.Add( ENTITY_TYPE_KEY, entityTypeConfigValue );
+
+            var allowMultipleConfigValue = new Field.ConfigurationValue( allowMultiple.ToString() );
+            FieldConfigurationValues.Add( ALLOW_MULTIPLE_KEY, allowMultipleConfigValue );
+
+            var entityTypeQualifierColumnConfigValue = new Field.ConfigurationValue( entityTypeQualifierColumn );
+            FieldConfigurationValues.Add( QUALIFIER_COLUMN_KEY, entityTypeQualifierColumnConfigValue );
+
+            if ( entityTypeQualifierColumn.EndsWith( "Id" ) && entityTypeQualifierValue.AsGuid() != Guid.Empty )
+            {
+                EntityTypeCache itemEntityType = EntityTypeCache.Read( "Rock.Model." + entityTypeQualifierColumn.Left( entityTypeQualifierColumn.Length - 2 ) );
+                if ( itemEntityType.AssemblyName != null )
+                {
+                    // get the actual type of what is being followed 
+                    Type entityType = itemEntityType.GetEntityType();
+                    if ( entityType != null )
+                    {
+                        var dbContext = Reflection.GetDbContextForEntityType( entityType );
+                        if ( dbContext != null )
+                        {
+                            var serviceInstance = Reflection.GetServiceForEntityType( entityType, dbContext );
+                            if ( serviceInstance != null )
+                            {
+                                MethodInfo getMethod = serviceInstance.GetType().GetMethod( "Get", new Type[] { typeof( Guid ) } );
+                                var entity = getMethod.Invoke( serviceInstance, new object[] { entityTypeQualifierValue.AsGuid() } ) as Rock.Data.IEntity;
+                                FieldConfigurationValues.Add( QUALIFIER_VALUE_KEY, new Field.ConfigurationValue( entity.Id.ToString() ) );
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var entityTypeQualifierValueConfigValue = new Field.ConfigurationValue( entityTypeQualifierValue );
+                FieldConfigurationValues.Add( QUALIFIER_VALUE_KEY, entityTypeQualifierValueConfigValue );
+            }
 
             if ( string.IsNullOrWhiteSpace( Name ) )
             {

--- a/RockWeb/Blocks/Cms/PublicProfileEdit.ascx
+++ b/RockWeb/Blocks/Cms/PublicProfileEdit.ascx
@@ -1,0 +1,282 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="PublicProfileEdit.ascx.cs" Inherits="RockWeb.Blocks.Cms.PublicProfileEdit" %>
+
+<script>
+    $(function () {
+        $(".photo a").fluidbox();
+    });
+</script>
+
+<div class="panel panel-block">
+    <div class="panel-heading">
+        <h1 class="panel-title"><i class="fa fa-user"></i>My Account</h1>
+    </div>
+    <div class="panel-body">
+        <asp:HiddenField ID="hfPersonId" runat="server" />
+        <asp:Panel ID="pnlView" runat="server">
+            <div class="row">
+
+                <div class="col-sm-3">
+                    <div class="photo">
+                        <asp:Literal ID="lImage" runat="server" />
+                    </div>
+                </div>
+
+                <div class="col-sm-9">
+                    <h1 class="title name">
+                        <asp:Literal ID="lName" runat="server" /><div class="pull-right">
+                            <Rock:RockDropDownList ID="ddlGroup" runat="server" DataTextField="Name" DataValueField="Id" OnSelectedIndexChanged="ddlGroup_SelectedIndexChanged" AutoPostBack="true" Visible="false" />
+                        </div>
+                    </h1>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <ul class="person-demographics list-unstyled">
+                                <li>
+                                    <asp:Literal ID="lAge" runat="server" /></li>
+                                <li>
+                                    <asp:Literal ID="lGender" runat="server" /></li>
+                                <li>
+                                    <asp:Literal ID="lMaritalStatus" runat="server" /></li>
+                                <li>
+                                    <asp:Literal ID="lGrade" runat="server" /></li>
+                            </ul>
+                        </div>
+                        <div class="col-md-6">
+                            <ul class="phone-list list-unstyled">
+                                <asp:Repeater ID="rptPhones" runat="server">
+                                    <ItemTemplate>
+                                        <li><%# (bool)Eval("IsUnlisted") ? "Unlisted" : FormatPhoneNumber( Eval("CountryCode"), Eval("Number") ) %> <small><%# Eval("NumberTypeValue.Value") %></small></li>
+                                    </ItemTemplate>
+                                </asp:Repeater>
+                            </ul>
+                            <asp:Literal ID="lEmail" runat="server" />
+                        </div>
+                    </div>
+                    <asp:Literal ID="lAddress" runat="server" />
+                    <br />
+                    <div class="row">
+                        <asp:Repeater ID="rptPersonAttributes" runat="server">
+                            <ItemTemplate>
+                                <div class="col-md-6">
+                                    <b><%# Eval("Name") %></b></br><small><%# Eval("Value") %></small>
+                                </div>
+                            </ItemTemplate>
+                        </asp:Repeater>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <asp:Literal ID="lFamilyHeader" runat="server" Text="<h4>Family Information</h4>" Visible="false" />
+                        </div>
+                        <asp:Repeater ID="rptGroupAttributes" runat="server">
+                            <ItemTemplate>
+                                <div class="col-md-6">
+                                    <b><%# Eval("Name") %></b></br><small><%# Eval("Value") %></small>
+                                </div>
+                            </ItemTemplate>
+                        </asp:Repeater>
+                    </div>
+                    <br />
+                    <asp:LinkButton ID="lbEditPerson" runat="server" CssClass="btn btn-primary btn-xs" OnClick="lbEditPerson_Click" CausesValidation="false"> Update</asp:LinkButton>
+                </div>
+            </div>
+            <hr />
+
+            <h3>
+                <asp:Literal ID="lGroupName" runat="server" />
+            </h3>
+            <asp:Repeater ID="rptGroupMembers" runat="server" OnItemDataBound="rptGroupMembers_ItemDataBound" OnItemCommand="rptGroupMembers_ItemCommand">
+                <ItemTemplate>
+                    <div class="row">
+                        <div class="col-md-1">
+                            <div class="photo">
+                                <asp:Literal ID="lGroupMemberImage" runat="server" />
+                            </div>
+                        </div>
+                        <div class="col-md-11">
+                            <div class="row">
+                                <div class="col-md-3">
+                                    <b>
+                                        <asp:Literal ID="lGroupMemberName" runat="server" /></b>
+                                </div>
+                                <div class="col-md-4">
+                                    <ul class="person-demographics list-unstyled">
+                                        <li>
+                                            <asp:Literal ID="lAge" runat="server" /></li>
+                                        <li>
+                                            <asp:Literal ID="lGender" runat="server" /></li>
+                                        <li>
+                                            <asp:Literal ID="lMaritalStatus" runat="server" /></li>
+                                        <li>
+                                            <asp:Literal ID="lGrade" runat="server" /></li>
+                                    </ul>
+                                </div>
+                                <div class="col-md-4">
+                                    <ul class="phone-list list-unstyled">
+                                        <asp:Repeater ID="rptGroupMemberPhones" runat="server">
+                                            <ItemTemplate>
+                                                <li><%# (bool)Eval("IsUnlisted") ? "Unlisted" : FormatPhoneNumber( Eval("CountryCode"), Eval("Number") ) %> <small><%# Eval("NumberTypeValue.Value") %></small></li>
+                                            </ItemTemplate>
+                                        </asp:Repeater>
+                                    </ul>
+                                    <asp:Literal ID="lGroupMemberEmail" runat="server" />
+                                </div>
+                            </div>
+                            <div class="row">
+                                <asp:Repeater ID="rptGroupMemberAttributes" runat="server">
+                                    <ItemTemplate>
+                                        <div class="col-md-6">
+                                            <b><%# Eval("Name") %></b></br><small><%# Eval("Value") %></small>
+                                        </div>
+                                    </ItemTemplate>
+                                </asp:Repeater>
+                            </div>
+                            <div class="row pull-right">
+                                <asp:LinkButton ID="lbEditGroupMember" runat="server" CssClass="btn btn-primary btn-xs" CommandArgument='<%# Eval("PersonId") %>' CommandName="Update"> Update</asp:LinkButton>
+                            </div>
+                        </div>
+                    </div>
+                    <br />
+                </ItemTemplate>
+            </asp:Repeater>
+            <asp:LinkButton ID="lbAddGroupMember" runat="server" CssClass="btn btn-primary btn-xs" OnClick="lbAddGroupMember_Click"> Add New Family Member</asp:LinkButton>
+
+            <asp:LinkButton ID="lbRequestChanges" runat="server" CssClass="btn btn-primary btn-xs" OnClick="lbRequestChanges_Click"> Request Additional Changes</asp:LinkButton>
+        </asp:Panel>
+
+        <asp:Panel ID="pnlEdit" runat="server">
+            <asp:ValidationSummary ID="valValidation" runat="server" HeaderText="Please Correct the Following" CssClass="alert alert-danger" />
+            <div class="row">
+
+                <div class="col-md-3">
+                    <Rock:ImageEditor ID="imgPhoto" runat="server" Label="Photo" BinaryFileTypeGuid="03BD8476-8A9F-4078-B628-5B538F967AFC" />
+                </div>
+
+                <div class="col-md-9">
+                    <Rock:RockDropDownList ID="ddlTitle" runat="server" CssClass="input-width-md" Label="Title" />
+                    <Rock:DataTextBox ID="tbFirstName" runat="server" SourceTypeName="Rock.Model.Person, Rock" PropertyName="FirstName" Required="true" />
+                    <Rock:DataTextBox ID="tbNickName" runat="server" SourceTypeName="Rock.Model.Person, Rock" PropertyName="NickName" />
+                    <Rock:DataTextBox ID="tbLastName" runat="server" SourceTypeName="Rock.Model.Person, Rock" PropertyName="LastName" Required="true" />
+                    <Rock:RockDropDownList ID="ddlSuffix" CssClass="input-width-md" runat="server" Label="Suffix" />
+                    <Rock:BirthdayPicker ID="bpBirthDay" runat="server" Label="Birthday" />
+                    <Rock:RockRadioButtonList ID="rblRole" runat="server" DataTextField="Name" DataValueField="Id" RepeatDirection="Horizontal" Label="Role" Visible="false" AutoPostBack="true" OnSelectedIndexChanged="rblRole_SelectedIndexChanged" />
+                    <div class="row">
+                        <div class="col-md-6">
+                            <Rock:RockRadioButtonList ID="rblGender" runat="server" RepeatDirection="Horizontal" Label="Gender" Required="true">
+                                <asp:ListItem Text="Male" Value="Male" />
+                                <asp:ListItem Text="Female" Value="Female" />
+                                <asp:ListItem Text="Unknown" Value="Unknown" />
+                            </Rock:RockRadioButtonList>
+                        </div>
+                        <div class="col-md-6">
+                            <Rock:YearPicker ID="ypGraduation" runat="server" Label="Graduation Year" Help="High School Graduation Year." Visible="false" />
+                            <Rock:GradePicker ID="ddlGradePicker" runat="server" Label="Grade" UseAbbreviation="true" UseGradeOffsetAsValue="true" Visible="false" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <hr />
+
+            <asp:Panel ID="pnlPersonAttributes" runat="server">
+                <div class="panel-heading clearfix">
+                    <h4 class="panel-title pull-left">Additional Information</h4>
+                </div>
+                <div class="panel-body">
+                    <asp:PlaceHolder ID="phPersonAttributes" runat="server" EnableViewState="false"></asp:PlaceHolder>
+                </div>
+                <hr />
+            </asp:Panel>
+
+            <asp:Panel ID="pnlFamilyAttributes" runat="server">
+                <div class="panel-heading clearfix">
+                    <h4 class="panel-title pull-left">Family Information</h4>
+                </div>
+                <div class="panel-body">
+                    <asp:PlaceHolder ID="phFamilyAttributes" runat="server" EnableViewState="false"></asp:PlaceHolder>
+                </div>
+                <hr />
+            </asp:Panel>
+
+            <h3>Contact Info</h3>
+            <div class="form-horizontal">
+                <asp:Repeater ID="rContactInfo" runat="server">
+                    <ItemTemplate>
+                        <div class="form-group">
+                            <div class="control-label col-md-2"><%# Eval("NumberTypeValue.Value")  %></div>
+                            <div class="controls col-md-10">
+                                <div class="row">
+                                    <div class="col-md-7">
+                                        <asp:HiddenField ID="hfPhoneType" runat="server" Value='<%# Eval("NumberTypeValueId")  %>' />
+                                        <Rock:PhoneNumberBox ID="pnbPhone" runat="server" CountryCode='<%# Eval("CountryCode")  %>' Number='<%# Eval("NumberFormatted")  %>' />
+                                    </div>
+                                    <div class="col-md-5">
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <asp:CheckBox ID="cbSms" runat="server" Text="SMS" Checked='<%# (bool)Eval("IsMessagingEnabled") %>' CssClass="js-sms-number" />
+                                            </div>
+                                            <div class="col-md-6">
+                                                <asp:CheckBox ID="cbUnlisted" runat="server" Text="Unlisted" Checked='<%# (bool)Eval("IsUnlisted") %>' />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </ItemTemplate>
+                </asp:Repeater>
+
+                <div class="form-group">
+                    <div class="control-label col-md-2">Email</div>
+                    <div class="controls col-md-10">
+                        <Rock:DataTextBox ID="tbEmail" PrependText="<i class='fa fa-envelope'></i>" runat="server" SourceTypeName="Rock.Model.Person, Rock" PropertyName="Email" Label="" />
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="controls col-md-10 col-md-offset-2">
+                        <Rock:RockRadioButtonList ID="rblEmailPreference" runat="server" RepeatDirection="Horizontal" Label="Email Preference">
+                            <asp:ListItem Text="Email Allowed" Value="EmailAllowed" />
+                            <asp:ListItem Text="No Mass Emails" Value="NoMassEmails" />
+                            <asp:ListItem Text="Do Not Email" Value="DoNotEmail" />
+                        </Rock:RockRadioButtonList>
+                    </div>
+                </div>
+            </div>
+
+            <asp:Panel ID="pnlAddress" runat="server">
+                <fieldset>
+                    <legend>
+                        <asp:Literal ID="lAddressTitle" runat="server" /></legend>
+
+                    <div class="clearfix">
+                        <div class="pull-left margin-b-md">
+                            <asp:Literal ID="lPreviousAddress" runat="server" />
+                        </div>
+                        <div class="pull-right">
+                            <asp:LinkButton ID="lbMoved" CssClass="btn btn-default btn-xs" runat="server" OnClick="lbMoved_Click"><i class="fa fa-truck"></i> Moved</asp:LinkButton>
+                        </div>
+                    </div>
+
+                    <asp:HiddenField ID="hfStreet1" runat="server" />
+                    <asp:HiddenField ID="hfStreet2" runat="server" />
+                    <asp:HiddenField ID="hfCity" runat="server" />
+                    <asp:HiddenField ID="hfState" runat="server" />
+                    <asp:HiddenField ID="hfPostalCode" runat="server" />
+                    <asp:HiddenField ID="hfCountry" runat="server" />
+
+                    <Rock:AddressControl ID="acAddress" runat="server" RequiredErrorMessage="Your Address is Required" />
+
+                    <div class="margin-b-md">
+                        <Rock:RockCheckBox ID="cbIsMailingAddress" runat="server" Text="This is my mailing address" Checked="true" />
+                        <Rock:RockCheckBox ID="cbIsPhysicalAddress" runat="server" Text="This is my physical address" Checked="true" />
+                    </div>
+                </fieldset>
+            </asp:Panel>
+
+            <div class="actions">
+                <asp:LinkButton ID="btnSave" runat="server" AccessKey="s" Text="Save" CssClass="btn btn-primary" OnClick="btnSave_Click" />
+                <asp:LinkButton ID="btnCancel" runat="server" AccessKey="c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="btnCancel_Click" />
+            </div>
+
+        </asp:Panel>
+    </div>
+</div>

--- a/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
+++ b/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
@@ -1,0 +1,1157 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace RockWeb.Blocks.Cms
+{
+    /// <summary>
+    /// The main Person Profile block the main information about a peron 
+    /// </summary>
+    [DisplayName( "Public Profile Edit" )]
+    [Category( "CMS" )]
+    [Description( "Public block for users to manage their accounts" )]
+
+    [BooleanField( "Show Family Members", "Whether family members are shown or not.", true, order: 0 )]
+    [DefinedValueField( "2E6540EA-63F0-40FE-BE50-F2A84735E600", "Connection Status", "The connection status to use for new individuals (default: 'Web Prospect'.)", true, false, "368DD475-242C-49C4-A42C-7278BE690CC2", order: 1 )]
+    [DefinedValueField( "8522BADD-2871-45A5-81DD-C76DA07E2E7E", "Record Status", "The record status to use for new individuals (default: 'Pending'.)", true, false, "283999EC-7346-42E3-B807-BCE9B2BABB49", order: 2 )]
+    [GroupLocationTypeField( Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY, "Address Type",
+        "The type of address to be displayed / edited.", false, Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME, "", order: 3 )]
+    [DefinedValueField( Rock.SystemGuid.DefinedType.PERSON_PHONE_TYPE, "Phone Numbers", "The types of phone numbers to display / edit.", true, true, Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_HOME, order: 4 )]
+    [LinkedPage( "Workflow Launch Page", "Page used to launch the workflow to make a profile change request", true, order: 5 )]
+    [AttributeField( Rock.SystemGuid.EntityType.GROUP, "GroupTypeId", Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY, "Family Attributes", "The family attributes that should be displayed / edited.", false, true, order: 6)]
+    [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Attributes (adults)", "The person attributes that should be displayed / edited for adults.", false, true, order: 7 )]
+    [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Attributes (children)", "The person attributes that should be displayed / edited for children.", false, true, order: 8 )]
+
+
+    public partial class PublicProfileEdit : RockBlock
+    {
+        #region Base Control Methods
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {        
+            base.OnInit( e );
+            ScriptManager.RegisterStartupScript( ddlGradePicker, ddlGradePicker.GetType(), "grade-selection-" + BlockId.ToString(), ddlGradePicker.GetJavascriptForYearPicker( ypGraduation ), true );
+
+            RockPage.AddCSSLink( ResolveRockUrl( "~/Styles/fluidbox.css" ) );
+            //RockPage.AddScriptLink( ResolveRockUrl( "~/Scripts/imagesloaded.min.js" ) );
+            RockPage.AddScriptLink( ResolveRockUrl( "~/Scripts/jquery.fluidbox.min.js" ) );
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+            if ( !Page.IsPostBack )
+            {
+                BindFamilies();
+            }
+            else
+            {
+                var rockContext = new RockContext();
+                var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValueAsId().Value );
+                var person = new PersonService( rockContext ).Get( hfPersonId.ValueAsInt() );
+                if ( person != null && group != null )
+                {
+                    // Person Attributes
+                    var displayedAttributeGuids = GetPersonAttributeGuids( person.Id );
+                    if ( !displayedAttributeGuids.Any() || person.Id == 0 )
+                    {
+                        pnlPersonAttributes.Visible = false;
+                    }
+                    else
+                    {
+                        pnlPersonAttributes.Visible = true;
+                        DisplayEditAttributes( person, displayedAttributeGuids, phPersonAttributes, pnlPersonAttributes, false );
+                    }
+
+                    // Family Attributes
+                    if ( person.Id == CurrentPerson.Id )
+                    {
+                        List<Guid> familyAttributeGuidList = GetAttributeValue( "FamilyAttributes" ).SplitDelimitedValues().AsGuidList();
+                        if ( familyAttributeGuidList.Any() )
+                        {
+                            pnlFamilyAttributes.Visible = true;
+                            DisplayEditAttributes( group, familyAttributeGuidList, phFamilyAttributes, pnlFamilyAttributes, false );
+                        }
+                        else
+                        {
+                            pnlFamilyAttributes.Visible = false;
+                        }
+                    }
+                }
+
+            }
+        }
+
+        private void BindFamilies()
+        {
+            ddlGroup.DataSource = CurrentPerson.GetFamilies().ToList();
+            ddlGroup.DataBind();
+            ShowDetail();
+        }
+
+        #endregion
+
+        #region Events
+
+        #region View Events
+
+        /// <summary>
+        /// Handles the Click event of the lbEditPerson control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbEditPerson_Click( object sender, EventArgs e )
+        {
+            ShowEditPersonDetails( CurrentPerson.Id );
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbMoved control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbMoved_Click( object sender, EventArgs e )
+        {
+            if ( !string.IsNullOrWhiteSpace( acAddress.Street1 ) )
+            {
+                hfStreet1.Value = acAddress.Street1;
+                hfStreet2.Value = acAddress.Street2;
+                hfCity.Value = acAddress.City;
+                hfState.Value = acAddress.State;
+                hfPostalCode.Value = acAddress.PostalCode;
+                hfCountry.Value = acAddress.Country;
+
+                Location currentAddress = new Location();
+                acAddress.GetValues( currentAddress );
+                lPreviousAddress.Text = string.Format( "<strong>Previous Address</strong><br />{0}", currentAddress.FormattedHtmlAddress );
+
+                acAddress.Street1 = string.Empty;
+                acAddress.Street2 = string.Empty;
+                acAddress.PostalCode = string.Empty;
+                acAddress.City = string.Empty;
+
+                cbIsMailingAddress.Checked = true;
+                cbIsPhysicalAddress.Checked = true;
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbRequestChanges control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbRequestChanges_Click( object sender, EventArgs e )
+        {
+            NavigateToLinkedPage( "WorkflowLaunchPage" );
+        }
+
+        /// <summary>
+        /// Handles the ItemCommand event of the rptGroupMembers control.
+        /// </summary>
+        /// <param name="source">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterCommandEventArgs"/> instance containing the event data.</param>
+        protected void rptGroupMembers_ItemCommand( object source, RepeaterCommandEventArgs e )
+        {
+            int personId = e.CommandArgument.ToString().AsInteger();
+            ShowEditPersonDetails( personId );
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbAddGroupMember control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbAddGroupMember_Click( object sender, EventArgs e )
+        {
+            if ( ddlGroup.SelectedValueAsId().HasValue )
+            {
+                ShowEditPersonDetails( 0 );
+            }
+        }
+
+        /// <summary>
+        /// Handles the ItemDataBound event of the rptGroupMembers control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
+        protected void rptGroupMembers_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        {
+            var rockContext = new RockContext();
+            var groupMemberService = new GroupMemberService( rockContext );
+            var attributeValueService = new AttributeValueService( rockContext );
+
+            var groupMember = e.Item.DataItem as GroupMember;
+            var person = groupMember.Person;
+            var lGroupMemberImage = e.Item.FindControl( "lGroupMemberImage" ) as Literal;
+            var lGroupMemberName = e.Item.FindControl( "lGroupMemberName" ) as Literal;
+            var lGroupMemberEmail = e.Item.FindControl( "lGroupMemberEmail" ) as Literal;
+            var lAge = e.Item.FindControl( "lAge" ) as Literal;
+            var lGender = e.Item.FindControl( "lGender" ) as Literal;
+            var lMaritalStatus = e.Item.FindControl( "lMaritalStatus" ) as Literal;
+            var lGrade = e.Item.FindControl( "lGrade" ) as Literal;
+            var rptGroupMemberPhones = e.Item.FindControl( "rptGroupMemberPhones" ) as Repeater;
+            var rptGroupMemberAttributes = e.Item.FindControl( "rptGroupMemberAttributes" ) as Repeater;
+            var lbEditGroupMember = e.Item.FindControl( "lbEditGroupMember" ) as LinkButton;
+
+            // Setup Image
+            string imgTag = Rock.Model.Person.GetPersonPhotoImageTag( person, 200, 200 );
+            if ( person.PhotoId.HasValue )
+            {
+                lGroupMemberImage.Text = string.Format( "<a href='{0}'>{1}</a>", person.PhotoUrl, imgTag );
+            }
+            else
+            {
+                lGroupMemberImage.Text = imgTag;
+            }
+
+            // Person Info
+            lGroupMemberName.Text = person.FullName;
+            lGroupMemberEmail.Text = person.Email;
+            if ( person.BirthDate.HasValue )
+            {
+                lAge.Text = string.Format( "{0}<small>({1})</small><br/>", person.FormatAge(), person.BirthYear != DateTime.MinValue.Year ? person.BirthDate.Value.ToShortDateString() : person.BirthDate.Value.ToMonthDayString() );
+            }
+
+            lGender.Text = person.Gender != Gender.Unknown ? person.Gender.ToString() : string.Empty;
+            lGrade.Text = person.GradeFormatted;
+            lMaritalStatus.Text = person.MaritalStatusValueId.DefinedValue();
+            if ( person.AnniversaryDate.HasValue )
+            {
+                lMaritalStatus.Text += string.Format( " {0} yrs <small>({1})</small>", person.AnniversaryDate.Value.Age(), person.AnniversaryDate.Value.ToMonthDayString() );
+            }
+
+            // Contact Info
+            if ( person.PhoneNumbers != null )
+            {
+                var selectedPhoneTypeGuids = GetAttributeValue( "PhoneNumbers" ).Split( ',' ).AsGuidList();
+                rptGroupMemberPhones.DataSource = person.PhoneNumbers.Where( pn => selectedPhoneTypeGuids.Contains( pn.NumberTypeValue.Guid ) ).ToList();
+                rptGroupMemberPhones.DataBind();
+            }
+
+            // Person Attributes
+            List<Guid> attributeGuidList = new List<Guid>();
+            var adultGuid = Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid();
+            var childGuid = Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD.AsGuid();
+
+            if ( groupMember.GroupRole.Guid == adultGuid )
+            {
+                attributeGuidList = GetAttributeValue( "PersonAttributes(adults)" ).SplitDelimitedValues().AsGuidList();
+            }
+            else
+            {
+                attributeGuidList = GetAttributeValue( "PersonAttributes(children)" ).SplitDelimitedValues().AsGuidList();
+            }
+
+            person.LoadAttributes();
+            rptGroupMemberAttributes.DataSource = person.Attributes.Where( a =>
+             attributeGuidList.Contains( a.Value.Guid ) )
+            .Select( a => new
+            {
+                Name = a.Value.Name,
+                Value = a.Value.FieldType.Field.FormatValue( null, person.GetAttributeValue( a.Key ), a.Value.QualifierValues, a.Value.FieldType.Class == typeof( Rock.Field.Types.ImageFieldType ).FullName )
+            } )
+            .OrderBy( av => av.Name )
+            .ToList()
+            .Where( av => !String.IsNullOrWhiteSpace( av.Value ) );
+            rptGroupMemberAttributes.DataBind();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Handles the Click event of the btnSave control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnSave_Click( object sender, EventArgs e )
+        {
+            var rockContext = new RockContext();
+            if ( ddlGroup.SelectedValueAsId().HasValue )
+            {
+                var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValueAsId().Value );
+                if ( group != null )
+                {
+                    rockContext.WrapTransaction( () =>
+                    {
+                        var personService = new PersonService( rockContext );
+
+                        var changes = new List<string>();
+
+                        var personId = hfPersonId.Value.AsInteger();
+                        if ( personId == 0 )
+                        {
+                            changes.Add( "Created" );
+                            DefinedValueCache dvcConnectionStatus = DefinedValueCache.Read( GetAttributeValue( "ConnectionStatus" ).AsGuid() );
+                            DefinedValueCache dvcRecordStatus = DefinedValueCache.Read( GetAttributeValue( "RecordStatus" ).AsGuid() );
+
+                            var groupMemberService = new GroupMemberService( rockContext );
+                            var groupMember = new GroupMember() { Person = new Person(), Group = group, GroupId = group.Id };
+                            groupMember.Person.TitleValueId = ddlTitle.SelectedValueAsId();
+                            groupMember.Person.FirstName = tbFirstName.Text;
+                            groupMember.Person.NickName = tbNickName.Text;
+                            groupMember.Person.LastName = tbLastName.Text;
+                            groupMember.Person.SuffixValueId = ddlSuffix.SelectedValueAsId();
+                            groupMember.Person.Gender = rblGender.SelectedValueAsEnum<Gender>();
+                            DateTime? birthdate = bpBirthDay.SelectedDate;
+                            if ( birthdate.HasValue )
+                            {
+                                // If setting a future birthdate, subtract a century until birthdate is not greater than today.
+                                var today = RockDateTime.Today;
+                                while ( birthdate.Value.CompareTo( today ) > 0 )
+                                {
+                                    birthdate = birthdate.Value.AddYears( -100 );
+                                }
+                            }
+
+                            groupMember.Person.SetBirthDate( birthdate );
+                            groupMember.Person.GradeOffset = ddlGradePicker.SelectedValueAsInt();
+                            var role = group.GroupType.Roles.Where( r => r.Id == ( rblRole.SelectedValueAsInt() ?? 0 ) ).FirstOrDefault();
+                            if ( role != null )
+                            {
+                                groupMember.GroupRole = role;
+                                groupMember.GroupRoleId = role.Id;
+                            }
+
+                            if ( dvcConnectionStatus != null )
+                            {
+                                groupMember.Person.ConnectionStatusValueId = dvcConnectionStatus.Id;
+                            }
+
+                            if ( dvcRecordStatus != null )
+                            {
+                                groupMember.Person.RecordStatusValueId = dvcRecordStatus.Id;
+                            }
+
+                            if ( groupMember.GroupRole.Guid == Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() )
+                            {
+                                groupMember.Person.GivingGroupId = group.Id;
+                            }
+
+                            groupMember.Person.IsEmailActive = true;
+                            groupMember.Person.EmailPreference = EmailPreference.EmailAllowed;
+                            groupMember.Person.RecordTypeValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_PERSON.AsGuid() ).Id;
+
+                            groupMemberService.Add( groupMember );
+                            rockContext.SaveChanges();
+                            personId = groupMember.PersonId;
+                        }
+
+                        var person = personService.Get( personId );
+                        if ( person != null )
+                        {
+                            int? orphanedPhotoId = null;
+                            if ( person.PhotoId != imgPhoto.BinaryFileId )
+                            {
+                                orphanedPhotoId = person.PhotoId;
+                                person.PhotoId = imgPhoto.BinaryFileId;
+
+                                if ( orphanedPhotoId.HasValue )
+                                {
+                                    if ( person.PhotoId.HasValue )
+                                    {
+                                        changes.Add( "Modified the photo." );
+                                    }
+                                    else
+                                    {
+                                        changes.Add( "Deleted the photo." );
+                                    }
+                                }
+                                else if ( person.PhotoId.HasValue )
+                                {
+                                    changes.Add( "Added a photo." );
+                                }
+                            }
+
+                            int? newTitleId = ddlTitle.SelectedValueAsInt();
+                            History.EvaluateChange( changes, "Title", DefinedValueCache.GetName( person.TitleValueId ), DefinedValueCache.GetName( newTitleId ) );
+                            person.TitleValueId = newTitleId;
+
+                            History.EvaluateChange( changes, "First Name", person.FirstName, tbFirstName.Text );
+                            person.FirstName = tbFirstName.Text;
+
+                            History.EvaluateChange( changes, "Nick Name", person.NickName, tbNickName.Text );
+                            person.NickName = tbNickName.Text;
+
+                            History.EvaluateChange( changes, "Last Name", person.LastName, tbLastName.Text );
+                            person.LastName = tbLastName.Text;
+
+                            int? newSuffixId = ddlSuffix.SelectedValueAsInt();
+                            History.EvaluateChange( changes, "Suffix", DefinedValueCache.GetName( person.SuffixValueId ), DefinedValueCache.GetName( newSuffixId ) );
+                            person.SuffixValueId = newSuffixId;
+
+                            var birthMonth = person.BirthMonth;
+                            var birthDay = person.BirthDay;
+                            var birthYear = person.BirthYear;
+
+                            var birthday = bpBirthDay.SelectedDate;
+                            if ( birthday.HasValue )
+                            {
+                                // If setting a future birthdate, subtract a century until birthdate is not greater than today.
+                                var today = RockDateTime.Today;
+                                while ( birthday.Value.CompareTo( today ) > 0 )
+                                {
+                                    birthday = birthday.Value.AddYears( -100 );
+                                }
+
+                                person.BirthMonth = birthday.Value.Month;
+                                person.BirthDay = birthday.Value.Day;
+                                if ( birthday.Value.Year != DateTime.MinValue.Year )
+                                {
+                                    person.BirthYear = birthday.Value.Year;
+                                }
+                                else
+                                {
+                                    person.BirthYear = null;
+                                }
+                            }
+                            else
+                            {
+                                person.SetBirthDate( null );
+                            }
+
+                            History.EvaluateChange( changes, "Birth Month", birthMonth, person.BirthMonth );
+                            History.EvaluateChange( changes, "Birth Day", birthDay, person.BirthDay );
+                            History.EvaluateChange( changes, "Birth Year", birthYear, person.BirthYear );
+
+                            int? graduationYear = null;
+                            if ( ypGraduation.SelectedYear.HasValue )
+                            {
+                                graduationYear = ypGraduation.SelectedYear.Value;
+                            }
+
+                            History.EvaluateChange( changes, "Graduation Year", person.GraduationYear, graduationYear );
+                            person.GraduationYear = graduationYear;
+
+                            var newGender = rblGender.SelectedValue.ConvertToEnum<Gender>();
+                            History.EvaluateChange( changes, "Gender", person.Gender, newGender );
+                            person.Gender = newGender;
+
+                            var phoneNumberTypeIds = new List<int>();
+
+                            bool smsSelected = false;
+
+                            foreach ( RepeaterItem item in rContactInfo.Items )
+                            {
+                                HiddenField hfPhoneType = item.FindControl( "hfPhoneType" ) as HiddenField;
+                                PhoneNumberBox pnbPhone = item.FindControl( "pnbPhone" ) as PhoneNumberBox;
+                                CheckBox cbUnlisted = item.FindControl( "cbUnlisted" ) as CheckBox;
+                                CheckBox cbSms = item.FindControl( "cbSms" ) as CheckBox;
+
+                                if ( hfPhoneType != null &&
+                                    pnbPhone != null &&
+                                    cbSms != null &&
+                                    cbUnlisted != null )
+                                {
+                                    if ( !string.IsNullOrWhiteSpace( PhoneNumber.CleanNumber( pnbPhone.Number ) ) )
+                                    {
+                                        int phoneNumberTypeId;
+                                        if ( int.TryParse( hfPhoneType.Value, out phoneNumberTypeId ) )
+                                        {
+                                            var phoneNumber = person.PhoneNumbers.FirstOrDefault( n => n.NumberTypeValueId == phoneNumberTypeId );
+                                            string oldPhoneNumber = string.Empty;
+                                            if ( phoneNumber == null )
+                                            {
+                                                phoneNumber = new PhoneNumber { NumberTypeValueId = phoneNumberTypeId };
+                                                person.PhoneNumbers.Add( phoneNumber );
+                                            }
+                                            else
+                                            {
+                                                oldPhoneNumber = phoneNumber.NumberFormattedWithCountryCode;
+                                            }
+
+                                            phoneNumber.CountryCode = PhoneNumber.CleanNumber( pnbPhone.CountryCode );
+                                            phoneNumber.Number = PhoneNumber.CleanNumber( pnbPhone.Number );
+
+                                            // Only allow one number to have SMS selected
+                                            if ( smsSelected )
+                                            {
+                                                phoneNumber.IsMessagingEnabled = false;
+                                            }
+                                            else
+                                            {
+                                                phoneNumber.IsMessagingEnabled = cbSms.Checked;
+                                                smsSelected = cbSms.Checked;
+                                            }
+
+                                            phoneNumber.IsUnlisted = cbUnlisted.Checked;
+                                            phoneNumberTypeIds.Add( phoneNumberTypeId );
+
+                                            History.EvaluateChange(
+                                                changes,
+                                                string.Format( "{0} Phone", DefinedValueCache.GetName( phoneNumberTypeId ) ),
+                                                oldPhoneNumber,
+                                                phoneNumber.NumberFormattedWithCountryCode );
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Remove any blank numbers
+                            var phoneNumberService = new PhoneNumberService( rockContext );
+                            foreach ( var phoneNumber in person.PhoneNumbers
+                                .Where( n => n.NumberTypeValueId.HasValue && !phoneNumberTypeIds.Contains( n.NumberTypeValueId.Value ) )
+                                .ToList() )
+                            {
+                                History.EvaluateChange(
+                                    changes,
+                                    string.Format( "{0} Phone", DefinedValueCache.GetName( phoneNumber.NumberTypeValueId ) ),
+                                    phoneNumber.ToString(),
+                                    string.Empty );
+
+                                person.PhoneNumbers.Remove( phoneNumber );
+                                phoneNumberService.Delete( phoneNumber );
+                            }
+
+                            History.EvaluateChange( changes, "Email", person.Email, tbEmail.Text );
+                            person.Email = tbEmail.Text.Trim();
+
+                            var newEmailPreference = rblEmailPreference.SelectedValue.ConvertToEnum<EmailPreference>();
+                            History.EvaluateChange( changes, "Email Preference", person.EmailPreference, newEmailPreference );
+                            person.EmailPreference = newEmailPreference;
+
+                            person.LoadAttributes();
+                            Rock.Attribute.Helper.GetEditValues( phPersonAttributes, person );
+
+                            if ( person.IsValid )
+                            {
+                                if ( rockContext.SaveChanges() > 0 )
+                                {
+                                    if ( changes.Any() )
+                                    {
+                                        HistoryService.SaveChanges(
+                                            rockContext,
+                                            typeof( Person ),
+                                            Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(),
+                                            person.Id,
+                                            changes );
+                                    }
+
+                                    if ( orphanedPhotoId.HasValue )
+                                    {
+                                        BinaryFileService binaryFileService = new BinaryFileService( rockContext );
+                                        var binaryFile = binaryFileService.Get( orphanedPhotoId.Value );
+                                        if ( binaryFile != null )
+                                        {
+                                            // marked the old images as IsTemporary so they will get cleaned up later
+                                            binaryFile.IsTemporary = true;
+                                            rockContext.SaveChanges();
+                                        }
+                                    }
+
+                                    // if they used the ImageEditor, and cropped it, the uncropped file is still in BinaryFile. So clean it up
+                                    if ( imgPhoto.CropBinaryFileId.HasValue )
+                                    {
+                                        if ( imgPhoto.CropBinaryFileId != person.PhotoId )
+                                        {
+                                            BinaryFileService binaryFileService = new BinaryFileService( rockContext );
+                                            var binaryFile = binaryFileService.Get( imgPhoto.CropBinaryFileId.Value );
+                                            if ( binaryFile != null && binaryFile.IsTemporary )
+                                            {
+                                                string errorMessage;
+                                                if ( binaryFileService.CanDelete( binaryFile, out errorMessage ) )
+                                                {
+                                                    binaryFileService.Delete( binaryFile );
+                                                    rockContext.SaveChanges();
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                person.SaveAttributeValues();
+
+                                // save family information
+                                if ( pnlAddress.Visible )
+                                {
+                                    Guid? familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuidOrNull();
+                                    if ( familyGroupTypeGuid.HasValue )
+                                    {
+                                        var familyGroup = new GroupService( rockContext ).Queryable()
+                                                        .Where( f => f.GroupType.Guid == familyGroupTypeGuid.Value
+                                                            && f.Members.Any( m => m.PersonId == person.Id ) )
+                                                        .FirstOrDefault();
+                                        if ( familyGroup != null )
+                                        {
+                                            Guid? addressTypeGuid = GetAttributeValue( "LocationType" ).AsGuidOrNull();
+                                            if ( addressTypeGuid.HasValue )
+                                            {
+                                                var groupLocationService = new GroupLocationService( rockContext );
+
+                                                var dvHomeAddressType = DefinedValueCache.Read( addressTypeGuid.Value );
+                                                var familyAddress = groupLocationService.Queryable().Where( l => l.GroupId == familyGroup.Id && l.GroupLocationTypeValueId == dvHomeAddressType.Id ).FirstOrDefault();
+                                                if ( familyAddress != null && string.IsNullOrWhiteSpace( acAddress.Street1 ) )
+                                                {
+                                                    // delete the current address
+                                                    History.EvaluateChange( changes, familyAddress.GroupLocationTypeValue.Value + " Location", familyAddress.Location.ToString(), string.Empty );
+                                                    groupLocationService.Delete( familyAddress );
+                                                    rockContext.SaveChanges();
+                                                }
+                                                else
+                                                {
+                                                    if ( !string.IsNullOrWhiteSpace( acAddress.Street1 ) )
+                                                    {
+                                                        if ( familyAddress == null )
+                                                        {
+                                                            familyAddress = new GroupLocation();
+                                                            groupLocationService.Add( familyAddress );
+                                                            familyAddress.GroupLocationTypeValueId = dvHomeAddressType.Id;
+                                                            familyAddress.GroupId = familyGroup.Id;
+                                                            familyAddress.IsMailingLocation = true;
+                                                            familyAddress.IsMappedLocation = true;
+                                                        }
+                                                        else if ( hfStreet1.Value != string.Empty )
+                                                        {
+                                                            // user clicked move so create a previous address
+                                                            var previousAddress = new GroupLocation();
+                                                            groupLocationService.Add( previousAddress );
+
+                                                            var previousAddressValue = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_PREVIOUS.AsGuid() );
+                                                            if ( previousAddressValue != null )
+                                                            {
+                                                                previousAddress.GroupLocationTypeValueId = previousAddressValue.Id;
+                                                                previousAddress.GroupId = familyGroup.Id;
+
+                                                                Location previousAddressLocation = new Location();
+                                                                previousAddressLocation.Street1 = hfStreet1.Value;
+                                                                previousAddressLocation.Street2 = hfStreet2.Value;
+                                                                previousAddressLocation.City = hfCity.Value;
+                                                                previousAddressLocation.State = hfState.Value;
+                                                                previousAddressLocation.PostalCode = hfPostalCode.Value;
+                                                                previousAddressLocation.Country = hfCountry.Value;
+
+                                                                previousAddress.Location = previousAddressLocation;
+                                                            }
+                                                        }
+
+                                                        familyAddress.IsMailingLocation = cbIsMailingAddress.Checked;
+                                                        familyAddress.IsMappedLocation = cbIsPhysicalAddress.Checked;
+
+                                                        var updatedHomeAddress = new Location();
+                                                        acAddress.GetValues( updatedHomeAddress );
+
+                                                        History.EvaluateChange( changes, dvHomeAddressType.Value + " Location", familyAddress.Location != null ? familyAddress.Location.ToString() : string.Empty, updatedHomeAddress.ToString() );
+
+                                                        familyAddress.Location = updatedHomeAddress;
+                                                        rockContext.SaveChanges();
+                                                    }
+                                                }
+
+                                                HistoryService.SaveChanges(
+                                                    rockContext,
+                                                    typeof( Person ),
+                                                    Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(),
+                                                    person.Id,
+                                                    changes );
+                                            }
+
+                                            familyGroup.LoadAttributes();
+                                            Rock.Attribute.Helper.GetEditValues( phFamilyAttributes, familyGroup );
+                                            familyGroup.SaveAttributeValues();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } );
+
+                    NavigateToCurrentPage();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the btnCancel control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnCancel_Click( object sender, EventArgs e )
+        {
+            ShowDetail();
+        }
+
+        /// <summary>
+        /// Handles the SelectedIndexChanged event of the ddlGroup control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ddlGroup_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            ShowDetail();
+        }
+
+        /// <summary>
+        /// Handles the SelectedIndexChanged event of the rblRole control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void rblRole_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            GroupTypeRoleService groupTypeRoleService = new GroupTypeRoleService( new RockContext() );
+            List<Guid> attributeGuidList = new List<Guid>();
+            var adultGuid = Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid();
+            var groupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid();
+            var selectedId = rblRole.SelectedValueAsId();
+            if ( selectedId.HasValue )
+            {
+                if ( groupTypeRoleService.Queryable().Where( gr =>
+                               gr.GroupType.Guid == groupTypeGuid &&
+                               gr.Guid == adultGuid &&
+                               gr.Id == selectedId ).Any() )
+                {
+                    attributeGuidList = GetAttributeValue( "PersonAttributes(adults)" ).SplitDelimitedValues().AsGuidList();
+                }
+                else
+                {
+                    attributeGuidList = GetAttributeValue( "PersonAttributes(children)" ).SplitDelimitedValues().AsGuidList();
+                }
+                if ( attributeGuidList.Any() )
+                {
+                    pnlPersonAttributes.Visible = true;
+                    DisplayEditAttributes( new Person(), attributeGuidList, phPersonAttributes, pnlPersonAttributes, true );
+                }
+                else
+                {
+                    pnlPersonAttributes.Visible = false;
+                }
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Shows the detail.
+        /// </summary>
+        private void ShowDetail()
+        {
+            var rockContext = new RockContext();
+            var groupMemberService = new GroupMemberService( rockContext );
+            var attributeValueService = new AttributeValueService( rockContext );
+
+            if ( CurrentPerson != null )
+            {
+                var personId = CurrentPerson.Id;
+
+                // Setup Image
+                string imgTag = Rock.Model.Person.GetPersonPhotoImageTag( CurrentPerson, 200, 200 );
+                if ( CurrentPerson.PhotoId.HasValue )
+                {
+                    lImage.Text = string.Format( "<a href='{0}'>{1}</a>", CurrentPerson.PhotoUrl, imgTag );
+                }
+                else
+                {
+                    lImage.Text = imgTag;
+                }
+
+                // Person Info
+                lName.Text = CurrentPerson.FullName;
+                if ( CurrentPerson.BirthDate.HasValue )
+                {
+                    lAge.Text = string.Format( "{0}<small>({1})</small><br/>", CurrentPerson.FormatAge(), CurrentPerson.BirthYear != DateTime.MinValue.Year ? CurrentPerson.BirthDate.Value.ToShortDateString() : CurrentPerson.BirthDate.Value.ToMonthDayString() );
+                }
+
+                lGender.Text = CurrentPerson.Gender != Gender.Unknown ? CurrentPerson.Gender.ToString() : string.Empty;
+                lGrade.Text = CurrentPerson.GradeFormatted;
+                lMaritalStatus.Text = CurrentPerson.MaritalStatusValueId.DefinedValue();
+                if ( CurrentPerson.AnniversaryDate.HasValue )
+                {
+                    lMaritalStatus.Text += string.Format( " {0} yrs <small>({1})</small>", CurrentPerson.AnniversaryDate.Value.Age(), CurrentPerson.AnniversaryDate.Value.ToMonthDayString() );
+                }
+
+                if ( CurrentPerson.GetFamilies().Count() > 1 )
+                {
+                    ddlGroup.Visible = true;
+                }
+
+                // Contact Info
+                if ( CurrentPerson.PhoneNumbers != null )
+                {
+                    var selectedPhoneTypeGuids = GetAttributeValue( "PhoneNumbers" ).Split( ',' ).AsGuidList();
+                    rptPhones.DataSource = CurrentPerson.PhoneNumbers.Where( pn => selectedPhoneTypeGuids.Contains( pn.NumberTypeValue.Guid ) ).ToList();
+                    rptPhones.DataBind();
+                }
+
+                lEmail.Text = CurrentPerson.Email;
+
+                // Person Attributes
+                List<Guid> attributeGuidList = GetPersonAttributeGuids( personId );
+                CurrentPerson.LoadAttributes();
+                rptPersonAttributes.DataSource = CurrentPerson.Attributes.Where( a =>
+                     attributeGuidList.Contains( a.Value.Guid ) )
+                    .Select( a => new
+                    {
+                        Name = a.Value.Name,
+                        Value = a.Value.FieldType.Field.FormatValue( null, CurrentPerson.GetAttributeValue( a.Key ), a.Value.QualifierValues, a.Value.FieldType.Class == typeof( Rock.Field.Types.ImageFieldType ).FullName )
+                    } )
+                    .OrderBy( av => av.Name )
+                    .ToList()
+                    .Where( av => !String.IsNullOrWhiteSpace( av.Value ) );
+                rptPersonAttributes.DataBind();
+
+                // Families
+                if ( GetAttributeValue( "ShowFamilyMembers" ).AsBoolean() )
+                {
+                    if ( ddlGroup.SelectedValueAsId().HasValue )
+                    {
+                        var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValueAsId().Value );
+                        if ( group != null )
+                        {
+
+                            // Family Name
+                            lGroupName.Text = group.Name;
+
+                            // Family Address
+                            Guid? locationTypeGuid = GetAttributeValue( "AddressType" ).AsGuidOrNull();
+                            if ( locationTypeGuid.HasValue )
+                            {
+                                var addressTypeDv = DefinedValueCache.Read( locationTypeGuid.Value );
+
+                                var familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuidOrNull();
+
+                                if ( familyGroupTypeGuid.HasValue )
+                                {
+                                    var familyGroupType = GroupTypeCache.Read( familyGroupTypeGuid.Value );
+
+                                    var address = new GroupLocationService( rockContext ).Queryable()
+                                                        .Where( l => l.Group.GroupTypeId == familyGroupType.Id
+                                                             && l.GroupLocationTypeValueId == addressTypeDv.Id
+                                                             && l.Group.Members.Any( m => m.PersonId == CurrentPerson.Id )
+                                                             && l.Group.Id == group.Id )
+                                                        .Select( l => l.Location )
+                                                        .FirstOrDefault();
+                                    if ( address != null )
+                                    {
+                                        lAddress.Text = string.Format( "<div class='margin-b-md'><b>{0} Address</b><br />{1}</div>", addressTypeDv.Value, address.FormattedHtmlAddress );
+                                    }
+                                }
+                            }
+
+                            // Family Attributes
+                            group.LoadAttributes();
+                            List<Guid> familyAttributeGuidList = GetAttributeValue( "FamilyAttributes" ).SplitDelimitedValues().AsGuidList();
+                            var familyAttributes = group.Attributes.Where( a =>
+                                 familyAttributeGuidList.Contains( a.Value.Guid ) )
+                                .Select( a => new
+                                {
+                                    Name = a.Value.Name,
+                                    Value = a.Value.FieldType.Field.FormatValue( null, group.GetAttributeValue( a.Key ), a.Value.QualifierValues, a.Value.FieldType.Class == typeof( Rock.Field.Types.ImageFieldType ).FullName )
+                                } )
+                                .OrderBy( av => av.Name )
+                                .ToList()
+                                .Where( av => !String.IsNullOrWhiteSpace( av.Value ) );
+                            if ( familyAttributes.Count() > 0 )
+                            {
+                                lFamilyHeader.Visible = true;
+                                rptGroupAttributes.DataSource = familyAttributes;
+                                rptGroupAttributes.DataBind();
+                            }
+
+                            rptGroupMembers.DataSource = group.Members.Where( gm =>
+                                gm.PersonId != CurrentPerson.Id &&
+                                gm.Person.IsDeceased == false )
+                                .OrderBy( m => m.GroupRole.Order )
+                                .ToList();
+                            rptGroupMembers.DataBind();
+                        }
+                    }
+                }
+            }
+
+            hfPersonId.Value = string.Empty;
+            pnlEdit.Visible = false;
+            pnlView.Visible = true;
+        }
+
+        /// <summary>
+        /// Shows the edit person details.
+        /// </summary>
+        /// <param name="personId">The person identifier.</param>
+        /// <param name="groupId">The group identifier.</param>
+        private void ShowEditPersonDetails( int personId )
+        {
+            var childGuid = Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD.AsGuid();
+
+            RockContext rockContext = new RockContext();
+            if ( ddlGroup.SelectedValueAsId().HasValue )
+            {
+                var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValueAsId().Value );
+                if ( group != null )
+                {
+                    hfPersonId.Value = personId.ToString();
+                    var person = new Person();
+                    if ( personId == 0 )
+                    {
+                        rblRole.DataSource = group.GroupType.Roles.OrderBy( r => r.Order ).ToList();
+                        rblRole.DataBind();
+                        rblRole.Visible = true;
+                        rblRole.Required = true;
+                    }
+                    else
+                    {
+                        person = new PersonService( rockContext ).Get( personId );
+                    }
+
+                    if ( ddlGroup.SelectedValueAsId().HasValue )
+                    {
+
+                        if ( person != null )
+                        {
+                            imgPhoto.BinaryFileId = person.PhotoId;
+                            imgPhoto.NoPictureUrl = Person.GetPersonPhotoUrl( person, 200, 200 );
+                            ddlTitle.SelectedValue = person.TitleValueId.HasValue ? person.TitleValueId.Value.ToString() : string.Empty;
+                            tbFirstName.Text = person.FirstName;
+                            tbNickName.Text = person.NickName;
+                            tbLastName.Text = person.LastName;
+                            ddlSuffix.SelectedValue = person.SuffixValueId.HasValue ? person.SuffixValueId.Value.ToString() : string.Empty;
+                            bpBirthDay.SelectedDate = person.BirthDate;
+                            rblGender.SelectedValue = person.Gender.ConvertToString();
+                            if ( group.Members.Where( gm => gm.PersonId == person.Id && gm.GroupRole.Guid == childGuid ).Any() )
+                            {
+                                if ( person.GraduationYear.HasValue )
+                                {
+                                    ypGraduation.SelectedYear = person.GraduationYear.Value;
+                                }
+                                else
+                                {
+                                    ypGraduation.SelectedYear = null;
+                                }
+
+                                ddlGradePicker.Visible = true;
+                                if ( !person.HasGraduated ?? false )
+                                {
+                                    int gradeOffset = person.GradeOffset.Value;
+                                    var maxGradeOffset = ddlGradePicker.MaxGradeOffset;
+
+                                    // keep trying until we find a Grade that has a gradeOffset that that includes the Person's gradeOffset (for example, there might be combined grades)
+                                    while ( !ddlGradePicker.Items.OfType<ListItem>().Any( a => a.Value.AsInteger() == gradeOffset ) && gradeOffset <= maxGradeOffset )
+                                    {
+                                        gradeOffset++;
+                                    }
+
+                                    ddlGradePicker.SetValue( gradeOffset );
+                                }
+                                else
+                                {
+                                    ddlGradePicker.SelectedIndex = 0;
+                                }
+                            }
+
+                            tbEmail.Text = person.Email;
+                            rblEmailPreference.SelectedValue = person.EmailPreference.ConvertToString( false );
+
+                            // Person Attributes
+                            var displayedAttributeGuids = GetPersonAttributeGuids( person.Id );
+                            if ( !displayedAttributeGuids.Any() || personId == 0 )
+                            {
+                                pnlPersonAttributes.Visible = false;
+                            }
+                            else
+                            {
+                                pnlPersonAttributes.Visible = true;
+                                DisplayEditAttributes( person, displayedAttributeGuids, phPersonAttributes, pnlPersonAttributes, true );
+                            }
+
+                            // Family Attributes
+                            if ( person.Id == CurrentPerson.Id )
+                            {
+                                List<Guid> familyAttributeGuidList = GetAttributeValue( "FamilyAttributes" ).SplitDelimitedValues().AsGuidList();
+                                if ( familyAttributeGuidList.Any() )
+                                {
+                                    pnlFamilyAttributes.Visible = true;
+                                    DisplayEditAttributes( group, familyAttributeGuidList, phFamilyAttributes, pnlFamilyAttributes, true );
+                                }
+                                else
+                                {
+                                    pnlFamilyAttributes.Visible = false;
+                                }
+
+                                Guid? locationTypeGuid = GetAttributeValue( "AddressType" ).AsGuidOrNull();
+                                if ( locationTypeGuid.HasValue )
+                                {
+                                    pnlAddress.Visible = true;
+                                    var addressTypeDv = DefinedValueCache.Read( locationTypeGuid.Value );
+
+                                    // if address type is home enable the move and is mailing/physical
+                                    if ( addressTypeDv.Guid == Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME.AsGuid() )
+                                    {
+                                        lbMoved.Visible = true;
+                                        cbIsMailingAddress.Visible = true;
+                                        cbIsPhysicalAddress.Visible = true;
+                                    }
+                                    else
+                                    {
+                                        lbMoved.Visible = false;
+                                        cbIsMailingAddress.Visible = false;
+                                        cbIsPhysicalAddress.Visible = false;
+                                    }
+
+                                    lAddressTitle.Text = addressTypeDv.Value + " Address";
+
+                                    var familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuidOrNull();
+
+                                    if ( familyGroupTypeGuid.HasValue )
+                                    {
+                                        var familyGroupType = GroupTypeCache.Read( familyGroupTypeGuid.Value );
+
+                                        var familyAddress = new GroupLocationService( rockContext ).Queryable()
+                                                            .Where( l => l.Group.GroupTypeId == familyGroupType.Id
+                                                                 && l.GroupLocationTypeValueId == addressTypeDv.Id
+                                                                 && l.Group.Members.Any( m => m.PersonId == person.Id ) )
+                                                            .FirstOrDefault();
+                                        if ( familyAddress != null )
+                                        {
+                                            acAddress.SetValues( familyAddress.Location );
+
+                                            cbIsMailingAddress.Checked = familyAddress.IsMailingLocation;
+                                            cbIsPhysicalAddress.Checked = familyAddress.IsMappedLocation;
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                pnlFamilyAttributes.Visible = false;
+                                pnlAddress.Visible = false;
+                            }
+
+                            var mobilePhoneType = DefinedValueCache.Read( new Guid( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE ) );
+
+                            var phoneNumbers = new List<PhoneNumber>();
+                            var phoneNumberTypes = DefinedTypeCache.Read( new Guid( Rock.SystemGuid.DefinedType.PERSON_PHONE_TYPE ) );
+                            var selectedPhoneTypeGuids = GetAttributeValue( "PhoneNumbers" ).Split( ',' ).AsGuidList();
+                            if ( phoneNumberTypes.DefinedValues.Where( pnt => selectedPhoneTypeGuids.Contains( pnt.Guid ) ).Any() )
+                            {
+                                foreach ( var phoneNumberType in phoneNumberTypes.DefinedValues.Where( pnt => selectedPhoneTypeGuids.Contains( pnt.Guid ) ) )
+                                {
+                                    var phoneNumber = person.PhoneNumbers.FirstOrDefault( n => n.NumberTypeValueId == phoneNumberType.Id );
+                                    if ( phoneNumber == null )
+                                    {
+                                        var numberType = new DefinedValue();
+                                        numberType.Id = phoneNumberType.Id;
+                                        numberType.Value = phoneNumberType.Value;
+
+                                        phoneNumber = new PhoneNumber { NumberTypeValueId = numberType.Id, NumberTypeValue = numberType };
+                                        phoneNumber.IsMessagingEnabled = mobilePhoneType != null && phoneNumberType.Id == mobilePhoneType.Id;
+                                    }
+                                    else
+                                    {
+                                        // Update number format, just in case it wasn't saved correctly
+                                        phoneNumber.NumberFormatted = PhoneNumber.FormattedNumber( phoneNumber.CountryCode, phoneNumber.Number );
+                                    }
+
+                                    phoneNumbers.Add( phoneNumber );
+                                }
+
+                                rContactInfo.DataSource = phoneNumbers;
+                                rContactInfo.DataBind();
+                            }
+                        }
+                    }
+                }
+            }
+
+            pnlView.Visible = false;
+            pnlEdit.Visible = true;
+        }
+
+        /// <summary>
+        /// Gets the person attribute guids.
+        /// </summary>
+        /// <param name="personId">The person identifier.</param>
+        /// <returns></returns>
+        private List<Guid> GetPersonAttributeGuids( int personId )
+        {
+            GroupMemberService groupMemberService = new GroupMemberService( new RockContext() );
+            List<Guid> attributeGuidList = new List<Guid>();
+            var adultGuid = Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid();
+            var childGuid = Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD.AsGuid();
+            var groupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid();
+
+            if ( groupMemberService.Queryable().Where( gm =>
+               gm.PersonId == personId &&
+               gm.Group.GroupType.Guid == groupTypeGuid &&
+               gm.GroupRole.Guid == adultGuid ).Any() )
+            {
+                attributeGuidList = GetAttributeValue( "PersonAttributes(adults)" ).SplitDelimitedValues().AsGuidList();
+            }
+            else
+            {
+                attributeGuidList = GetAttributeValue( "PersonAttributes(children)" ).SplitDelimitedValues().AsGuidList();
+            }
+
+            return attributeGuidList;
+        }
+
+        /// <summary>
+        /// Displays the edit attributes.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="displayedAttributeGuids">The displayed attribute guids.</param>
+        /// <param name="phAttributes">The ph attributes.</param>
+        /// <param name="pnlAttributes">The PNL attributes.</param>
+        private void DisplayEditAttributes( IHasAttributes item, List<Guid> displayedAttributeGuids, PlaceHolder phAttributes, Panel pnlAttributes, bool setValue )
+        {
+            phAttributes.Controls.Clear();
+            item.LoadAttributes();
+            var excludedAttributeList = item.Attributes.Where( a => !displayedAttributeGuids.Contains( a.Value.Guid ) ).Select( a => a.Value.Key ).ToList();
+            if ( item.Attributes != null && item.Attributes.Any() && displayedAttributeGuids.Any() )
+            {
+                pnlAttributes.Visible = true;
+                Rock.Attribute.Helper.AddEditControls( item, phAttributes, setValue, BlockValidationGroup, excludedAttributeList, false, 2 );
+            }
+            else
+            {
+                pnlAttributes.Visible = false;
+            }
+        }
+
+        /// <summary>
+        /// Formats the phone number.
+        /// </summary>
+        /// <param name="countryCode">The country code.</param>
+        /// <param name="number">The number.</param>
+        /// <returns></returns>
+        protected string FormatPhoneNumber( object countryCode, object number )
+        {
+            string cc = countryCode as string ?? string.Empty;
+            string n = number as string ?? string.Empty;
+            return PhoneNumber.FormattedNumber( cc, n );
+        }
+
+        #endregion                          
+    }
+}


### PR DESCRIPTION
This adds a block that can be placed on the front-end website, allowing a user to edit not only their information, but that of their family(s), including adding new family members. It also includes a button to send the user to a page where they could request additional changes. This block did require some changes to the AttributeFieldType and AttributeFieldAttribute classes to add in qualifier column/value functionality. This was because the 'Family Attributes' block setting was displaying attributes from check-in groups, and we wanted it to only display Family GroupType attributes.
![image](https://cloud.githubusercontent.com/assets/5482014/17498204/b230128c-5d7a-11e6-82a1-4a14dfda3ec4.png)
![image](https://cloud.githubusercontent.com/assets/5482014/17498205/b5f7883c-5d7a-11e6-985c-e8864c88e299.png)

![image](https://cloud.githubusercontent.com/assets/5482014/17498208/bbad4078-5d7a-11e6-8379-69131128b0f9.png)

