### PR TITLE
Fix Remove Person from Group Using Attribute Workflow Action removing all groups

### DIFF
--- a/Rock/Workflow/Action/Groups/RemovePersonFromGroupAttribute.cs
+++ b/Rock/Workflow/Action/Groups/RemovePersonFromGroupAttribute.cs
@@ -124,7 +124,7 @@ namespace Rock.Workflow.Action
                 try
                 {
                     var groupMemberService = new GroupMemberService( rockContext );
-                    var groupMembers = groupMemberService.Queryable().Where( m => m.PersonId == person.Id );
+                    var groupMembers = groupMemberService.Queryable().Where( m => m.PersonId == person.Id && m.GroupId == group.Id );
 
                     foreach ( var groupMember in groupMembers )
                     {


### PR DESCRIPTION
# Context
The `Group Member Remove Person from Group Using Attribute` Workflow action removes the person from all of their groups instead of just the one specified.

# Goal
Fix so that the person is only removed from the specified group.

# Strategy
Add a filter to the list of group members to delete so it only removes ones in the specified group
