### PR TITLE
Added Public Name and Description to the AccountSummary class in the ContributionStatementLava page so that either of these values can be used in place of Name on the statement.

### DIFF
--- a/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
@@ -44,10 +44,22 @@ namespace RockWeb.Blocks.Finance
         {
             base.OnLoad( e );
 
+            var accountId = PageParameter("accountId").AsInteger();
             if ( !Page.IsPostBack )
             {
-                ShowDetail( PageParameter( "accountId" ).AsInteger() );
+                ShowDetail( accountId );
             }
+
+            // Add any attribute controls. 
+            // This must be done here regardless of whether it is a postback so that the attribute values will get saved.
+            var account = new FinancialAccountService(new RockContext()).Get(accountId);
+            if (account == null)
+            {
+                account = new FinancialAccount();
+            }
+            account.LoadAttributes();
+            phAttributes.Controls.Clear();
+            Helper.AddEditControls(account, phAttributes, true, BlockValidationGroup);
         }
 
         #endregion
@@ -159,22 +171,15 @@ namespace RockWeb.Blocks.Finance
 
             hfAccountId.Value = account.Id.ToString();
 
-            bool readOnly = false;
-
             nbEditModeMessage.Text = string.Empty;
-            if ( !editAllowed || !editAllowed )
+            if (editAllowed)
             {
-                readOnly = true;
-                nbEditModeMessage.Text = EditModeMessage.ReadOnlyEditActionNotAllowed( FinancialAccount.FriendlyTypeName );
-            }
-
-            if ( readOnly )
-            {
-                ShowReadonlyDetails( account );
+                ShowEditDetails(account);
             }
             else
             {
-                ShowEditDetails( account );
+                nbEditModeMessage.Text = EditModeMessage.ReadOnlyEditActionNotAllowed(FinancialAccount.FriendlyTypeName);
+                ShowReadonlyDetails(account);
             }
         }
 
@@ -195,10 +200,6 @@ namespace RockWeb.Blocks.Finance
             {
                 lActionTitle.Text = account.Name.FormatAsHtmlTitle();
             }
-
-            account.LoadAttributes();
-            phAttributes.Controls.Clear();
-            Rock.Attribute.Helper.AddEditControls( account, phAttributes, true, BlockValidationGroup );
 
             hlInactive.Visible = !account.IsActive;
 

--- a/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
@@ -44,22 +44,10 @@ namespace RockWeb.Blocks.Finance
         {
             base.OnLoad( e );
 
-            var accountId = PageParameter("accountId").AsInteger();
             if ( !Page.IsPostBack )
             {
-                ShowDetail( accountId );
+                ShowDetail( PageParameter( "accountId" ).AsInteger() );
             }
-
-            // Add any attribute controls. 
-            // This must be done here regardless of whether it is a postback so that the attribute values will get saved.
-            var account = new FinancialAccountService(new RockContext()).Get(accountId);
-            if (account == null)
-            {
-                account = new FinancialAccount();
-            }
-            account.LoadAttributes();
-            phAttributes.Controls.Clear();
-            Helper.AddEditControls(account, phAttributes, true, BlockValidationGroup);
         }
 
         #endregion
@@ -171,15 +159,22 @@ namespace RockWeb.Blocks.Finance
 
             hfAccountId.Value = account.Id.ToString();
 
+            bool readOnly = false;
+
             nbEditModeMessage.Text = string.Empty;
-            if (editAllowed)
+            if ( !editAllowed || !editAllowed )
             {
-                ShowEditDetails(account);
+                readOnly = true;
+                nbEditModeMessage.Text = EditModeMessage.ReadOnlyEditActionNotAllowed( FinancialAccount.FriendlyTypeName );
+            }
+
+            if ( readOnly )
+            {
+                ShowReadonlyDetails( account );
             }
             else
             {
-                nbEditModeMessage.Text = EditModeMessage.ReadOnlyEditActionNotAllowed(FinancialAccount.FriendlyTypeName);
-                ShowReadonlyDetails(account);
+                ShowEditDetails( account );
             }
         }
 
@@ -200,6 +195,10 @@ namespace RockWeb.Blocks.Finance
             {
                 lActionTitle.Text = account.Name.FormatAsHtmlTitle();
             }
+
+            account.LoadAttributes();
+            phAttributes.Controls.Clear();
+            Rock.Attribute.Helper.AddEditControls( account, phAttributes, true, BlockValidationGroup );
 
             hlInactive.Visible = !account.IsActive;
 

--- a/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
@@ -342,9 +342,17 @@ namespace RockWeb.Blocks.Finance
             }
 
             mergeFields.Add( "TransactionDetails", qry.ToList() );
-                        
-            mergeFields.Add( "AccountSummary", qry.GroupBy( t => t.Account.Name ).Select( s => new AccountSummary { AccountName = s.Key, Total = s.Sum( a => a.Amount ), Order = s.Max(a => a.Account.Order) } ).OrderBy(s => s.Order ));
 
+            mergeFields.Add("AccountSummary", qry.GroupBy(t => new { t.Account.Name, t.Account.PublicName, t.Account.Description })
+                                                .Select(s => new AccountSummary
+                                                {
+                                                    AccountName = s.Key.Name,
+                                                    PublicName = s.Key.PublicName,
+                                                    Description = s.Key.Description,
+                                                    Total = s.Sum(a => a.Amount),
+                                                    Order = s.Max(a => a.Account.Order)
+                                                })
+                                                .OrderBy(s => s.Order));
             // pledge information
             var pledges = new FinancialPledgeService( rockContext ).Queryable().AsNoTracking()
                                 .Where( p =>
@@ -480,6 +488,22 @@ namespace RockWeb.Blocks.Finance
             /// The name of the account.
             /// </value>
             public string AccountName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the public name of the account.
+            /// </summary>
+            /// <value>
+            /// The public name of the account.
+            /// </value>
+            public string PublicName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the description of the account.
+            /// </summary>
+            /// <value>
+            /// The description of the account.
+            /// </value>
+            public string Description { get; set; }
 
             /// <summary>
             /// Gets or sets the total.


### PR DESCRIPTION
# Context
Our finance department wanted first to be able to use PublicName instead of Name on the Contribution Statement, but then seeing that PublicName is used in the Account Picker they decided to use Description. These were not available options in the Summary section.

# Goal
To give churches options on which fields they want to show in the summary on the Contribution Statement

# Strategy
Added the properties to the class and populate them.

# Possible Implications
None

# Screenshots
None