### PR TITLE
Fix LinkedPage merge fields missed in ad47233

### DIFF
--- a/RockWeb/Blocks/Cms/ContentChannelItemPersonalListLava.ascx.cs
+++ b/RockWeb/Blocks/Cms/ContentChannelItemPersonalListLava.ascx.cs
@@ -141,7 +141,7 @@ namespace RockWeb.Blocks.Cms
             }
 
             var mergeFields = new Dictionary<string, object>();
-            mergeFields.Add( "DetailPage", LinkedPageUrl( "DetailPage", null ) );
+            mergeFields.Add( "DetailPage", LinkedPageRoute( "DetailPage" ) );
             mergeFields.Add( "ContentChannel", contentChannel );    
             mergeFields.Add( "CurrentPerson", CurrentPerson );
             mergeFields.Add( "Items", items.Take(GetAttributeValue( "MaxItems" ).AsInteger()).ToList() );

--- a/RockWeb/Blocks/Event/CalendarLava.ascx.cs
+++ b/RockWeb/Blocks/Event/CalendarLava.ascx.cs
@@ -412,7 +412,7 @@ namespace RockWeb.Blocks.Event
 
             var mergeFields = new Dictionary<string, object>();
             mergeFields.Add( "TimeFrame", ViewMode );
-            mergeFields.Add( "DetailsPage", LinkedPageUrl( "DetailsPage", null ) );
+            mergeFields.Add( "DetailsPage", LinkedPageRoute( "DetailsPage" ) );
             mergeFields.Add( "EventItems", eventSummaries );
             mergeFields.Add( "EventItemOccurrences", eventOccurrenceSummaries );
             mergeFields.Add( "CurrentPerson", CurrentPerson );

--- a/RockWeb/Blocks/Event/EventItemListLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemListLava.ascx.cs
@@ -217,7 +217,7 @@ namespace RockWeb.Blocks.Event
             }
 
             var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
-            mergeFields.Add( "DetailsPage", LinkedPageUrl( "DetailsPage", null ) );
+            mergeFields.Add( "DetailsPage", LinkedPageRoute( "DetailsPage" ) );
             mergeFields.Add( "EventOccurrenceSummaries", eventOccurrenceSummaries );
 
             lContent.Text = GetAttributeValue( "LavaTemplate" ).ResolveMergeFields( mergeFields );

--- a/RockWeb/Blocks/Event/EventItemOccurrenceLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemOccurrenceLava.ascx.cs
@@ -139,7 +139,7 @@ namespace RockWeb.Blocks.Event
                 var eventItemOccurrence = qry.FirstOrDefault();
 
                 var mergeFields = new Dictionary<string, object>();
-                mergeFields.Add( "RegistrationPage", LinkedPageUrl( "RegistrationPage", null ) );
+                mergeFields.Add( "RegistrationPage", LinkedPageRoute( "RegistrationPage" ) );
 
                 var campusEntityType = EntityTypeCache.Read( "Rock.Model.Campus" );
                 var contextCampus = RockPage.GetCurrentContext( campusEntityType ) as Campus;

--- a/RockWeb/Blocks/Event/EventItemOccurrenceListByAudienceLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemOccurrenceListByAudienceLava.ascx.cs
@@ -200,8 +200,8 @@ namespace RockWeb.Blocks.Event
                 }
 
                 mergeFields.Add( "ListTitle", GetAttributeValue("ListTitle") );
-                mergeFields.Add( "EventDetailPage", LinkedPageUrl( "EventDetailPage", null ) );
-                mergeFields.Add( "RegistrationPage", LinkedPageUrl( "RegistrationPage", null ) );
+                mergeFields.Add( "EventDetailPage", LinkedPageRoute( "EventDetailPage" ) );
+                mergeFields.Add( "RegistrationPage", LinkedPageRoute( "RegistrationPage" ) );
                 mergeFields.Add( "EventItemOccurrences", itemOccurrences );
                
                 lContent.Text = GetAttributeValue( "LavaTemplate" ).ResolveMergeFields( mergeFields );

--- a/RockWeb/Blocks/Event/EventItemOccurrenceListLava.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemOccurrenceListLava.ascx.cs
@@ -170,7 +170,7 @@ namespace RockWeb.Blocks.Event
 
                 // make lava merge fields
                 var mergeFields = new Dictionary<string, object>();
-                mergeFields.Add( "RegistrationPage", LinkedPageUrl( "RegistrationPage", null ) );
+                mergeFields.Add( "RegistrationPage", LinkedPageRoute( "RegistrationPage" ) );
                 mergeFields.Add( "EventItem", eventItem);
                 mergeFields.Add( "EventItemOccurrences", itemOccurrences );
 

--- a/RockWeb/Blocks/Finance/ContributionStatementListLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementListLava.ascx.cs
@@ -134,7 +134,7 @@ namespace RockWeb.Blocks.Finance
                                 .OrderByDescending(y => y.Year);
 
             var mergeFields = new Dictionary<string, object>();
-            mergeFields.Add( "DetailPage", LinkedPageUrl( "DetailPage", null ) );
+            mergeFields.Add( "DetailPage", LinkedPageRoute( "DetailPage" ) );
             mergeFields.Add( "StatementYears", yearQry.Take( numberOfYears ) );
             
             var template = GetAttributeValue( "LavaTemplate" );

--- a/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
@@ -1055,7 +1055,7 @@ namespace RockWeb.Blocks.Groups
                             }
                             else
                             {
-                                linkedPages.Add( "RegisterPage", LinkedPageUrl( "RegisterPage", null ) );
+                                linkedPages.Add( "RegisterPage", LinkedPageRoute( "RegisterPage" ) );
                             }
 
                             mergeFields.Add( "LinkedPages", linkedPages );
@@ -1118,7 +1118,7 @@ namespace RockWeb.Blocks.Groups
                 mergeFields.Add( "Groups", groups );
 
                 Dictionary<string, object> linkedPages = new Dictionary<string, object>();
-                linkedPages.Add( "GroupDetailPage", LinkedPageUrl( "GroupDetailPage", null ) );
+                linkedPages.Add( "GroupDetailPage", LinkedPageRoute( "GroupDetailPage" ) );
 
                 if ( _targetPersonGuid != Guid.Empty )
                 {
@@ -1126,7 +1126,7 @@ namespace RockWeb.Blocks.Groups
                 }
                 else
                 {
-                    linkedPages.Add( "RegisterPage", LinkedPageUrl( "RegisterPage", null ) );
+                    linkedPages.Add( "RegisterPage", LinkedPageRoute( "RegisterPage" ) );
                 }
 
                 mergeFields.Add( "LinkedPages", linkedPages );


### PR DESCRIPTION
# Context
Some merge fields did not get updated from `LinkedPageUrl` to `LinkedPageRoute` in commit ad47233 - this fixes the ones I could find.