### PR TITLE
Use the same SVG width and height for children

### DIFF
--- a/RockWeb/Assets/Images/person-no-photo-child-female.svg
+++ b/RockWeb/Assets/Images/person-no-photo-child-female.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 298.8 298.7" enable-background="new 0 0 298.8 298.7" xml:space="preserve">
+	 width="298.811px" height="298.708px" viewBox="0 0 298.8 298.7" enable-background="new 0 0 298.8 298.7" xml:space="preserve">
 <linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="149.4055" y1="984.584" x2="149.4055" y2="1283.3929" gradientTransform="matrix(1 0 0 1 0 -984.584)">
 	<stop  offset="0" style="stop-color:#DFDFDF"/>
 	<stop  offset="1" style="stop-color:#C9C9C9"/>

--- a/RockWeb/Assets/Images/person-no-photo-child-male.svg
+++ b/RockWeb/Assets/Images/person-no-photo-child-male.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 298.8 298.7" enable-background="new 0 0 298.8 298.7" xml:space="preserve">
+	 width="298.811px" height="298.708px" viewBox="0 0 298.8 298.7" enable-background="new 0 0 298.8 298.7" xml:space="preserve">
 <linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="149.4055" y1="984.584" x2="149.4055" y2="1283.3929" gradientTransform="matrix(1 0 0 1 0 -984.584)">
 	<stop  offset="0" style="stop-color:#DFDFDF"/>
 	<stop  offset="1" style="stop-color:#C9C9C9"/>


### PR DESCRIPTION
# Context
The SVG files for Children don't show in the Checkin Manager because they don't have a default width and height. This pull adds the same width and height used by the default male and female SVGs (Fixes #1786)

# Goal
Add a default width and height to match the style found on the `person-no-photo` SVGs 

# Strategy
Matching code used on the working images `width="298.811px" height="298.708px"`

# Possible Implications
Nothing to mention. Going forward it should be noted that Rock doesn't like the responsive image default from Adobe Illustrator because Illustrator expects the parent container to have a width/height attribute. 

# Screenshots
From `/checkinmanager`
Before:
<img width="328" alt="screen shot 2016-10-04 at 8 58 48 pm" src="https://cloud.githubusercontent.com/assets/374209/19100704/09a4da52-8a76-11e6-87d1-49cba63f082d.png">
After:
<img width="299" alt="screen shot 2016-10-04 at 8 59 29 pm" src="https://cloud.githubusercontent.com/assets/374209/19100703/07894794-8a76-11e6-9c50-3d96e04cbe75.png">



