### PR TITLE
Add workflow action to start a Job

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1554,6 +1554,7 @@
     <Compile Include="Workflow\Action\People\PersonTagAdd.cs" />
     <Compile Include="Workflow\Action\People\PersonTagRemove.cs" />
     <Compile Include="Workflow\Action\People\SetPersonAttribute.cs" />
+    <Compile Include="Workflow\Action\Utility\RunJob.cs" />
     <Compile Include="Workflow\Action\Utility\RunSQL.cs" />
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeFromEntity.cs" />
     <Compile Include="Workflow\Action\WorkflowAttributes\SetAttributeFromPerson.cs" />

--- a/Rock/Workflow/Action/Utility/RunJob.cs
+++ b/Rock/Workflow/Action/Utility/RunJob.cs
@@ -1,0 +1,64 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+
+namespace Rock.Workflow.Action
+{
+    [ActionCategory( "Utility" )]
+    [Description( "Triggers a job to run" )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Job Run" )]
+
+    [CustomDropdownListField( "Job", "The job to run.", "SELECT j.[Guid] AS [Value], j.[Name] AS [Text] From [ServiceJob] j ORDER BY j.[Name]", true, "", "", 0)]
+    class RunJob : ActionComponent
+    {
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+            
+            var JobGuid = GetAttributeValue( action, "Job" ).AsGuid();
+
+            if ( !JobGuid.IsEmpty() )
+            {
+                ServiceJob Job = new ServiceJobService( rockContext ).Get( JobGuid );
+                if ( Job != null )
+                {
+                    var transaction = new Rock.Transactions.RunJobNowTransaction( Job.Id );
+
+                    // Process the transaction on another thread
+                    System.Threading.Tasks.Task.Run( () => transaction.Execute() );
+
+                    action.AddLogEntry( string.Format( "The '{0}' job has been started.", Job.Name ) );
+
+                    return true;
+                }
+
+            }
+
+            errorMessages.Add("The specified Job could not be found");
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Context
There are some jobs (Such as calculating group requirements or group sync) that someone may want to be able to trigger automatically via a workflow. This way they can run a job on demand without needing to manually run it themselves or waiting for the scheduled time.

# Goal
Allow triggering jobs to run from inside a workflow.

# Strategy
This PR adds a new workflow action that will trigger a job to run.

# Possible Implications
I didn't explicitly check if a job is already running, but I'm pretty sure the scheduler handles that?

# Screenshots
<img width="646" alt="capture33" src="https://cloud.githubusercontent.com/assets/2406499/18281989/1b77fe76-742d-11e6-9ad4-e61d31ff446f.PNG">

