### PR TITLE
Reload Transaction amounts after changing displayed accounts on Transaction Matching screen.

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionMatching.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionMatching.ascx.cs
@@ -515,6 +515,28 @@ namespace RockWeb.Blocks.Finance
 
             mdAccountsPersonalFilter.Hide();
             LoadDropDowns();
+
+            // Reload the transaction amounts after changing the displayed accounts.
+            int? transactionId = hfTransactionId.Value.AsIntegerOrNull();
+            if (transactionId.HasValue)
+            {
+                using (var rockContext = new RockContext())
+                {
+                    var financialTransactionService = new FinancialTransactionService(rockContext);
+                    var txn = financialTransactionService.Queryable().Where(t => t.Id == transactionId).SingleOrDefault();
+
+                    foreach (var detail in txn.TransactionDetails)
+                    {
+                        var accountBox = rptAccounts.ControlsOfTypeRecursive<CurrencyBox>().Where(a => a.Attributes["data-account-id"].AsInteger() == detail.AccountId).FirstOrDefault();
+                        if (accountBox != null)
+                        {
+                            accountBox.Text = detail.Amount.ToString();
+                        }
+                    }
+                }
+            }
+
+
         }
 
         /// <summary>


### PR DESCRIPTION
# Context

We use Shelby Teller to scan checks and a custom plugin to import those checks into Rock. The amounts are already assigned in Teller and loaded correctly into the matching screen.  But when the user chooses to display a different set of accounts on that screen, even if the populated account(s) are included, the previously stored values are erased and must be retyped.
# Goal

To reload any existing amounts into their proper account controls after changing which accounts should display. This should be done even if amounts are not pre-loaded because the user could have entered an amount already before noticing that one of the accounts they need is not displayed, and so they should not have to re-enter amounts after changing this display.
# Strategy

Load the values in the Save event for the Accounts Personal Filter.
# Possible Implications

None.
# Screenshots

None.
