### PR TITLE
Make Entity TypeId and TypeName accessible in Lava

### DIFF
--- a/Rock/Data/Entity.cs
+++ b/Rock/Data/Entity.cs
@@ -123,6 +123,7 @@ namespace Rock.Data
         /// <value>
         /// An <see cref="System.Int32"/> that represents the identifier for the current Entity object type. 
         /// </value>
+        [LavaInclude]
         public virtual int TypeId
         {
             get

--- a/Rock/Data/Entity.cs
+++ b/Rock/Data/Entity.cs
@@ -140,6 +140,7 @@ namespace Rock.Data
         /// The name of the entity type.
         /// </value>
         [NotMapped]
+        [LavaInclude]
         public virtual string TypeName
         {
             get


### PR DESCRIPTION
This allows a workflow trigger to determine which entity type is being updated or changed.  

One use case for this would be triggering an update to a third party system, where a workflow could fire only on certain entity types (without having to create a trigger for each specific type).