### PR TITLE
Fix ActivateWorkflow action not copying attributes properly

### DIFF
--- a/Rock/Workflow/Action/WorkflowControl/ActivateWorkflow.cs
+++ b/Rock/Workflow/Action/WorkflowControl/ActivateWorkflow.cs
@@ -72,7 +72,7 @@ namespace Rock.Workflow.Action
                         {
                             if (workflow.Attributes.ContainsKey(keyPair.Value))
                             {
-                                var value = action.Activity.Workflow.AttributeValues[keyPair.Key].ValueFormatted;
+                                var value = action.Activity.Workflow.AttributeValues[keyPair.Key].Value;
                                 workflow.SetAttributeValue(keyPair.Value, value);
                             }
                             else


### PR DESCRIPTION
# Context
The ActivateWorkflow activity doesn't copy attributes to the new workflow properly - it's only copying the formatted value.

# Goal
Fix how the attributes are copied.

# Strategy
This fixes the issue by changing it so that the raw value is copied instead of the formatted value.

