### PR TITLE
Added Payment Detail entity attributes to the Transaction Detail and Transaction Matching blocks

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx
@@ -76,6 +76,7 @@
                             <Rock:RockDropDownList ID="ddlSourceType" runat="server" Label="Source" />
                             <Rock:RockDropDownList ID="ddlCurrencyType" runat="server" Label="Currency Type" AutoPostBack="true" OnSelectedIndexChanged="ddlCurrencyType_SelectedIndexChanged" />
                             <Rock:RockDropDownList ID="ddlCreditCardType" runat="server" Label="Credit Card Type" />
+                            <asp:PlaceHolder ID="phPaymentAttributeEdits" runat="server" EnableViewState="false"></asp:PlaceHolder>
                             <Rock:FinancialGatewayPicker ID="gpPaymentGateway" runat="server" Label="Payment Gateway" ShowAll="true" />
                             <Rock:DataTextBox ID="tbTransactionCode" runat="server" Label="Transaction Code"
                                 SourceTypeName="Rock.Model.FinancialTransaction, Rock" PropertyName="TransactionCode" />

--- a/RockWeb/Blocks/Finance/TransactionMatching.ascx
+++ b/RockWeb/Blocks/Finance/TransactionMatching.ascx
@@ -79,6 +79,12 @@
                                     </asp:Panel>
                                 </div>
                             </div>
+
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <asp:PlaceHolder ID="phPaymentAttributeEdits" runat="server" EnableViewState="false"></asp:PlaceHolder>
+                                </div>
+                            </div>
                             
                             <Rock:NotificationBox ID="nbSaveError" runat="server" NotificationBoxType="Danger" Dismissable="true" Text="Warning. Unable to save..." />
                             <Rock:RockControlWrapper ID="rcwAccountSplit" runat="server" Label="Account Split" Help="Enter the amount that should be allocated to each account. The total must match the amount shown on the transaction image">

--- a/RockWeb/Blocks/Finance/TransactionMatching.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionMatching.ascx.cs
@@ -95,6 +95,30 @@ namespace RockWeb.Blocks.Finance
                 LoadDropDowns();
                 ShowDetail( PageParameter( "BatchId" ).AsInteger() );
             }
+
+            // Display Payment Detail Attributes
+            int? transactionId = hfTransactionId.Value.AsIntegerOrNull();
+            if (transactionId.HasValue)
+            {
+                using (var rockContext = new RockContext())
+                {
+                    var financialTransactionService = new FinancialTransactionService(rockContext);
+                    var txn = financialTransactionService.Queryable().Where(t => t.Id == transactionId).SingleOrDefault();
+
+                    DisplayPaymentDetailAttributeControls(txn);
+                }
+            }
+        }
+
+        /// <summary>
+        /// If there are any Payment Detail attributes, display their edit controls and populate any existing values
+        /// </summary>
+        /// <param name="txn">The <see cref="FinancialTransaction"/> to load attributes from </param>
+        protected void DisplayPaymentDetailAttributeControls(FinancialTransaction txn)
+        {
+            txn.FinancialPaymentDetail.LoadAttributes();
+            phPaymentAttributeEdits.Controls.Clear();
+            Helper.AddEditControls(txn.FinancialPaymentDetail, phPaymentAttributeEdits, true, BlockValidationGroup);
         }
 
         /// <summary>
@@ -459,6 +483,8 @@ namespace RockWeb.Blocks.Finance
                         rptrImages.DataBind();
                         nbNoTransactionImageWarning.Visible = true;
                     }
+
+                    DisplayPaymentDetailAttributeControls(transactionToMatch);
                 }
                 else
                 {
@@ -712,6 +738,10 @@ namespace RockWeb.Blocks.Finance
                 financialTransaction.ProcessedByPersonAliasId = this.CurrentPersonAlias.Id;
                 financialTransaction.ProcessedDateTime = RockDateTime.Now;
 
+                // Payment Detail Attributes
+                financialTransaction.FinancialPaymentDetail.LoadAttributes(rockContext);
+                Helper.GetEditValues(phPaymentAttributeEdits, financialTransaction.FinancialPaymentDetail);
+
                 changes.Add( "Matched transaction" );
 
                 HistoryService.SaveChanges(
@@ -726,6 +756,7 @@ namespace RockWeb.Blocks.Finance
                     false );
 
                 rockContext.SaveChanges();
+                financialTransaction.FinancialPaymentDetail.SaveAttributeValues(rockContext);
             }
             else
             {


### PR DESCRIPTION
# Context

We have the need to track transaction attributes that only apply for a given currency type. These are implemented by adding Financial Payment Detail attributes with qualifiers on CurrencyTypeValueId. In our case we have an optional attribute for Checks and a few required attributes for Stocks.
# Goal

We need to be able to set these attributes on the Transaction Detail screen when the associated currency type is chosen. We also need to allow these values to be set on the Transaction Matching screen.
# Strategy

Added code to display and save edit controls for the Payment Detail Attributes.
# Possible Implications

None
# Screenshots

Attributes for stock (Transaction Detail block):
![image](https://cloud.githubusercontent.com/assets/18447084/19656199/97b90534-99e4-11e6-8488-b6480df47640.png)

Attributes for checks (Transaction Detail block):
![image](https://cloud.githubusercontent.com/assets/18447084/19656250/c6d3dfec-99e4-11e6-899d-30d5942f1b57.png)

Attributes for checks (Transaction Matching block):
![image](https://cloud.githubusercontent.com/assets/18447084/19656297/05feae2c-99e5-11e6-8e0f-bdb945ab63a4.png)
