### PR TITLE
Add bottom margin to .picker-menu

### DIFF
--- a/RockWeb/Styles/_components.less
+++ b/RockWeb/Styles/_components.less
@@ -117,6 +117,7 @@
   .picker-menu {
     width: 400px;
     padding: 10px;
+    margin-bottom: 36px;
 
     h4:first-child {
       margin-top: 0;
@@ -772,6 +773,7 @@ div.tagsinput {
     background-color: @autocomplete-bg;
     border: 1px solid @autocomplete-border;
     border-radius: 0 0 @border-radius-base @border-radius-base;
+
     .box-shadow(0 5px 10px rgba(0,0,0,.2));
 
     li {
@@ -1814,6 +1816,7 @@ ul.rocklist {
           background-clip: padding-box;
   border: 1px solid @autocomplete-border;
   border-radius: 0 0 @border-radius-base @border-radius-base;
+
   .box-shadow(0 5px 10px rgba(0,0,0,.2));
 }
 


### PR DESCRIPTION
# Context
Fixes issue #1736, the admin bar interfering with selecting or canceling on the picker menu.

# Goal
Adds a 36px margin to the bottom of the picker menu, forcing the page to extend, which moves the admin bar out of the way.

# Possible Implications
Minimal, fixes rendering.

# Screenshots
With fix:
![selectorfix](https://cloud.githubusercontent.com/assets/374209/18218894/87dd0374-711a-11e6-9feb-ada5881c2d27.gif)

Without fix:
![selectorissue](https://cloud.githubusercontent.com/assets/374209/18218907/96f17a34-711a-11e6-880b-d964f9fc870b.gif)

