### PR TITLE
Add attribute placeholder and methods for editing and saving Financia…

### DIFF
--- a/RockWeb/Blocks/Finance/AccountDetail.ascx
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx
@@ -83,6 +83,14 @@
                             <Rock:RockCheckBox ID="cbIsTaxDeductible" runat="server" Label="Tax Deductible" />           
                         </div>
                     </div>
+                    
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="attributes">
+                                <asp:PlaceHolder ID="phAttributes" runat="server" EnableViewState="false"></asp:PlaceHolder>
+                            </div>
+                        </div>
+                    </div>
 
                     <div class="actions">
                         <asp:LinkButton ID="btnSave" runat="server" AccessKey="s" Text="Save" CssClass="btn btn-primary" OnClick="btnSave_Click" />

--- a/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
@@ -18,6 +18,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using Rock;
+using Rock.Attribute;
 using Rock.Constants;
 using Rock.Data;
 using Rock.Model;
@@ -99,6 +100,9 @@ namespace RockWeb.Blocks.Finance
             account.ModifiedDateTime = RockDateTime.Now;
             account.ModifiedByPersonAliasId = CurrentPersonAliasId;
 
+            account.LoadAttributes( rockContext );
+            Rock.Attribute.Helper.GetEditValues( phAttributes, account );
+
             // if the account IsValid is false, and the UI controls didn't report any errors, it is probably because the custom rules of account didn't pass.
             // So, make sure a message is displayed in the validation summary
             cvAccount.IsValid = account.IsValid;
@@ -110,6 +114,7 @@ namespace RockWeb.Blocks.Finance
             }
 
             rockContext.SaveChanges();
+            account.SaveAttributeValues( rockContext );
 
             NavigateToParentPage();
         }
@@ -190,6 +195,10 @@ namespace RockWeb.Blocks.Finance
             {
                 lActionTitle.Text = account.Name.FormatAsHtmlTitle();
             }
+
+            account.LoadAttributes();
+            phAttributes.Controls.Clear();
+            Rock.Attribute.Helper.AddEditControls( account, phAttributes, true, BlockValidationGroup );
 
             hlInactive.Visible = !account.IsActive;
 


### PR DESCRIPTION
# Context
Needed to be able to enter and edit attribute values for FinancialAccounts.

# Goal
Edit controls are now included in the AccountDetail block.

# Strategy
Used the code from the CampusDetail block as guideline to add the edit controls and save the data.

# Possible Implications
The attributes are not exposed to the view only mode of the AccountDetail block, so that could be limiting and might need to be added later - however, view mode is limited in what's exposed so maybe not a concern.

# Screenshots
![account_atrributes](https://cloud.githubusercontent.com/assets/3513589/18060862/446c1014-6dee-11e6-815b-2d90c56f429f.png)
