### PR TITLE
+ Add Activate Activity in Other Workflow workflow action

### DIFF
--- a/Rock/Field/Types/WorkflowActivityTypeFieldType.cs
+++ b/Rock/Field/Types/WorkflowActivityTypeFieldType.cs
@@ -37,6 +37,79 @@ namespace Rock.Field.Types
 
         private const string WORKFLOW_TYPE_KEY = "WorkflowType";
 
+        public override List<string> ConfigurationKeys()
+        {
+            var configKeys = base.ConfigurationKeys();
+            configKeys.Add( WORKFLOW_TYPE_KEY );
+            return configKeys;
+        }
+
+        /// <summary>
+        /// Creates the HTML controls required to configure this type of field
+        /// </summary>
+        /// <returns></returns>
+        public override List<Control> ConfigurationControls()
+        {
+            var controls = base.ConfigurationControls();
+
+            // build a drop down list of workflow types (the one that gets selected is
+            // used to build a list of workflow activity types) 
+            var ddl = new RockDropDownList();
+            controls.Add( ddl );
+            ddl.AutoPostBack = true;
+            ddl.SelectedIndexChanged += OnQualifierUpdated;
+            ddl.Label = "Workflow Type";
+            ddl.Help = "The Workflow Type to select activities from.";
+            var originalValue = ddl.SelectedValue;
+
+            Rock.Model.WorkflowTypeService workflowTypeService = new Model.WorkflowTypeService( new RockContext() );
+            foreach ( var workflowType in workflowTypeService.Queryable().OrderBy( w => w.Name ) )
+            {
+                ddl.Items.Add( new ListItem( workflowType.Name, workflowType.Guid.ToString() ) );
+            }
+
+            var httpContext = System.Web.HttpContext.Current;
+            if ( string.IsNullOrEmpty(originalValue) && httpContext != null && httpContext.Request != null && httpContext.Request.Params["workflowTypeId"] != null && httpContext.Request.Params["workflowTypeId"].AsIntegerOrNull() == 0 )
+            {
+
+                var workflowType = GetContextWorkflowType();
+                ddl.Items.Add( new ListItem( ( string.IsNullOrWhiteSpace( workflowType.Name ) ? "Current Workflow" : workflowType.Name ), "" ) );
+                ddl.SelectedIndex = ddl.Items.Count - 1;
+            }
+            return controls;
+        }
+
+        /// <summary>
+        /// Gets the configuration value.
+        /// </summary>
+        /// <param name="controls">The controls.</param>
+        /// <returns></returns>
+        public override Dictionary<string, ConfigurationValue> ConfigurationValues( List<Control> controls )
+        {
+            Dictionary<string, ConfigurationValue> configurationValues = new Dictionary<string, ConfigurationValue>();
+            configurationValues.Add( WORKFLOW_TYPE_KEY, new ConfigurationValue( "Workflow Type", "The Workflow Type to select activities from", string.Empty ) );
+
+            if ( controls != null && controls.Count > 0 && controls[0] != null && controls[0] is DropDownList )
+            {
+                configurationValues[WORKFLOW_TYPE_KEY].Value = ( ( DropDownList ) controls[0] ).SelectedValue;
+            }
+
+            return configurationValues;
+        }
+
+        /// <summary>
+        /// Sets the configuration value.
+        /// </summary>
+        /// <param name="controls"></param>
+        /// <param name="configurationValues"></param>
+        public override void SetConfigurationValues( List<Control> controls, Dictionary<string, ConfigurationValue> configurationValues )
+        {
+            if ( controls != null && configurationValues != null && controls.Count > 0 && controls[0] != null && controls[0] is DropDownList && configurationValues.ContainsKey( WORKFLOW_TYPE_KEY ) )
+            {
+                ( ( DropDownList ) controls[0] ).SelectedValue = configurationValues[WORKFLOW_TYPE_KEY].Value;
+            }
+        }
+
         #endregion
 
         #region Formatting
@@ -99,32 +172,39 @@ namespace Rock.Field.Types
 
             IEnumerable<WorkflowActivityType> activityTypes = null;
 
-            var workflowType = GetContextWorkflowType();
+            Guid? workflowTypeGuid = configurationValues != null && configurationValues.ContainsKey( WORKFLOW_TYPE_KEY ) ? configurationValues[WORKFLOW_TYPE_KEY].Value.AsGuidOrNull() : null;
+
+            WorkflowType workflowType = null;
+
+            if ( workflowTypeGuid.HasValue )
+            {
+                var workflowTypeService = new WorkflowTypeService( new RockContext() );
+                workflowType = workflowTypeService.Get( workflowTypeGuid.Value );
+            }
+
+            if ( workflowType == null )
+            {
+                workflowType = GetContextWorkflowType();
+            }
+
             if ( workflowType != null )
             {
                 activityTypes = workflowType.ActivityTypes;
-            }
 
-            if (activityTypes == null && configurationValues != null && configurationValues.ContainsKey( WORKFLOW_TYPE_KEY ) )
-            {
-                Guid workflowTypeGuid = configurationValues[WORKFLOW_TYPE_KEY].Value.AsGuid();
-                if ( !workflowTypeGuid.IsEmpty() )
+                if ( activityTypes != null && activityTypes.Any() )
                 {
-                    activityTypes = new WorkflowActivityTypeService( new RockContext() )
-                        .Queryable()
-                        .Where( t => t.WorkflowType.Guid.Equals( workflowTypeGuid ) );
+                    foreach ( var activityType in activityTypes.OrderBy( a => a.Order ) )
+                    {
+                        editControl.Items.Add( new ListItem( activityType.Name ?? "[New Activity]", activityType.Guid.ToString().ToUpper() ) );
+                    }
                 }
+
+                return editControl;
             }
 
-            if (activityTypes != null && activityTypes.Any() )
-            {
-                foreach ( var activityType in activityTypes.OrderBy( a => a.Order ) )
-                {
-                    editControl.Items.Add( new ListItem( activityType.Name ?? "[New Activity]", activityType.Guid.ToString().ToUpper() ) );
-                }
-            }
+            return null;
 
-            return editControl;
+
         }
 
         /// <summary>
@@ -137,7 +217,7 @@ namespace Rock.Field.Types
         {
             if ( control != null && control is RockDropDownList )
             {
-                return ( (RockDropDownList)control ).SelectedValue;
+                return ( ( RockDropDownList ) control ).SelectedValue;
             }
 
             return string.Empty;
@@ -155,7 +235,7 @@ namespace Rock.Field.Types
             {
                 if ( control != null && control is RockDropDownList )
                 {
-                    ( (RockDropDownList)control ).SetValue( value.ToUpper() );
+                    ( ( RockDropDownList ) control ).SetValue( value.ToUpper() );
                 }
             }
         }
@@ -199,6 +279,6 @@ namespace Rock.Field.Types
         }
 
         #endregion
-      
+
     }
 }

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1559,6 +1559,8 @@
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeToGroupLeader.cs" />
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeToInitiator.cs" />
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeValue.cs" />
+    <Compile Include="Workflow\Action\WorkflowControl\ActivateActivityinOtherWorkflow.cs" />
+    <Compile Include="Workflow\Action\WorkflowControl\ActivateActivityInOtherWorkflowOnMatch.cs" />
     <Compile Include="Workflow\Action\WorkflowControl\ActivateWorkflow.cs" />
     <Compile Include="Workflow\Action\WorkflowControl\ActivateActions.cs" />
     <Compile Include="Workflow\Action\WorkflowControl\ActivateActivity.cs" />

--- a/Rock/Workflow/Action/WorkflowControl/ActivateActivityInOtherWorkflowOnMatch.cs
+++ b/Rock/Workflow/Action/WorkflowControl/ActivateActivityInOtherWorkflowOnMatch.cs
@@ -1,0 +1,106 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Data.Entity;
+using System.Linq;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Activates a new activity for a given activity type
+    /// </summary>
+    [ActionCategory( "Workflow Control" )]
+    [Description( "Activates a new activity instance and all of its actions in a different workflow when a given attribute matches." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Activate Activity in Other Workflow On Match" )]
+
+    [WorkflowAttribute( "Activity", "The activity that should be activated", true, fieldTypeClassNames: new string[] { "Rock.Field.Types.WorkflowActivityFieldType" } )]
+    [WorkflowTextOrAttribute( "Attribute Key to Match", "Attribute Key to Match", "The workflow attribute key to match against in the target workflow.", true, key: "WorkflowAttributeKey" )]
+    [WorkflowTextOrAttribute( "Attribute Value to Match", "Attribute Value to Match", "The workflow attribute value to match against in the target workflow.", true, key: "WorkflowAttributeValue" )]
+    public class ActivateOtherActivityOnMatch : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            var workflowActivityGuid = action.GetWorklowAttributeValue( GetAttributeValue( action, "Activity" ).AsGuid() ).AsGuid();
+            if ( workflowActivityGuid.IsEmpty() )
+            {
+                action.AddLogEntry( "Invalid Activity Property", true );
+                return false;
+            }
+
+            var attributeKey = GetAttributeValue( action, "WorkflowAttributeKey", true );
+            var attributeValue = GetAttributeValue( action, "WorkflowAttributeValue", true );
+            if ( string.IsNullOrWhiteSpace( attributeKey) || string.IsNullOrWhiteSpace(attributeValue) )
+            {
+                action.AddLogEntry( "Invalid Workflow Property", true );
+                return false;
+            }
+
+            var activityType = new WorkflowActivityTypeService( rockContext ).Queryable()
+                .Where( a => a.Guid.Equals( workflowActivityGuid ) ).FirstOrDefault();
+
+            if ( activityType == null )
+            {
+                action.AddLogEntry( "Invalid Activity Property", true );
+                return false;
+            }
+
+            var entityType = EntityTypeCache.Read( typeof( Rock.Model.Workflow ) );
+
+            var workflowIds = new AttributeValueService( rockContext )
+                .Queryable()
+                .AsNoTracking()
+                .Where( a => a.Attribute.Key == attributeKey && a.Value == attributeValue && a.Attribute.EntityTypeId == entityType.Id )
+                .Select(a => a.EntityId);
+
+            var workflows = new WorkflowService( rockContext )
+                .Queryable()
+                //.AsNoTracking()
+                .Where( w => w.WorkflowType.ActivityTypes.Any( a => a.Guid == activityType.Guid ) && workflowIds.Contains(w.Id) )
+                .ToList();
+
+            foreach (var workflow in workflows )
+            {
+                WorkflowActivity.Activate( activityType, workflow );
+                action.AddLogEntry( string.Format( "Activated new '{0}' activity in {1} {2}", activityType.ToString(), workflow.TypeName, workflow.WorkflowId ) );
+            }
+            
+
+            return true;
+        }
+
+    }
+}

--- a/Rock/Workflow/Action/WorkflowControl/ActivateActivityinOtherWorkflow.cs
+++ b/Rock/Workflow/Action/WorkflowControl/ActivateActivityinOtherWorkflow.cs
@@ -1,0 +1,100 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Activates a new activity for a given activity type
+    /// </summary>
+    [ActionCategory( "Workflow Control" )]
+    [Description( "Activates a new activity instance and all of its actions in a different workflow." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Activate Activity in Other Workflow" )]
+
+    [WorkflowAttribute("Activity", "The activity that should be activated", true, fieldTypeClassNames: new string[] { "Rock.Field.Types.WorkflowActivityFieldType" } )]
+    [WorkflowTextOrAttribute("Workflow", "Workflow Attribute", "The ID or Guid of the workflow that should be activated", true, key:"WorkflowReference" )]
+    public class ActivateOtherActivity : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            var workflowActivityGuid = action.GetWorklowAttributeValue( GetAttributeValue( action, "Activity" ).AsGuid() ).AsGuid();
+            if ( workflowActivityGuid.IsEmpty() )
+            {
+                action.AddLogEntry( "Invalid Activity Property", true );
+                return false;
+            }
+
+            var reference = GetAttributeValue( action, "WorkflowReference", true );
+            Rock.Model.Workflow workflow = null;
+            if (reference.AsGuidOrNull() != null )
+            {
+                var referenceGuid = reference.AsGuid();
+                workflow = new WorkflowService( rockContext ).Queryable()
+                    .Where( w => w.Guid == referenceGuid )
+                    .FirstOrDefault();
+            }
+            else if (reference.AsIntegerOrNull() != null )
+            {
+                var referenceInt = reference.AsInteger();
+                workflow = new WorkflowService( rockContext ).Queryable()
+                   .Where( w => w.Id == referenceInt )
+                   .FirstOrDefault();
+            }
+            else
+            {
+                action.AddLogEntry( "Invalid Workflow Property", true );
+                return false;
+            }            
+            
+            var activityType = new WorkflowActivityTypeService( rockContext ).Queryable()
+                .Where( a => a.Guid.Equals( workflowActivityGuid ) ).FirstOrDefault();
+
+            if ( activityType == null )
+            {
+                action.AddLogEntry( "Invalid Activity Property", true );
+                return false;
+            }
+
+            WorkflowActivity.Activate( activityType, workflow );
+            action.AddLogEntry( string.Format( "Activated new '{0}' activity", activityType.ToString() ) );
+
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
# Context
There's a new action in v6 that lets you activate a workflow using a workflow action. If based on logic you want to complete ~~kill~~ that workflow processing there's no way to do so. 

# Goal
To provide the ability for a workflow to activate an activity in another workflow.

# Strategy
* Edit the workflow fieldtype to provide a drop down list of possible workflow types to select an activity type
* Add a workflow action that will take an activity type and a workflow id and then activate the activity in the given workflow.

# Possible Implications
The WorkflowActivityTypeFieldType was not designed to be used outside of the context of a workflow and so uses a HTTP.context method, there could be issues there (although these haven't been observed).

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._
![image](https://cloud.githubusercontent.com/assets/8703222/17718647/d3786d0e-63c9-11e6-8462-959691e19500.png)

![image](https://cloud.githubusercontent.com/assets/8703222/17718663/f435b8bc-63c9-11e6-9c3b-841265ccac08.png)

