### PR TITLE
- Fix Lava Properties in EventItemOccurrenceLava  not hydrating with enable debug off

### DIFF
--- a/RockWeb/Blocks/Event/EventItemOccurrenceLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemOccurrenceLava.ascx.cs
@@ -130,18 +130,12 @@ namespace RockWeb.Blocks.Event
                 eventItemOccurrenceId = Convert.ToInt32( PageParameter( "EventOccurrenceId" ) );
             }
             if ( eventItemOccurrenceId > 0 )
-            {
-                bool enableDebug = GetAttributeValue( "EnableDebug" ).AsBoolean();
-
+            {                                                              
                 var eventItemOccurrenceService = new EventItemOccurrenceService( new RockContext() );
                 var qry = eventItemOccurrenceService
                     .Queryable( "EventItem, EventItem.Photo, Campus, Linkages" )
                     .Where( i => i.Id == eventItemOccurrenceId );
 
-                if ( !enableDebug )
-                {
-                    qry = qry.AsNoTracking();
-                }
                 var eventItemOccurrence = qry.FirstOrDefault();
 
                 var mergeFields = new Dictionary<string, object>();


### PR DESCRIPTION
# Context
Request from Slack to investigate why lava was only working with debug on. [Example here](http://rock.rocksolidchurchdemo.com/page/5392?EventOccurrenceId=5)

# Goal
Ensure the the lava is hydrated.

# Strategy
I removed a check where the query was set .AsNoTracking() when debug was off.

# Possible Implications
The query will have a greater (but necessary!) overhead.