### PR TITLE
Account Entity Attributes will now save properly from the AccountDetail Block.

### DIFF
--- a/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx.cs
@@ -44,10 +44,22 @@ namespace RockWeb.Blocks.Finance
         {
             base.OnLoad( e );
 
+            var accountId = PageParameter("accountId").AsInteger();
             if ( !Page.IsPostBack )
             {
-                ShowDetail( PageParameter( "accountId" ).AsInteger() );
+                ShowDetail( accountId );
             }
+
+            // Add any attribute controls. 
+            // This must be done here regardless of whether it is a postback so that the attribute values will get saved.
+            var account = new FinancialAccountService(new RockContext()).Get(accountId);
+            if (account == null)
+            {
+                account = new FinancialAccount();
+            }
+            account.LoadAttributes();
+            phAttributes.Controls.Clear();
+            Helper.AddEditControls(account, phAttributes, true, BlockValidationGroup);
         }
 
         #endregion
@@ -159,22 +171,15 @@ namespace RockWeb.Blocks.Finance
 
             hfAccountId.Value = account.Id.ToString();
 
-            bool readOnly = false;
-
             nbEditModeMessage.Text = string.Empty;
-            if ( !editAllowed || !editAllowed )
+            if (editAllowed)
             {
-                readOnly = true;
-                nbEditModeMessage.Text = EditModeMessage.ReadOnlyEditActionNotAllowed( FinancialAccount.FriendlyTypeName );
-            }
-
-            if ( readOnly )
-            {
-                ShowReadonlyDetails( account );
+                ShowEditDetails(account);
             }
             else
             {
-                ShowEditDetails( account );
+                nbEditModeMessage.Text = EditModeMessage.ReadOnlyEditActionNotAllowed(FinancialAccount.FriendlyTypeName);
+                ShowReadonlyDetails(account);
             }
         }
 
@@ -195,10 +200,6 @@ namespace RockWeb.Blocks.Finance
             {
                 lActionTitle.Text = account.Name.FormatAsHtmlTitle();
             }
-
-            account.LoadAttributes();
-            phAttributes.Controls.Clear();
-            Rock.Attribute.Helper.AddEditControls( account, phAttributes, true, BlockValidationGroup );
 
             hlInactive.Visible = !account.IsActive;
 


### PR DESCRIPTION
# Context

Account Entity Attributes could be edited on the AccountDetail block, but were not being Saved properly.
# Goal

To Save all values on the AccountDetail block properly.
# Strategy

Moved the code to display and populate the attribute edit controls up to the OnLoad() function, outside of the logic that checks for a PostBack. If the attribute controls are not created on PostBack, then they do not exist to have their values saved.
# Possible Implications

None
# Screenshots

None
# Notes

Also cleaned up a little bit of messy conditional logic in ShowDetail(), no impact on functionality.
