### PR TITLE
Business: RegistrationEntry Null Reference

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -1717,6 +1717,12 @@ namespace RockWeb.Blocks.Event
 
             if ( newRegistrar )
             {
+                // Businesses have no first name.  This resolves null reference issues downstream.
+                if ( CurrentPerson != null && CurrentPerson.FirstName == null )
+                {
+                    CurrentPerson.FirstName = "";
+                }
+
                 if ( CurrentPerson != null && CurrentPerson.NickName == null )
                 {
                     CurrentPerson.NickName = CurrentPerson.FirstName;


### PR DESCRIPTION
# Context
Null reference when we have a UserLogin attached to a Business.

# Goal
Allow user's that are attached to Businesses to register.

# Strategy
Set the FirstName of the CurrentPerson to "" instead of leaving it Null.

# Possible Implications
This probably helps nobody since I doubt anyone else has UserLogin's attached to Businesses.

# Screenshots
N/A

- Setting the FirstName to an empty string for situations where the FirstName might be null.