### PR TITLE
Automatically load entity configurations from plugin assemblies.

### DIFF
--- a/Rock/Data/RockContext.cs
+++ b/Rock/Data/RockContext.cs
@@ -1190,6 +1190,12 @@ namespace Rock.Data
                 {
                     modelBuilder.RegisterEntityType( entityType );
                 }
+
+                // add configurations that might be in plugin assemblies
+                foreach ( var assembly in entityTypeList.Select( a => a.Assembly ).Distinct() )
+                {
+                    modelBuilder.Configurations.AddFromAssembly( assembly );
+                }
             }
             catch ( Exception ex )
             {


### PR DESCRIPTION
# Context
When a plugin contains entities that have corresponding configurations, these configurations are not loading into RockContext.  This change is mostly the work of Mike Peterson at CCV.

# Goal
Completely load all IRockEntity entities and their configurations into the RockContext.

# Strategy
This uses reflection to find any configurations for entities that extend IRockEntity.

# Possible Implications
We have been running this for a month and 1/2 in production and for many months before that in our development environments.  It completely resolves issues when loading plugin entities into the Rock.

# Attachments
I have attached a sample entity to this which contains a configuration.  Without this change, an error is thrown when the plugin is loaded into the RockContext.
[KioskType.cs.txt](https://github.com/SparkDevNetwork/Rock/files/461814/KioskType.cs.txt)



