### PR TITLE
Add option to toggle tracking on mailgun emails

### DIFF
--- a/Rock.Mailgun/Communication/Transport/MailgunSmtp.cs
+++ b/Rock.Mailgun/Communication/Transport/MailgunSmtp.cs
@@ -37,6 +37,7 @@ namespace Rock.Communication.Transport
     [TextField( "API Key", "The API Key provided by Mailgun " )]
     [IntegerField( "Port", "", false, 587, "", 3 )]
     [BooleanField( "Use SSL", "", true, "", 4 )]
+    [BooleanField( "Track Clicks", "", true, "", 5 )]
     public class MailgunSmtp : SMTPComponent
     {
         /// <summary>
@@ -49,7 +50,7 @@ namespace Rock.Communication.Transport
         {
             get
             {
-                return true;
+                return GetAttributeValue( "TrackClicks" ).AsBoolean( true );
             }
         }
 
@@ -74,10 +75,12 @@ namespace Rock.Communication.Transport
         /// <param name="headers">The headers.</param>
         public override void AddAdditionalHeaders( MailMessage message, Dictionary<string, string> headers )
         {
+            var trackClicks = GetAttributeValue( "TrackClicks" ).AsBoolean( true ) ? "yes" : "no";
+
             // add headers
-            message.Headers.Add( "X-Mailgun-Track", "yes" );
-            message.Headers.Add( "X-Mailgun-Track-Clicks", "yes" );
-            message.Headers.Add( "X-Mailgun-Track-Opens", "yes" );
+            message.Headers.Add( "X-Mailgun-Track", trackClicks );
+            message.Headers.Add( "X-Mailgun-Track-Clicks", trackClicks );
+            message.Headers.Add( "X-Mailgun-Track-Opens", trackClicks );
 
             if ( headers != null )
             {


### PR DESCRIPTION
# Context
Someone on slack brought up wanting to disable tracking links in Mailgun emails. Right now the email headers are hard-coded to enable tracking. 

# Goal
Add an option to disable tracking on Mailgun emails.

# Strategy
This PR adds a "Track Clicks" option to the MailgunSmtp config which toggles the respective email headers.

# Possible Implications
None: the option is true by default, maintaining the previous behavior.

# Screenshots
<img width="592" alt="capture34" src="https://cloud.githubusercontent.com/assets/2406499/18282616/e0e58258-742f-11e6-83c8-3e3d549746a2.PNG">
