### PR TITLE
Fixed formatting & validation of currency-typed entity attributes.

### DIFF
--- a/Rock/Field/Types/CurrencyFieldType.cs
+++ b/Rock/Field/Types/CurrencyFieldType.cs
@@ -24,7 +24,7 @@ namespace Rock.Field.Types
     /// <summary>
     /// Field used to save and display a currency amount
     /// </summary>
-    public class CurrencyFieldType : FieldType
+    public class CurrencyFieldType : DecimalFieldType
     {
 
         #region Formatting
@@ -41,12 +41,12 @@ namespace Rock.Field.Types
         }
 
         /// <summary>
-        /// Formats date display
+        /// Formats the value.
         /// </summary>
         /// <param name="parentControl">The parent control.</param>
-        /// <param name="value">Information about the value</param>
+        /// <param name="value">The value.</param>
         /// <param name="configurationValues">The configuration values.</param>
-        /// <param name="condensed">Flag indicating if the value should be condensed (i.e. for use in a grid column)</param>
+        /// <param name="condensed">if set to <c>true</c> [condensed].</param>
         /// <returns></returns>
         public override string FormatValue( System.Web.UI.Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed )
         {
@@ -60,19 +60,19 @@ namespace Rock.Field.Types
 
         #endregion
 
-            #region Edit Control
+        #region Edit Control
 
-            /// <summary>
-            /// Creates the control(s) necessary for prompting user for a new value
-            /// </summary>
-            /// <param name="configurationValues">The configuration values.</param>
-            /// <param name="id"></param>
-            /// <returns>
-            /// The control
-            /// </returns>
-        public override System.Web.UI.Control EditControl( System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues, string id )
+        /// <summary>
+        /// Creates the control(s) necessary for prompting user for a new value
+        /// </summary>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="id"></param>
+        /// <returns>
+        /// The control
+        /// </returns>
+        public override System.Web.UI.Control EditControl(System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues, string id)
         {
-            return new CurrencyBox { ID = id }; 
+            return new CurrencyBox { ID = id };
         }
 
         /// <summary>

--- a/Rock/Web/UI/Controls/CurrencyBox.cs
+++ b/Rock/Web/UI/Controls/CurrencyBox.cs
@@ -26,8 +26,17 @@ namespace Rock.Web.UI.Controls
     /// A <see cref="T:System.Web.UI.WebControls.CurrencyBox"/> control with an associated label.
     /// </summary>
     [ToolboxData( "<{0}:CurrencyBox runat=server></{0}:CurrencyBox>" )]
-    public class CurrencyBox : RockTextBox
+    public class CurrencyBox : NumberBox
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurrencyBox" /> class.
+        /// </summary>
+        public CurrencyBox()
+            : base()
+        {
+            this.NumberType = ValidationDataType.Currency;
+        }
+
         /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
         /// </summary>

--- a/Rock/Web/UI/Controls/NumberBox.cs
+++ b/Rock/Web/UI/Controls/NumberBox.cs
@@ -116,7 +116,7 @@ namespace Rock.Web.UI.Controls
             _rangeValidator.Display = ValidatorDisplay.Dynamic;
             _rangeValidator.CssClass = "validation-error help-inline";
             
-            _rangeValidator.Type = System.Web.UI.WebControls.ValidationDataType.Integer;
+            _rangeValidator.Type = this.NumberType;
             _rangeValidator.MinimumValue = int.MinValue.ToString();
             _rangeValidator.MaximumValue = int.MaxValue.ToString();
 


### PR DESCRIPTION
# Context
While working on adding Payment Detail entity attributes to the Transaction Detail edit screen (pull request coming soon), I noticed that attributes of the currency type were not being formatted or validated correctly. It was possible to enter alphabet characters into a currency attribute, which should only accept decimal numbers. 

# Goal
To correct the format and validation of currency attribute controls.

# Strategy
CurrencyFieldType now inherits from DecimalFieldType and CurrencyBox inherits from NumberBox. CurrencyBox sets its NumberType to Currency when constructed (which allows values with commas to be accepted by the validator), and NumberBox uses its current NumberType for validation rather than always using Integer. Also fixed misc. comments and formatting.

# Possible Implications
None likely.

# Screenshots
None.
