### PR TITLE
PostAttendanceToGroup Improvements

### DIFF
--- a/Rock/Workflow/Action/Groups/PostAttendanceToGroup.cs
+++ b/Rock/Workflow/Action/Groups/PostAttendanceToGroup.cs
@@ -189,7 +189,6 @@ namespace Rock.Workflow.Action
                         else
                         {
                             action.AddLogEntry(string.Format("{0} was not a member of the group {1} and the action was not configured to add them.", person.FullName, group.Name));
-                            return true;
                         }
                     }
 
@@ -199,6 +198,7 @@ namespace Rock.Workflow.Action
                     attendance.GroupId = group.Id;
                     attendance.PersonAliasId = person.PrimaryAliasId;
                     attendance.StartDateTime = attendanceDateTime;
+                    attendance.CampusId = group.CampusId;
                     attendance.DidAttend = true;
 
                     if ( locationGuid != Guid.Empty )


### PR DESCRIPTION
# Context
The Post Attendance to Group workflow action does not set the campus id for a given location. And the action will fail if the person who's attendance is being posted is not already in the group.

The description for Add To Group implies that attendance should be posted despite group membership. As does the add [log entry action](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock/Workflow/Action/Groups/PostAttendanceToGroup.cs#L191) on line 191 of the PostAttendanceToGroup.cs file, since it is a log entry rather than an error.

# Goal
Allow attendance markings without being part of a group, or being added to a group (similar behavior to check-in kiosks). Also include the campus id in the attendance marking. 

# Strategy
This PR removes the return statement that stops attendance from being posted when a person does not have group membership. It also adds the campus id from the group, as found in the SaveAttendance file for checkin.

# Possible Implications
There might be a good reason to stop attendance from being marked where a person is not a member of a group. Since it's part of a workflow it could be stopped elsewhere, or by adding boolean value of "Allow Guest Attendance", "Create attendance record if a person is not already a member." But since there are

