### PR TITLE
Group finder: show info window if no detail page

### DIFF
--- a/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
@@ -370,9 +370,10 @@ namespace RockWeb.Blocks.Groups
         /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
         protected void gGroups_RowSelected( object sender, RowEventArgs e )
         {
-            if ( !NavigateToLinkedPage( "GroupDetailPage", "GroupId", e.RowKeyId ) )
+            if (!NavigateToLinkedPage("GroupDetailPage", "GroupId", e.RowKeyId))
             {
                 ShowResults();
+                ScriptManager.RegisterStartupScript(pnlMap, pnlMap.GetType(), "group-finder-row-selected", "openInfoWindowById("+e.RowKeyId+");", true);
             }
         }
 
@@ -1381,6 +1382,16 @@ namespace RockWeb.Blocks.Groups
 
         }}
 
+        function openInfoWindowById(id) {{
+            marker = $.grep(allMarkers, function(m) {{ return m.id == id }})[0];
+            openInfoWindow(marker);
+        }}
+
+        function openInfoWindow(marker) {{
+            infoWindow.setContent( $('<div/>').html(marker.info_window).text() );
+            infoWindow.open(map, marker);
+        }}
+
         function addMapItem( i, mapItem, color ) {{
 
             var items = [];
@@ -1400,11 +1411,13 @@ namespace RockWeb.Blocks.Groups
                     new google.maps.Point(10, 34));
 
                 marker = new google.maps.Marker({{
+                    id: mapItem.EntityId,
                     position: position,
                     map: map,
                     title: htmlDecode(mapItem.Name),
                     icon: pinImage,
-                    shadow: pinShadow
+                    shadow: pinShadow,
+                    info_window: mapItem.InfoWindow
                 }});
     
                 items.push(marker);
@@ -1413,8 +1426,7 @@ namespace RockWeb.Blocks.Groups
                 if ( mapItem.InfoWindow != null ) {{ 
                     google.maps.event.addListener(marker, 'click', (function (marker, i) {{
                         return function () {{
-                            infoWindow.setContent( $('<div/>').html(mapItem.InfoWindow).text() );
-                            infoWindow.open(map, marker);
+                            openInfoWindow(marker);
                         }}
                     }})(marker, i));
                 }}


### PR DESCRIPTION
# Context
When using a group finder block that does not have a group detail page set, clicking on a group in the grid view just reloads the page with no visible change.

# Goal
Give users better visual feedback after selecting a group, given the context

# Strategy
Show the info window when group is clicked.
In the postback, when there is no group detail page set, a javascript function is called that opens the corresponding infowindow.

# Possible Implications
None I can see

# Note
This is not a perfect solution as it would probably be better to not fire the post back at all, but I was having trouble trying to dynamically set the OnRowSelected attribute for the grid. If there is a better way to implement this, feel free to change it.
