### PR TITLE
Use the new Google Maps url structure & HTTPS

### DIFF
--- a/Rock/Model/Location.cs
+++ b/Rock/Model/Location.cs
@@ -613,7 +613,7 @@ namespace Rock.Model
         /// </summary>
         /// <param name="title">A unused <see cref="System.String"/> containing the location name parameters.</param>
         /// <returns>A <see cref="System.String"/> containing the link to Google Maps for this location.</returns>
-        public virtual string GoogleMapLink( string title )
+        public virtual string GoogleMapLink( string title = "" )
         {
             string qParm = this.GetFullStreetAddress();
             // Remove linebreaks and commas

--- a/Rock/Model/Location.cs
+++ b/Rock/Model/Location.cs
@@ -611,17 +611,15 @@ namespace Rock.Model
         /// <summary>
         /// Returns a Google Maps link to use for this Location
         /// </summary>
-        /// <param name="title">A <see cref="System.String"/> containing the parameters needed by Google Maps to display this location.</param>
+        /// <param name="title">A unused <see cref="System.String"/> containing the location name parameters.</param>
         /// <returns>A <see cref="System.String"/> containing the link to Google Maps for this location.</returns>
         public virtual string GoogleMapLink( string title )
         {
             string qParm = this.GetFullStreetAddress();
-            if ( !string.IsNullOrWhiteSpace( title ) )
-            {
-                qParm += " (" + title + ")";
-            }
+            // Remove linebreaks and commas
+            qParm = qParm.Replace( "\x0D\x0A", " " ).Replace( ",", string.Empty );
 
-            return "http://maps.google.com/maps?q=" +
+            return "https://www.google.com/maps/place/" +
                 System.Web.HttpUtility.UrlEncode( qParm );
         }
 

--- a/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
@@ -271,7 +271,7 @@ namespace RockWeb.Blocks.Crm.PersonDetail
                     HtmlAnchor aMap = e.Item.FindControl( "aMap" ) as HtmlAnchor;
                     if ( aMap != null )
                     {
-                        aMap.HRef = loc.GoogleMapLink( Person.FullName );
+                        aMap.HRef = loc.GoogleMapLink();
                     }
 
                     LinkButton lbVerify = e.Item.FindControl( "lbVerify" ) as LinkButton;


### PR DESCRIPTION
# Context
Google maps doesn't use HTTPS or the new map link standard (`https://www.google.com/maps/place/`)

# Goal
Add HTTPS link style and remove unused label parameter. 

# Strategy
Remove commas and encoded linebreaks which google doesn't like

# Possible Implications
The new URL structure seems to be quite a bit more sensitive to poorly encoded URLs so there might be some outliers.

