### PR TITLE
Add workflow action with large code editor for running lava

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1554,6 +1554,7 @@
     <Compile Include="Workflow\Action\People\PersonTagAdd.cs" />
     <Compile Include="Workflow\Action\People\PersonTagRemove.cs" />
     <Compile Include="Workflow\Action\People\SetPersonAttribute.cs" />
+    <Compile Include="Workflow\Action\Utility\RunLava.cs" />
     <Compile Include="Workflow\Action\Utility\RunSQL.cs" />
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeFromEntity.cs" />
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeFromPerson.cs" />

--- a/Rock/Workflow/Action/Utility/RunLava.cs
+++ b/Rock/Workflow/Action/Utility/RunLava.cs
@@ -1,0 +1,80 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Runs Lava and sets an attribute's value to the result.
+    /// </summary>
+    [ActionCategory( "Utility" )]
+    [Description( "Runs Lava and sets an attribute's value to the result." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Lava Run" )]
+
+    [CodeEditorField( "Lava", "The <span class='tip tip-lava'></span> to run.", Web.UI.Controls.CodeEditorMode.Lava, Web.UI.Controls.CodeEditorTheme.Rock, 300, true, "", "", 0, "Value" )]
+    [WorkflowAttribute( "Attribute", "The attribute to store the result in.", false, "", "", 1 )]
+    public class RunLava : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            Guid guid = GetAttributeValue( action, "Attribute" ).AsGuid();
+            if ( !guid.IsEmpty() )
+            {
+                var attribute = AttributeCache.Read( guid, rockContext );
+                if ( attribute != null )
+                {
+                    string value = GetAttributeValue( action, "Value" );
+
+                    value = value.ResolveMergeFields( GetMergeFields( action ) );
+
+                    if ( attribute.EntityTypeId == new Rock.Model.Workflow().TypeId )
+                    {
+                        action.Activity.Workflow.SetAttributeValue( attribute.Key, value );
+                        action.AddLogEntry( string.Format( "Set '{0}' attribute to '{1}'.", attribute.Name, value ) );
+                    }
+                    else if ( attribute.EntityTypeId == new Rock.Model.WorkflowActivity().TypeId )
+                    {
+                        action.Activity.SetAttributeValue( attribute.Key, value );
+                        action.AddLogEntry( string.Format( "Set '{0}' attribute to '{1}'.", attribute.Name, value ) );
+                    }
+                }
+            }
+
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
# Context
With the use of lava becoming more and more prevalent, the existing method of running lava in a workflow - the Attribute Set Value action - is getting harder to use (It only has a small text box).

# Goal
To have a large editor for running lava in a workflow.

# Strategy
This PR adds a new workflow action dedicated to running lava and provides a large code editor for editing.

# Possible Implications
None that I know of.

# Screenshots
<img width="647" alt="capture31" src="https://cloud.githubusercontent.com/assets/2406499/18280157/21a21284-7426-11e6-9683-0d993f5b58a5.PNG">

