### PR TITLE
Feature mp groupmap campusfilter

### DIFF
--- a/Rock.Rest/Controllers/GroupsController.Partial.cs
+++ b/Rock.Rest/Controllers/GroupsController.Partial.cs
@@ -795,11 +795,26 @@ namespace Rock.Rest.Controllers
         /// <param name="groupId">The group identifier.</param>
         /// <param name="statusId">The status identifier.</param>
         /// <returns></returns>
-        /// <exception cref="System.Web.Http.HttpResponseException">
-        /// </exception>
         [Authenticate, Secured]
         [System.Web.Http.Route( "api/Groups/GetMapInfo/{groupId}/Families/{statusId}" )]
         public IQueryable<MapItem> GetFamiliesMapInfo( int groupId, int statusId )
+        {
+            return GetFamiliesMapInfo( groupId, statusId, null );
+        }
+
+        /// <summary>
+        /// Gets the families map information.
+        /// </summary>
+        /// <param name="groupId">The group identifier.</param>
+        /// <param name="statusId">The status identifier.</param>
+        /// <param name="campusIds">If specified, only show families that are associated with any of the campus ids.</param>
+        /// <returns></returns>
+        /// <exception cref="HttpResponseException">
+        /// </exception>
+        /// <exception cref="System.Web.Http.HttpResponseException"></exception>
+        [Authenticate, Secured]
+        [System.Web.Http.Route( "api/Groups/GetMapInfo/{groupId}/Families/{statusId}" )]
+        public IQueryable<MapItem> GetFamiliesMapInfo( int groupId, int statusId, string campusIds)
         {
             // Enable proxy creation since security is being checked and need to navigate parent authorities
             SetProxyCreation( true );
@@ -838,6 +853,7 @@ namespace Rock.Rest.Controllers
                                 l.Location,
                                 l.Group.Id,
                                 l.Group.Name,
+                                l.Group.CampusId,
                                 MinStatus = l.Group.Members
                                     .Where( m =>
                                         m.Person.RecordStatusValueId.HasValue &&
@@ -847,6 +863,12 @@ namespace Rock.Rest.Controllers
                                     .Select( m => m.Person.ConnectionStatusValue.Id )
                                     .FirstOrDefault()
                             } );
+
+                        var campusIdList = ( campusIds ?? string.Empty ).SplitDelimitedValues().AsIntegerList();
+                        if ( campusIdList.Any() )
+                        {
+                            families = families.Where( a => a.CampusId.HasValue && campusIdList.Contains( a.CampusId.Value ) );
+                        }
 
                         foreach ( var family in families.Where( f => f.MinStatus == statusId ) )
                         {

--- a/RockWeb/Blocks/Groups/GroupMap.ascx
+++ b/RockWeb/Blocks/Groups/GroupMap.ascx
@@ -29,6 +29,8 @@
             <div class="panel-body">
 
                 <asp:Literal ID="lMapStyling" runat="server" />
+
+                <Rock:CampusesPicker ID="cpCampuses" runat="server" CssClass="js-campuses-picker" Label="Campus Filter" Help="Select the campuses to narrow the results down to families with that home campus." Required="false" />
         
                 <div class="form-inline clearfix">
 

--- a/RockWeb/Blocks/Groups/GroupMap.ascx
+++ b/RockWeb/Blocks/Groups/GroupMap.ascx
@@ -30,7 +30,7 @@
 
                 <asp:Literal ID="lMapStyling" runat="server" />
 
-                <Rock:CampusesPicker ID="cpCampuses" runat="server" CssClass="js-campuses-picker" Label="Campus Filter" Help="Select the campuses to narrow the results down to families with that home campus." Required="false" />
+                <Rock:CampusesPicker ID="cpCampuses" runat="server" FormGroupCssClass="js-campuses-picker" Label="Campus Filter" Help="Select the campuses to narrow the results down to families with that home campus." Required="false" />
         
                 <div class="form-inline clearfix">
 

--- a/RockWeb/Blocks/Groups/GroupMap.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupMap.ascx.cs
@@ -304,6 +304,9 @@ namespace RockWeb.Blocks.Groups
 
         initializeMap();
 
+        // the campuses picker only applies to the connection status checkboxes        
+        $('.js-campuses-picker').hide();
+
         function initializeMap() {{
 
             // Set default map options
@@ -485,6 +488,9 @@ namespace RockWeb.Blocks.Groups
 
                 if ( mapItem.EntityId == {0} ) {{
                     $('.js-connection-status').show();
+                    
+                    // the campuses picker only applies to the connection status checkboxes
+                    $('.js-campuses-picker').show();
                 }}
         
             }}

--- a/RockWeb/Blocks/Groups/GroupMap.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupMap.ascx.cs
@@ -50,6 +50,7 @@ namespace RockWeb.Blocks.Groups
     [DefinedValueField( Rock.SystemGuid.DefinedType.MAP_STYLES, "Map Style", "The map theme that should be used for styling the map.", true, false, Rock.SystemGuid.DefinedValue.MAP_STYLE_GOOGLE, "", 3 )]
     [IntegerField( "Map Height", "Height of the map in pixels (default value is 600px)", false, 600, "", 4 )]
     [TextField( "Polygon Colors", "Comma-Delimited list of colors to use when displaying multiple polygons (e.g. #f37833,#446f7a,#afd074,#649dac,#f8eba2,#92d0df,#eaf7fc).", true, "#f37833,#446f7a,#afd074,#649dac,#f8eba2,#92d0df,#eaf7fc", "", 5 )]
+    [BooleanField( "Show Campuses Filter", "", false, order: 6 )]
     [CodeEditorField( "Info Window Contents", "Liquid template for the info window. To suppress the window provide a blank template.", CodeEditorMode.Lava, CodeEditorTheme.Rock, 600, false, @"
 <div style='width:250px'>
 
@@ -96,7 +97,7 @@ namespace RockWeb.Blocks.Groups
 	{% endif %}
 
 </div>
-", "", 6 )]
+", "", 7 )]
     public partial class GroupMap : Rock.Web.UI.RockBlock
     {
         #region Fields
@@ -167,8 +168,12 @@ namespace RockWeb.Blocks.Groups
                         Color = ( v.GetAttributeValue( "Color" ) ?? "" ).Replace( "#", "" )
                     } )
                     .ToList();
+
                 rptStatus.DataSource = statuses.Where( s => s.Color != "" ).ToList();
                 rptStatus.DataBind();
+                
+                cpCampuses.Campuses = CampusCache.All();
+                cpCampuses.Visible = this.GetAttributeValue( "ShowCampusesFilter" ).AsBoolean();
 
                 Map();
             }
@@ -276,6 +281,7 @@ namespace RockWeb.Blocks.Groups
         var childGroupItems = [];
         var groupMemberItems = [];
         var familyItems = {{}};
+        var fetchFamiliesPromise = {{}};
 
         var map;
         var bounds = new google.maps.LatLngBounds();
@@ -514,16 +520,49 @@ namespace RockWeb.Blocks.Groups
             }}
         }});
 
+        $('.js-campuses-picker input').click( function() {{
+            // clear out all the family markers since we have a new set of Campuses
+            $('.js-connection-status-cb').each( function(i) {{
+                var statusId = $(this).attr('data-item');   
+                if (familyItems[statusId] !== undefined) {{
+                    setAllMap(familyItems[statusId], null);      
+                }}          
+            }});
+            familyItems = {{}};
+    
+            // re-select and fetch the familyitems for each selected connection status using the new set of campusids
+            $('.js-connection-status-cb:checked').each( function(i) {{
+                $(this).attr('checked', false);
+                $(this).click();                    
+            }});    
+        }});
+
         // Show/Hide families
         $('.js-connection-status-cb').click( function() {{
             var statusId = $(this).attr('data-item');
+
+            var campusIds = '';            
+            $('.js-campuses-picker input:checked').each(function(i) {{
+                campusIds += $(this).val() + ',';
+            }});
+
             if ($(this).prop('checked')) {{
                 if (typeof familyItems[statusId] !== 'undefined') {{
                     setAllMap(familyItems[statusId], map);
                 }} else {{
                     familyItems[statusId] = [];
                     var color = $(this).attr('data-color');
-                    $.get( Rock.settings.get('baseUrl') + 'api/Groups/GetMapInfo/{0}/Families/' + statusId, function( mapItems ) {{
+                    var getMapInfoUrl = Rock.settings.get('baseUrl') + 'api/Groups/GetMapInfo/{0}/Families/' + statusId;
+                    if (campusIds != '') {{
+                        getMapInfoUrl += '?campusIds=' + campusIds;
+                    }}
+
+                    // if we are already in the process of fetching families for this status, abort and start over again
+                    if (fetchFamiliesPromise[statusId] !== undefined) {{
+                        fetchFamiliesPromise[statusId].abort();
+                    }}
+
+                    fetchFamiliesPromise[statusId] = $.get( getMapInfoUrl, function( mapItems ) {{
                         $.each(mapItems, function (i, mapItem) {{
                             var items = addMapItem(i, mapItem, color);
                             for (var i = 0; i < items.length; i++) {{


### PR DESCRIPTION
# Context

At CCV, our Neighborhood Groups (small groups) are organized by Campus and Region, and there are sometimes 1000s of people inside those regions.  In CCVs case, when somebody clicks on the Map icon for a Neighborhood Group Region, they are typically just concerned about a specific campus.  
# Goal / # Strategy

This pull request adds an "Show Campus Filter" option to GroupMap.  The option defaults to false, since it is probably a feature that most places won't use.  If it is enabled, a Campus Filter will show up which will limit which Families show up when the "ConnectionStatus" checkboxes are toggled. (If no campuses are selected, it won't filter by campus)
# Possible Implications

The block has a couple of modes where it doesn't show Connection Status checkboxes, so I made sure that the CampusFilter won't be showing in that case.
# Screenshots

![pasted image at 2016_10_17 03_04 pm](https://cloud.githubusercontent.com/assets/2430748/19490910/e0bc73ec-9525-11e6-8ae4-87313f388188.png)

…edit the block settings.
