### PR TITLE
[WIP] Integrated theme compliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ RockWeb/App_Data/PackageStaging
 *.sln.GhostDoc.xml
 
 Packages/*
+
+#javascript tooling
+node_modules

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.1.0",
+    "command": "gulp",
+    "fileLocation": ["relative", "${workspaceRoot}./Dev Tools/Themes/gulpfile.js"],
+    "isShellCommand": true,
+    "tasks": [
+        {
+            "taskName": "default",
+            "isBuildCommand": true,
+            "showOutput": "always",
+            "isWatching": true
+        }
+    ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,28 @@
+var gulp        = require('gulp');
+var browserSync = require('browser-sync').create();
+var less        = require('gulp-less');
+var root = process.cwd() + '/RockWeb/Themes/';
+
+// Static Server + watching scss/html files
+gulp.task('serve', ['less'], function() {
+
+    browserSync.init({ proxy: 'rock.dev' });
+
+    gulp.watch(root + '**/*.less', ['less']);
+    gulp.watch(root + '**/*.(aspx|lava)').on('change', browserSync.reload);
+});
+
+// Compile less into CSS & auto-inject into browsers
+gulp.task('less', function() {
+    return gulp.src(root + '**/theme.less')
+        .pipe(less())
+        .pipe(gulp.dest(function(f) {
+          return f.base;
+        }))
+        // XXX add support for grouping media queries
+        // XXX add support for auto-prefixer
+        // XXX add support for minification
+        .pipe(browserSync.stream());
+});
+
+gulp.task('default', ['serve']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rock",
+  "version": "6.0.0",
+  "description": "An open source CMS, Relationship Management System (RMS) and Church Management System (ChMS) all rolled into one.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SparkDevNetwork/Rock.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/SparkDevNetwork/Rock/issues"
+  },
+  "homepage": "https://github.com/SparkDevNetwork/Rock#readme",
+  "devDependencies": {
+    "browser-sync": "^2.17.0",
+    "gulp": "^3.9.1",
+    "gulp-less": "^3.1.0"
+  }
+}


### PR DESCRIPTION
# Context

When developing themes, I didn't find a standard way to compile less while working.
# Goal

To make theme development standardized and integrated to rock dev. This PR will support using any editor with gulp tie ins (most) including vscode. It also will have integration with visual studio via [this](http://www.davepaquette.com/archive/2014/10/08/how-to-use-gulp-in-visual-studio.aspx).

The task will also add some css minification / prefixing / media-query grouping making for better css.
# Strategy

Using a gulp task (node will be needed to run) and IDE hooks (or gulp globally installed), a developer can start the task which will also inject css changes into the browser without a reload. This makes for really fast feedback with designing
# Possible Implications

Since this is an optional local development tool, it shouldn't break anyone's current setup. It _should_ help with making a standard theme process though!
## TODO
- [ ] test visual studio integrations
- [ ] test on CI's for production builds
- [ ] test local development of themes and plugins (will need to expand glob)
- [ ] document usage

cc @dcs619
