### PR TITLE
Adding "New Tab" support for SignNow

### DIFF
--- a/RockWeb/Blocks/Event/DocumentReturn.html
+++ b/RockWeb/Blocks/Event/DocumentReturn.html
@@ -2,6 +2,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title></title>
+    <script>
+        // This handles the callback when SignNow redirects back to Rock.
+        if (window.opener && window.opener.processIframeReturn) {
+            window.opener.processIframeReturn(window.location.search);
+            window.close();
+        }
+    </script>
 </head>
 <body>
 </body>

--- a/RockWeb/Blocks/Event/DocumentReturn.html
+++ b/RockWeb/Blocks/Event/DocumentReturn.html
@@ -3,13 +3,86 @@
 <head>
     <title></title>
     <script>
-        // This handles the callback when SignNow redirects back to Rock.
-        if (window.opener && window.opener.processIframeReturn) {
-            window.opener.processIframeReturn(window.location.search);
-            window.close();
+        function closeWindow()
+        {
+            setTimeout(function ()
+            {
+                window.close();
+            }, 2500);
         }
+
+        // This handles the callback when SignNow redirects back to Rock.
+        if (window == window.top)
+        {
+            //window.opener.processIframeReturn(window.location.search);
+            window.onload = closeWindow();
+        }
+
     </script>
+    <style>
+        .loader,
+.loader:before,
+.loader:after {
+  background: #000;
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+}
+.loader {
+  color: #000;
+  text-indent: -9999em;
+  margin: 88px auto;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+.loader:before,
+.loader:after {
+  position: absolute;
+  top: 0;
+  content: '';
+}
+.loader:before {
+  left: -1.5em;
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+.loader:after {
+  left: 1.5em;
+}
+@-webkit-keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}
+@keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}
+    </style>
 </head>
 <body>
+    <div style="text-align: center; width: 100%; font-family: sans-serif;">Please wait, we are processing your request.</div>
+    <div class="loader">Processing...</div>
 </body>
 </html>

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx
@@ -70,7 +70,8 @@
             <asp:HiddenField ID="hfRequiredDocumentLinkUrl" runat="server" />
             <asp:HiddenField ID="hfRequiredDocumentQueryString" runat="server" />
 
-            <iframe id="iframeRequiredDocument" frameborder="0" ></iframe>
+            <iframe id="iframeRequiredDocument" frameborder="0" runat="server" Visible="false" ClientIDMode="Static"></iframe>
+            <asp:Button id="btnRequiredDocument" runat="server" Visible="false" OnClientClick="var win = window.open($('input[id$=hfRequiredDocumentLinkUrl]').val(), '_blank');win.focus(); return false;" Text="Open Document" CssClass="btn btn-default pull-right"></asp:Button>
             <span style="display:none" >
                 <asp:LinkButton ID="lbRequiredDocumentNext" runat="server" Text="Required Document Return" OnClick="lbRequiredDocumentNext_Click" CausesValidation="false" ></asp:LinkButton>
             </span>

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx
@@ -69,6 +69,7 @@
             <Rock:NotificationBox ID="nbDigitalSignature" runat="server" NotificationBoxType="Info"></Rock:NotificationBox>
             <asp:HiddenField ID="hfRequiredDocumentLinkUrl" runat="server" />
             <asp:HiddenField ID="hfRequiredDocumentQueryString" runat="server" />
+            <asp:HiddenField ID="hfRegistrantGuid" runat="server" ClientIDMode="Static" />
 
             <iframe id="iframeRequiredDocument" frameborder="0" runat="server" Visible="false" ClientIDMode="Static"></iframe>
             <asp:Button id="btnRequiredDocument" runat="server" Visible="false" OnClientClick="var win = window.open($('input[id$=hfRequiredDocumentLinkUrl]').val(), '_blank');win.focus(); return false;" Text="Open Document" CssClass="btn btn-default pull-right"></asp:Button>

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -3198,9 +3198,9 @@ namespace RockWeb.Blocks.Event
                     if ( !string.IsNullOrWhiteSpace( inviteLink ) )
                     {
                         string returnUrl = GlobalAttributesCache.Read().GetValue( "PublicApplicationRoot" ).EnsureTrailingForwardslash() +
-                            ResolveRockUrl( Request.RawUrl + "?registration_key=" + RegistrationState.Registrants[CurrentRegistrantIndex].Guid ).TrimStart( '/' );
+                            ResolveRockUrl( Request.RawUrl + (Request.QueryString.Count == 0 ? "?" : "&") + "registration_key=" + RegistrationState.Registrants[CurrentRegistrantIndex].Guid ).TrimStart( '/' );
 
-                        hfRequiredDocumentLinkUrl.Value = string.Format( "{0}?redirect_uri={1}", inviteLink, returnUrl );
+                        hfRequiredDocumentLinkUrl.Value = string.Format( "{0}?redirect_uri={1}", inviteLink, returnUrl.UrlEncode() );
                         hfRegistrantGuid.Value = RegistrationState.Registrants[CurrentRegistrantIndex].Guid.ToString();
                     }
                     else
@@ -3601,7 +3601,7 @@ namespace RockWeb.Blocks.Event
     poll = function() {{
        setTimeout(function(){{
           $.ajax({{ 
-            url: '{22}?registration_key='+$('#hfRegistrantGuid').val(), 
+            url: '{22}registration_key='+$('#hfRegistrantGuid').val(), 
             success: function(data){{
                 //
                 if (data != ''&& data.startsWith('?document_id') ) {{
@@ -3647,7 +3647,7 @@ namespace RockWeb.Blocks.Event
             ,hfRequiredDocumentQueryString.ClientID // {19}
             ,this.Page.ClientScript.GetPostBackEventReference( lbRequiredDocumentNext, "" ) // {20}
             ,hfRequiredDocumentLinkUrl.ClientID     // {21}
-            , this.Request.RawUrl // {22}
+            , this.Request.RawUrl + ( Request.QueryString.Count == 0 ? "?" : "&" ) // {22}
 );
 
             ScriptManager.RegisterStartupScript( Page, Page.GetType(), "registrationEntry", script, true );


### PR DESCRIPTION
# Context

Iframe support for SignNow was pretty sketchy on mobile and IE
# Goal

This adds a block setting which will open the document in a new tab instead of the iframe
# Strategy

Added a block attribute to configure whether to use an Iframe or a new tab.  If new tab is selected, the button actually opens the document in a new tab and then the DocumentReturn.html has a little javascript to tell the window.opener what the DocumentId is.
# Possible Implications

The default is Iframe so it shouldn't cause anything to break for people who are already using this (shouldn't be too many people).
# Screenshots

![image](https://cloud.githubusercontent.com/assets/1248118/19400927/7cb5ce18-9226-11e6-8278-1c997fc3a951.png)
