### PR TITLE
#1791 - Updating the Excel export and PersonData methods to honor the RowFilter.

### DIFF
--- a/Rock/Web/UI/Controls/Grid/Grid.cs
+++ b/Rock/Web/UI/Controls/Grid/Grid.cs
@@ -1563,11 +1563,11 @@ namespace Rock.Web.UI.Controls
                     }
 
                     // print data
-                    foreach ( DataRow row in data.Rows )
+                    foreach ( DataRowView rowView in data.DefaultView )
                     {
                         for ( int i = 0; i < data.Columns.Count; i++ )
                         {
-                            SetExcelValue( worksheet.Cells[rowCounter, i + 1], row[i] );
+                            SetExcelValue( worksheet.Cells[rowCounter, i + 1], rowView.Row[i] );
                         }
 
                         rowCounter++;
@@ -2183,8 +2183,9 @@ namespace Rock.Web.UI.Controls
                 {
                     DataTable data = this.DataSourceAsDataTable;
 
-                    foreach ( DataRow row in data.Rows )
+                    foreach ( DataRowView rowView in data.DefaultView )
                     {
+                        DataRow row = rowView.Row;
                         object dataKey = row[dataKeyColumn];
                         if ( !keysSelected.Any() || keysSelected.Contains( dataKey ) )
                         {

--- a/Rock/Web/UI/Controls/Grid/Grid.cs
+++ b/Rock/Web/UI/Controls/Grid/Grid.cs
@@ -2471,7 +2471,7 @@ namespace Rock.Web.UI.Controls
             entitySet.ExpireDateTime = RockDateTime.Now.AddMinutes( 5 );
 
             int itemOrder = 0;
-            foreach ( var row in this.DataSourceAsDataTable.Rows.OfType<DataRow>() )
+            foreach ( DataRowView row in this.DataSourceAsDataTable.DefaultView )
             {
                 try
                 {
@@ -2480,7 +2480,7 @@ namespace Rock.Web.UI.Controls
                     if ( entitySet.EntityTypeId.HasValue && dataKeyColumn != null )
                     {
                         // we know the EntityTypeId, so set the EntityId to the dataKeyColumn value
-                        item.EntityId = ( row[dataKeyColumn] as int? ) ?? 0;
+                        item.EntityId = ( row[dataKeyColumn.ColumnName] as int? ) ?? 0;
                     }
                     else
                     {
@@ -2492,7 +2492,7 @@ namespace Rock.Web.UI.Controls
                     item.AdditionalMergeValues = new Dictionary<string, object>();
                     foreach ( var col in this.DataSourceAsDataTable.Columns.OfType<DataColumn>() )
                     {
-                        item.AdditionalMergeValues.Add( col.ColumnName, row[col] );
+                        item.AdditionalMergeValues.Add( col.ColumnName, row[col.ColumnName] );
                     }
 
                     entitySet.Items.Add( item );


### PR DESCRIPTION
# Context
When exporting data to Excel or using the Communication tool from a filtered DynamicData block, it always used all the data instead of using the data with the filter applied.

# Goal
This updates the PersonData and ExcelExport to used the applied RowFilter.

# Strategy
Use the DefaultView of the DataTable instead of just iterating through the Rows.

# Possible Implications
It's possible that exporting all the data is someone's desired behavior.  I think this is unlikely but it's hard to know these kinds of things.
