### PR TITLE
- Tweak Linq that filters FinancialTransactions by a specific GivingI…

### DIFF
--- a/Rock.Rest/Controllers/FinancialTransactionsController.Partial.cs
+++ b/Rock.Rest/Controllers/FinancialTransactionsController.Partial.cs
@@ -368,7 +368,11 @@ namespace Rock.Rest.Controllers
                 throw new HttpResponseException( response );
             }
 
-            return Get().Where( t => t.AuthorizedPersonAlias.Person.GivingId == givingId );
+            // fetch all the possible PersonAliasIds that have this GivingID to help optimize the SQL
+            var personAliasIds = new PersonAliasService( (RockContext)this.Service.Context ).Queryable().Where( a => a.Person.GivingId == givingId ).Select( a => a.Id ).ToList();
+
+            // get the transactions for the person or all the members in the person's giving group (Family)
+            return Get().Where( t => t.AuthorizedPersonAliasId.HasValue && personAliasIds.Contains( t.AuthorizedPersonAliasId.Value ) );
         }
 
         /// <summary>

--- a/RockWeb/Blocks/Finance/TransactionList.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionList.ascx.cs
@@ -970,8 +970,11 @@ namespace RockWeb.Blocks.Finance
                 // otherwise set the selection based on filter settings
                 if ( _person != null )
                 {
+                    // fetch all the possible PersonAliasIds that have this GivingID to help optimize the SQL
+                    var personAliasIds = new PersonAliasService( rockContext ).Queryable().Where( a => a.Person.GivingId == _person.GivingId ).Select( a => a.Id ).ToList();
+
                     // get the transactions for the person or all the members in the person's giving group (Family)
-                    qry = qry.Where( t => t.AuthorizedPersonAlias.Person.GivingId == _person.GivingId );
+                    qry = qry.Where( t => t.AuthorizedPersonAliasId.HasValue && personAliasIds.Contains(t.AuthorizedPersonAliasId.Value) );
                 }
 
                 // Date Range
@@ -1064,7 +1067,11 @@ namespace RockWeb.Blocks.Finance
                         var filterPerson = new PersonService( rockContext ).Get( filterPersonId.Value );
                         if ( filterPerson != null )
                         {
-                            qry = qry.Where( t => t.AuthorizedPersonAlias.Person.GivingId == filterPerson.GivingId );
+                            // fetch all the possible PersonAliasIds that have this GivingID to help optimize the SQL
+                            var personAliasIds = new PersonAliasService( rockContext ).Queryable().Where( a => a.Person.GivingId == filterPerson.GivingId ).Select( a => a.Id ).ToList();
+
+                            // get the transactions for the person or all the members in the person's giving group (Family)
+                            qry = qry.Where( t => t.AuthorizedPersonAliasId.HasValue && personAliasIds.Contains( t.AuthorizedPersonAliasId.Value ) );
                         }
                     }
                 }


### PR DESCRIPTION
# Context
When using the TransactionList block with a PersonFilter or PersonContext, the query is often much slower than it should be

# Goal / # Strategy
The cause of the slowness seemed to be a direct result of the LINQ generating an OUTER JOIN on Person and PersonAlias which is much more costly vs an INNER JOIN.  This PR avoids the JOIN altogether by prefetching all the possible PersonAliasIds that are associated with the specified GivingID

In my testing, this made the TransactionList grid quite a bit faster in cases were a specific person (GivingID) is the filter.  For example, the Person Contribution tab used to take around 4-5+ seconds, but now is around 1-2 seconds

# Possible Implications
Anytime the LINQ is tweaked, there is a risk that what is faster for one situation could end up being slower in another.  In this case, I think the risk of this is minimal to none.  The other possible risk is if somehow a GivingID is associated with 1000s of PersonAliasIds.  I'm not sure how that could happen unless there is an extremely large family :)

# Screenshots
--

…d to prefetch the personAliasIds associated with that GivingId. This helps optimize the SQL and avoid a costly outer join on PersonAlias and Person