### PR TITLE
Eliminate extra spaces in SQL Query block

### DIFF
--- a/RockWeb/Blocks/Reporting/SqlCommand.ascx
+++ b/RockWeb/Blocks/Reporting/SqlCommand.ascx
@@ -17,8 +17,7 @@
 SELECT
     TOP 10 *
 FROM
-    [Person]
-                        </Rock:CodeEditor>
+    [Person]<%--    --%></Rock:CodeEditor>
 
                         <Rock:Toggle ID="tQuery" runat="server" Label="Selection Query?" OnText="Yes" OffText="No" Checked="true"
                             Help="Will the SQL Text above return rows? If so, a grid will be displayed containing the results of the query." />


### PR DESCRIPTION
# Context
Extra spaces at the end of the SQL command default contents which show up as indent marks to the end user and make the more picky among us feel the need to delete them each time.

# Goal
This pull request uses comments to keep the coding clean and in-line vertically, while not putting the side-effects on the end user

# Strategy
Strategic use of comments

# Possible Implications
The only impact should be the cleanliness of the code, which is important to the project and perhaps there is a different preferred way to deal with this.

# Screenshots
<img width="188" alt="sql query indents" src="https://cloud.githubusercontent.com/assets/6932047/18376796/f5b92a5c-7616-11e6-9a13-d8d8020658cc.PNG">

The line break and indents make sense in the ascx file but left unpleasant spaces in the default block contents. I recommend this strategic use of comments to maintain the cleanliness of the code while not leaving any side-effects for the end user.