### PR TITLE
#1528 - Implement standard DbMigration methods in Plugin Migration Take 2

### DIFF
--- a/Rock/Plugin/Migration.cs
+++ b/Rock/Plugin/Migration.cs
@@ -15,8 +15,14 @@
 // </copyright>
 //
 using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Data.Entity.Migrations.Builders;
+using System.Data.Entity.Migrations.Model;
+using System.Data.Entity.Migrations.Sql;
+using System.Data.Entity.SqlServer;
 using System.Data.SqlClient;
+using System.Reflection;
 using System.Text;
 
 namespace Rock.Plugin
@@ -32,7 +38,7 @@ namespace Rock.Plugin
         /// <value>
         /// The SQL connection.
         /// </value>
-        public virtual SqlConnection SqlConnection { get; set;}
+        public virtual SqlConnection SqlConnection { get; set; }
 
         /// <summary>
         /// Gets or sets the SQL transaction.
@@ -51,6 +57,7 @@ namespace Rock.Plugin
         /// The commands to undo a migration from a specific version
         /// </summary>
         public abstract void Down();
+
 
         /// <summary>
         /// Gets the rock migration helper.
@@ -89,6 +96,199 @@ namespace Rock.Plugin
             {
                 throw new NullReferenceException( "The Plugin Migration requires valid SqlConnection and SqlTransaction values when executing SQL" );
             }
+        }
+
+        /// <summary>
+        ///     Adds an operation to create a new table.  This is a wrapper for the default DBMigration CreateTable.
+        /// </summary>
+        /// <typeparam name="TColumns"> The columns in this create table operation. You do not need to specify this type, it will be inferred from the columnsAction parameter you supply. </typeparam>
+        /// <param name="name"> The name of the table. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="columnsAction"> An action that specifies the columns to be included in the table. i.e. t => new { Id = t.Int(identity: true), Name = t.String() } </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        /// <returns> An object that allows further configuration of the table creation operation. </returns>
+        public TableBuilder<TColumns> CreateTable<TColumns>( string name, Func<ColumnBuilder, TColumns> columnsAction, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            var table = dbMigration.CreateTable( name, columnsAction, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+            return table;
+        }
+
+        /// <summary>
+        ///     Adds an operation to add a column to an existing table.  This is a wrapper for the default DBMigration AddColumn.
+        /// </summary>
+        /// <param name="table"> The name of the table to add the column to. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="name"> The name of the column to be added. </param>
+        /// <param name="columnAction"> An action that specifies the column to be added. i.e. c => c.Int(nullable: false, defaultValue: 3) </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        public void AddColumn( string table, string name, Func<ColumnBuilder, ColumnModel> columnAction, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            dbMigration.AddColumn( table, name, columnAction, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+        }
+
+        /// <summary>
+        ///     Adds an operation to drop an existing column.  This is a wrapper for the default DBMigration DropColumn.
+        /// </summary>
+        /// <param name="table"> The name of the table to drop the column from. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="name"> The name of the column to be dropped. </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        public void DropColumn( string table, string name, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            dbMigration.DropColumn( table, name, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+        }
+
+        /// <summary>
+        ///     Adds an operation to drop an index based on its name.  This is a wrapper for the default DBMigration DropIndex.
+        /// </summary>
+        /// <param name="table"> The name of the table to drop the index from. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="name"> The name of the index to be dropped. </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        public void DropIndex( string table, string name, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            dbMigration.DropIndex( table, name, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+        }
+
+        /// <summary>
+        ///     Adds an operation to drop a foreign key constraint based on its name.  This is a wrapper for the default DBMigration DropForeignKey.
+        /// </summary>
+        /// <param name="dependentTable"> The table that contains the foreign key column. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="name"> The name of the foreign key constraint in the database. </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        public void DropForeignKey( string dependentTable, string name, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            dbMigration.DropForeignKey( dependentTable, name, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+        }
+
+        /// <summary>
+        ///     Adds an operation to drop an index based on its name.  This is a wrapper for the default DBMigration DropIndex.
+        /// </summary>
+        /// <param name="table"> The name of the table to drop the index from. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="name"> The name of the index to be dropped. </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        public void DropIndex( string table, string[] columns, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            dbMigration.DropIndex( table, columns, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+        }
+
+        /// <summary>
+        ///     Adds an operation to drop an index based on the columns it targets.  This is a wrapper for the default DBMigration DropTable.
+        /// </summary>
+        /// <param name="table"> The name of the table to drop the index from. Schema name is optional, if no schema is specified then dbo is assumed. </param>
+        /// <param name="columns"> The name of the column(s) the index targets. </param>
+        /// <param name="anonymousArguments"> Additional arguments that may be processed by providers. Use anonymous type syntax to specify arguments e.g. 'new { SampleArgument = "MyValue" }'. </param>
+        public void DropTable( string name, object anonymousArguments = null )
+        {
+            DbMigration dbMigration = new DbMigration();
+            dbMigration.DropTable( name, anonymousArguments );
+            Sql( dbMigration.GetMigrationSql( SqlConnection ) );
+        }
+        
+        /// <summary>
+        /// This is a private instance of DBMigration which exposes the base DBMigration methods for plugins to use.
+        /// </summary>
+        private class DbMigration : System.Data.Entity.Migrations.DbMigration
+        {
+            public override void Up()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// Wrapper for the base CreateTable method to expose it to the parent class.
+            /// </summary>
+            internal new TableBuilder<TColumns> CreateTable<TColumns>( string name, Func<ColumnBuilder, TColumns> columnsAction, object anonymousArguments = null )
+            {
+                return base.CreateTable( name, columnsAction, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Wrapper for the base AddColumn method to expose it to the parent class.
+            /// </summary>
+            internal new void AddColumn( string table, string name, Func<ColumnBuilder, ColumnModel> columnAction, object anonymousArguments = null )
+            {
+                base.AddColumn( table, name, columnAction, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Wrapper for the base DropColumn method to expose it to the parent class.
+            /// </summary>
+            internal new void DropColumn( string table, string name, object anonymousArguments = null )
+            {
+                base.DropColumn( table, name, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Wrapper for the base DropForeignKey method to expose it to the parent class.
+            /// </summary>
+            internal new void DropForeignKey( string dependentTable, string name, object anonymousArguments = null )
+            {
+                base.DropForeignKey( dependentTable, name, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Wrapper for the base DropIndex method to expose it to the parent class.
+            /// </summary>
+            internal new void DropIndex( string table, string name, object anonymousArguments = null )
+            {
+                base.DropIndex( table, name, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Wrapper for the base DropIndex method to expose it to the parent class.
+            /// </summary>
+            internal new void DropIndex( string table, string[] columns, object anonymousArguments = null )
+            {
+                base.DropIndex( table, columns, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Wrapper for the base DropTable method to expose it to the parent class.
+            /// </summary>
+            internal new void DropTable( string name, object anonymousArguments = null )
+            {
+                base.DropTable( name, anonymousArguments );
+            }
+
+            /// <summary>
+            /// Get the migration operation's Sql.  This iterates through the DbMigrations operations list and pulls out the sql.
+            /// </summary>
+            /// <param name="SqlConnection">The SqlConnection object from the Plugin Migration class.</param>
+            /// <returns>A string containing the SQL generated from the current migration.</returns>
+            internal string GetMigrationSql( SqlConnection SqlConnection )
+            {
+                StringBuilder sql = new StringBuilder();
+                var prop = this.GetType().GetProperty( "Operations", BindingFlags.NonPublic | BindingFlags.Instance );
+                if ( prop != null )
+                {
+                    IEnumerable<MigrationOperation> operations = prop.GetValue( this ) as IEnumerable<MigrationOperation>;
+                    foreach ( var operation in operations )
+                    {
+                        if ( operation is AddForeignKeyOperation && ( ( AddForeignKeyOperation ) operation ).PrincipalColumns.Count == 0 )
+                        {
+                            // In Rock, the principal column should always be the Id.  This isn't always the case . . . .
+                            ( ( AddForeignKeyOperation ) operation ).PrincipalColumns.Add( "Id" );
+                        }
+                    }
+                    var generator = new SqlServerMigrationSqlGenerator();
+                    var statements = generator.Generate( operations, SqlConnection.ServerVersion.AsInteger() > 10 ? "2008" : "2005" );
+                    foreach ( MigrationStatement item in statements )
+                    {
+                        sql.Append( item.Sql );
+                    }
+                }
+                return sql.ToString();
+            }
+
         }
     }
 }


### PR DESCRIPTION
# Context
This adds the ability to use standard DbMigration methods in a plugin migration.

# Goal
The goal is to make plugin migration development "feel" more like standard entity framework.

# Strategy
I wrapped a handful of the standard migration methods into plugin migration. This allows for Rock to include the DbMigration methods for things like CreateTable, DropIndex etc. to expose them to Plugin Migrations.  More information about a previous PR which would have added an EF dependency to plugins is available here: https://github.com/SparkDevNetwork/Rock/pull/1529

# Possible Implications
This should not break any backwards compatibility.  It only adds new functionality.

# Screenshots
There are no UI changes.