### PR TITLE
Creating a new batch with the Batch Detail page will default the Status to Open.

### DIFF
--- a/RockWeb/Blocks/Finance/BatchDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/BatchDetail.ascx.cs
@@ -355,7 +355,7 @@ namespace RockWeb.Blocks.Finance
 
             if ( batch == null )
             {
-                batch = new FinancialBatch { Id = 0 };
+                batch = new FinancialBatch { Id = 0, Status = BatchStatus.Open };
 
                 // hide the panel drawer that show created and last modified dates
                 pdAuditDetails.Visible = false;


### PR DESCRIPTION
# Context
When adding a new batch from the Batch List screen, the status was defaulting to Pending. The documentation states that Pending is intended for use with the check scanner to indicate that a batch is currently being imported into. 

# Goal
To save the user an extra step of marking each manual batch Open when creating it.

# Strategy
I set the status when creating a new object in the Batch Detail page only; I considered adding it to the constructor so that all batch objects would be Open by default but I thought that might have unintended consequences elsewhere in the code, and the Batch List/Detail blocks are the primary way a Batch would be created.

# Possible Implications
None

# Screenshots
None