### PR TITLE
Person Search Performance

### DIFF
--- a/RockWeb/Blocks/Crm/PersonSearch.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonSearch.ascx.cs
@@ -262,6 +262,10 @@ namespace RockWeb.Blocks.Crm
                         }
                 }
 
+                var personIdList = people.Select( p => p.Id ).ToList();
+
+                people = personService.Queryable(true).Where( p => personIdList.Contains( p.Id ) );
+				
                 SortProperty sortProperty = gPeople.SortProperty;
                 if ( sortProperty != null )
                 {


### PR DESCRIPTION
# Context
Person search was incredibly slow.  Even with a search that matched a single record, it took around 5 seconds for the search to execute before being redirected to the person's profile.  This PR updates the person search to first load a list of id's and then re-query for all the rest of their data as this significantly speeds up the person search block.

# Goal
This is drastically faster (and a relatively small change)

# Strategy
This does a search first just to get the person id's that matches, then does a secondary search to load all their data.

# Possible Implications
None that I know of.  It seems to work fine and improve speed no matter the size of the result set.