### PR TITLE
- Added GetFormattedDataValue to CallbackField to make it easier to g…

### DIFF
--- a/Rock/Web/UI/Controls/Grid/CallbackField.cs
+++ b/Rock/Web/UI/Controls/Grid/CallbackField.cs
@@ -51,6 +51,16 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
+        /// Gets the formatted data value.
+        /// </summary>
+        /// <param name="dataValue">The data value.</param>
+        /// <returns></returns>
+        public string GetFormattedDataValue( object dataValue )
+        {
+            return FormatDataValue( dataValue, this.HtmlEncode );
+        }
+
+        /// <summary>
         /// Gets the value that should be exported to Excel
         /// </summary>
         /// <param name="row">The row.</param>

--- a/Rock/Web/UI/Controls/Grid/Grid.cs
+++ b/Rock/Web/UI/Controls/Grid/Grid.cs
@@ -1738,8 +1738,8 @@ namespace Rock.Web.UI.Controls
                                     worksheet.Cells[rowCounter, columnCounter].Value = resultHtml;
                                 }
                                 continue;
-                            } 
-                            
+                            }
+
                             var boundField = dataField as BoundField;
                             if ( boundField != null )
                             {
@@ -1747,6 +1747,11 @@ namespace Rock.Web.UI.Controls
                                 if ( prop != null )
                                 {
                                     object propValue = prop.GetValue( item, null );
+
+                                    if ( dataField is CallbackField )
+                                    {
+                                        propValue = ( dataField as CallbackField ).GetFormattedDataValue( propValue );
+                                    }
 
                                     var definedValueAttribute = prop.GetCustomAttributes( typeof( DefinedValueAttribute ), true ).FirstOrDefault();
 


### PR DESCRIPTION
# Context
_What is the problem you encountered that lead to you creating this pull request?_
We had a Report that included a person attribute called "Working Campus" which was a CampusField.  When exporting to excel, it would export the Guid instead of the Campus.Name

# Goal
_What will this pull request achieve and how will this fix the problem?_
The ReportingHelper creates a CallbackField for Attributes, so any exports from a Report or DynamicReport will have the raw value for Attributes instead of the value shown on the Grid.  This solution fixes the problem by detecting a CallbackField in Grid.cs and getting the FormattedValue of the field instead of the raw value.

# Strategy
_How have you implemented your solution?_
a change the Grid.cs and CallbackField.cs

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
If people were counting on the Raw Value of an attribute when exporting from a Reporting grid, this will change the behavior. So that is a concern.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

…et the resulting value of a CallbackField

- Updated Grid Excel Export so that CallbackField exports are the formatted value instead raw value.  This fixes an issue where Attributes that uses field types such as "CampusField" will return export the name of the campus instead of the Guid in Reports and DynamicReports.