### PR TITLE
#1748 - Show the Workflow Type's Icon and Name on the block.

### DIFF
--- a/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
@@ -149,7 +149,9 @@ namespace RockWeb.Blocks.WorkFlow
                 {
                     RockPage.PageIcon = _workflowType.IconCssClass;
                 }
-
+            }
+            if ( _workflowType != null )
+            {
                 lTitle.Text = string.Format( "{0} Entry", _workflowType.WorkTerm );
 
                 if ( ! string.IsNullOrWhiteSpace( _workflowType.IconCssClass ) )


### PR DESCRIPTION
# Context
See https://github.com/SparkDevNetwork/Rock/issues/1748

# Goal
This fixes the issue by always executing the code to set the icon and name on a workflow.

# Strategy
Split an If condition into two sections.

# Possible Implications
None that I know of.

# Screenshots
See https://github.com/SparkDevNetwork/Rock/issues/1748

