### PR TITLE
Added PublicName and Description to the AccountSummary on the Contribution Statement.

### DIFF
--- a/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
@@ -342,9 +342,17 @@ namespace RockWeb.Blocks.Finance
             }
 
             mergeFields.Add( "TransactionDetails", qry.ToList() );
-                        
-            mergeFields.Add( "AccountSummary", qry.GroupBy( t => t.Account.Name ).Select( s => new AccountSummary { AccountName = s.Key, Total = s.Sum( a => a.Amount ), Order = s.Max(a => a.Account.Order) } ).OrderBy(s => s.Order ));
 
+            mergeFields.Add("AccountSummary", qry.GroupBy(t => new { t.Account.Name, t.Account.PublicName, t.Account.Description })
+                                                .Select(s => new AccountSummary
+                                                {
+                                                    AccountName = s.Key.Name,
+                                                    PublicName = s.Key.PublicName,
+                                                    Description = s.Key.Description,
+                                                    Total = s.Sum(a => a.Amount),
+                                                    Order = s.Max(a => a.Account.Order)
+                                                })
+                                                .OrderBy(s => s.Order));
             // pledge information
             var pledges = new FinancialPledgeService( rockContext ).Queryable().AsNoTracking()
                                 .Where( p =>
@@ -480,6 +488,22 @@ namespace RockWeb.Blocks.Finance
             /// The name of the account.
             /// </value>
             public string AccountName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the public name of the account.
+            /// </summary>
+            /// <value>
+            /// The public name of the account.
+            /// </value>
+            public string PublicName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the description of the account.
+            /// </summary>
+            /// <value>
+            /// The description of the account.
+            /// </value>
+            public string Description { get; set; }
 
             /// <summary>
             /// Gets or sets the total.


### PR DESCRIPTION
# Context
Our finance department wanted first to be able to use PublicName instead of Name on the Contribution Statement, but then seeing that PublicName is used in the Account Picker they decided to use Description. These were not available options in the Summary section.

# Goal
To give churches options on which fields they want to show in the summary on the Contribution Statement

# Strategy
Added the properties to the class and populate them.

# Possible Implications
None

# Screenshots
None