### PR TITLE
- Fix ContentChannelView query parameter filtering not working with a…

### DIFF
--- a/RockWeb/Blocks/Cms/ContentChannelView.ascx.cs
+++ b/RockWeb/Blocks/Cms/ContentChannelView.ascx.cs
@@ -827,9 +827,8 @@ $(document).ready(function() {
                                                 break;
                                             case Rock.SystemGuid.FieldType.MULTI_SELECT:
                                                 {
-                                                    var values = new List<string>();
-                                                    values.Add( value );
-                                                    selection.Add( Newtonsoft.Json.JsonConvert.SerializeObject( values ) );
+                                                    selection.Add( ComparisonType.Contains.ConvertToInt().ToString() );
+                                                    selection.Add( value );
                                                 }
                                                 break;
                                             default:


### PR DESCRIPTION
# Context
If a Content Channel Item has a MultiSelect attribute, query parameter filter wasn't working.  For example, if a Content Channel Item has a FavoriteColors of Red,Blue,Green, a ?FavoriteColors=Blue wasn't working

# Goal
Fix ContentChannelItem to send the filter parameters to the propertryFilter expression builder correctly

# Strategy
small code change to fix it

# Possible Implications
if somebody had written a content channel view and had used a MultiSelect query parameter, it wouldn't have had any effect.  So, with the bug fix, it will now filter correctly

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

… MultiSelect fieldtype