### PR TITLE
Change date picker next/prev and switch buttons to use pointer

### DIFF
--- a/RockWeb/Styles/_components.less
+++ b/RockWeb/Styles/_components.less
@@ -772,6 +772,7 @@ div.tagsinput {
     background-color: @autocomplete-bg;
     border: 1px solid @autocomplete-border;
     border-radius: 0 0 @border-radius-base @border-radius-base;
+
     .box-shadow(0 5px 10px rgba(0,0,0,.2));
 
     li {
@@ -1086,7 +1087,7 @@ fieldset .actions {
   .datepicker-switch,
   .prev,
   .next {
-    cursor:pointer;
+    cursor: pointer;
   }
 
   table {
@@ -1820,6 +1821,7 @@ ul.rocklist {
           background-clip: padding-box;
   border: 1px solid @autocomplete-border;
   border-radius: 0 0 @border-radius-base @border-radius-base;
+
   .box-shadow(0 5px 10px rgba(0,0,0,.2));
 }
 

--- a/RockWeb/Styles/_components.less
+++ b/RockWeb/Styles/_components.less
@@ -1083,6 +1083,12 @@ fieldset .actions {
     }
   }
 
+  .datepicker-switch,
+  .prev,
+  .next {
+    cursor:pointer;
+  }
+
   table {
     background-color: transparent;
 


### PR DESCRIPTION
# Context
Fixes issue #1710 

# Goal
Adds classes to .datepicker-switch, prev, and next to use a pointer instead of the text selector cursor.

# Strategy
CSS change in `_components.less` file

# Possible Implications
None?

# Screenshots
![dateselectorfix](https://cloud.githubusercontent.com/assets/374209/18219332/ae9a0f68-711d-11e6-9374-32730f3419db.gif)


