### PR TITLE
Update Google Map Link to HTTPS

### DIFF
--- a/Rock/Model/Location.cs
+++ b/Rock/Model/Location.cs
@@ -611,17 +611,13 @@ namespace Rock.Model
         /// <summary>
         /// Returns a Google Maps link to use for this Location
         /// </summary>
-        /// <param name="title">A <see cref="System.String"/> containing the parameters needed by Google Maps to display this location.</param>
+        /// <param name="title">A unused <see cref="System.String"/> containing the location name label. (Kept optional for compatibility)</param>
         /// <returns>A <see cref="System.String"/> containing the link to Google Maps for this location.</returns>
-        public virtual string GoogleMapLink( string title )
+        public virtual string GoogleMapLink( string title = "" )
         {
             string qParm = this.GetFullStreetAddress();
-            if ( !string.IsNullOrWhiteSpace( title ) )
-            {
-                qParm += " (" + title + ")";
-            }
 
-            return "http://maps.google.com/maps?q=" +
+            return "https://maps.google.com/maps?q=" +
                 System.Web.HttpUtility.UrlEncode( qParm );
         }
 

--- a/Rock/Model/Location.cs
+++ b/Rock/Model/Location.cs
@@ -611,9 +611,9 @@ namespace Rock.Model
         /// <summary>
         /// Returns a Google Maps link to use for this Location
         /// </summary>
-        /// <param name="title">A unused <see cref="System.String"/> containing the location name label. (Kept optional for compatibility)</param>
+        /// <param name="title">A unused <see cref="System.String"/> containing the location name label.</param>
         /// <returns>A <see cref="System.String"/> containing the link to Google Maps for this location.</returns>
-        public virtual string GoogleMapLink( string title = "" )
+        public virtual string GoogleMapLink( string title )
         {
             string qParm = this.GetFullStreetAddress();
 


### PR DESCRIPTION
# Context
A simpler version of PR #1740, that maintains the current, and ubiquitous `maps.google.com/maps?q=` link structure. Updates to include HTTPS, confirmed working with US and international addresses.

# Goal
Use HTTPS without using Google's new, and undocumented link structure.

# Strategy
Added an "S" to the current links. This PR also removes the location label from the URL, but makes the title string optional to maintain backwards compatibility.

# Possible Implications
Minimal comparative to PR #1740, Google could depreciate this link format, but it's unlikely considering the number of sites and projects using this structure. 
