### PR TITLE
Email Functionality

### DIFF
--- a/Rock/Web/UI/Controls/Communication/Email.cs
+++ b/Rock/Web/UI/Controls/Communication/Email.cs
@@ -37,6 +37,8 @@ namespace Rock.Web.UI.Controls.Communication
         private RockLiteral lFromName;
         private RockLiteral lFromAddress;
         private EmailBox ebReplyToAddress;
+        private EmailBox ebCcAddress;
+        private EmailBox ebBccAddress;
         private RockTextBox tbSubject;
         private HtmlEditor htmlMessage;
         private RockTextBox tbTextMessage;
@@ -59,6 +61,19 @@ namespace Rock.Web.UI.Controls.Communication
             set { ViewState["UseSimpleMode"] = value; }
         }
 
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [allow cc/bcc].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [allow cc/bcc]; otherwise, <c>false</c>.
+        /// </value>
+        public bool AllowCcBcc
+        {
+            get { return ViewState["AllowCcBcc"] as Boolean? ?? false; }
+            set { ViewState["AllowCcBcc"] = value; }
+        }
+
         /// <summary>
         /// Gets or sets the medium data.
         /// </summary>
@@ -78,6 +93,8 @@ namespace Rock.Web.UI.Controls.Communication
                 data.Add( "HtmlMessage", htmlMessage.Text );
                 data.Add( "TextMessage", tbTextMessage.Text );
                 data.Add( "Attachments", hfAttachments.Value );
+                data.Add( "CC", ebCcAddress.Text );
+                data.Add( "BCC", ebBccAddress.Text );
                 return data;
             }
 
@@ -91,6 +108,8 @@ namespace Rock.Web.UI.Controls.Communication
                 htmlMessage.Text = GetDataValue( value, "HtmlMessage" );
                 tbTextMessage.Text = GetDataValue( value, "TextMessage" );
                 hfAttachments.Value = GetDataValue( value, "Attachments" );
+                ebCcAddress.Text = GetDataValue( value, "CC" );
+                ebBccAddress.Text = GetDataValue( value, "BCC" );
             }
         }
 
@@ -145,7 +164,6 @@ namespace Rock.Web.UI.Controls.Communication
         {
             UseSimpleMode = useSimpleMode;
         }
-
         #endregion
 
         #region CompositeControl Methods
@@ -215,6 +233,18 @@ namespace Rock.Web.UI.Controls.Communication
             fuAttachments.Label = "Attachments";
             fuAttachments.FileUploaded += fuAttachments_FileUploaded;
             Controls.Add( fuAttachments );
+
+            ebCcAddress = new EmailBox();
+            ebCcAddress.ID = string.Format( "ebCcAddress_{0}", this.ID );
+            ebCcAddress.Label = "CC Address";
+            ebCcAddress.Help = "Any address in this field will be copied on the email sent to every recipient.  Lava can be used to access recipent data. <span class='tip tip-lava'></span>";
+            Controls.Add( ebCcAddress );
+
+            ebBccAddress = new EmailBox();
+            ebBccAddress.ID = string.Format( "ebBccAddress{0}", this.ID );
+            ebBccAddress.Label = "Bcc Address";
+            ebBccAddress.Help = "Any address in this field will be copied on the email sent to every recipient.  Lava can be used to access recipent data. <span class='tip tip-lava'></span>";
+            Controls.Add( ebBccAddress );
         }
 
         /// <summary>
@@ -329,6 +359,13 @@ namespace Rock.Web.UI.Controls.Communication
 
             writer.RenderEndTag();  // ul
             writer.RenderEndTag();  // attachment div
+
+
+            if ( !UseSimpleMode && AllowCcBcc)
+            {
+                ebCcAddress.RenderControl( writer );
+                ebBccAddress.RenderControl( writer );
+            }
 
             writer.RenderEndTag();  // span6 div
 

--- a/RockWeb/Blocks/Communication/CommunicationEntry.ascx.cs
+++ b/RockWeb/Blocks/Communication/CommunicationEntry.ascx.cs
@@ -55,7 +55,8 @@ namespace RockWeb.Blocks.Communication
     [IntegerField( "Display Count", "The initial number of recipients to display prior to expanding list", false, 0, "", 4  )]
     [BooleanField( "Send When Approved", "Should communication be sent once it's approved (vs. just being queued for scheduled job to send)?", true, "", 5 )]
     [CustomDropdownListField("Mode", "The mode to use ( 'Simple' mode will prevent uers from searching/adding new people to communication).", "Full,Simple", true, "Full", "", 6)]
-	[BooleanField( "Show Attachment Uploader", "Should the attachment uploader be shown for email communications.", true, "", 7 )]
+    [BooleanField( "Allow CC/Bcc", "Allow CC and Bcc addresses to be entered for email communications?", false, "", 7, "AllowCcBcc" )]
+    [BooleanField( "Show Attachment Uploader", "Should the attachment uploader be shown for email communications.", true, "", 8 )]
     public partial class CommunicationEntry : RockBlock
     {
 
@@ -914,6 +915,10 @@ namespace RockWeb.Blocks.Communication
             if (component != null)
             {
                 var mediumControl = component.GetControl( !_fullMode );
+                if (mediumControl is Rock.Web.UI.Controls.Communication.Email  )
+                {
+                    ( ( Rock.Web.UI.Controls.Communication.Email ) mediumControl ).AllowCcBcc = GetAttributeValue( "AllowCcBcc" ).AsBoolean();
+                }
                 mediumControl.ID = "commControl";
                 mediumControl.IsTemplate = false;
                 mediumControl.AdditionalMergeFields = this.AdditionalMergeFields.ToList();

--- a/RockWeb/Blocks/Communication/SystemEmailDetail.ascx
+++ b/RockWeb/Blocks/Communication/SystemEmailDetail.ascx
@@ -22,8 +22,8 @@
                     </div>
                     <div class="col-md-6">
                         <Rock:CategoryPicker ID="cpCategory" runat="server" Required="true" Label="Category" EntityTypeName="Rock.Model.SystemEmail" />
-                        <Rock:DataTextBox ID="tbCc" runat="server" SourceTypeName="Rock.Model.SystemEmail, Rock" PropertyName="Cc" />
-                        <Rock:DataTextBox ID="tbBcc" runat="server" SourceTypeName="Rock.Model.SystemEmail, Rock" PropertyName="Bcc" />
+                        <Rock:DataTextBox ID="tbCc" runat="server" SourceTypeName="Rock.Model.SystemEmail, Rock" PropertyName="Cc" Help="<small><span class='tip tip-lava'></span></small>" />
+                        <Rock:DataTextBox ID="tbBcc" runat="server" SourceTypeName="Rock.Model.SystemEmail, Rock" PropertyName="Bcc" Help="<small><span class='tip tip-lava'></span></small>" />
                     </div>
                 </div>
 

--- a/RockWeb/Blocks/Communication/SystemEmailDetail.ascx.cs
+++ b/RockWeb/Blocks/Communication/SystemEmailDetail.ascx.cs
@@ -157,10 +157,10 @@ namespace RockWeb.Blocks.Communication
             var globalAttributes = GlobalAttributesCache.Read();
             
             string globalFromName = globalAttributes.GetValue( "OrganizationName" );
-            tbFromName.Help = string.Format( "If a From Name value is not entered the 'Organization Name' Global Attribute value of '{0}' will be used when this template is sent.", globalFromName );
+            tbFromName.Help = string.Format( "If a From Name value is not entered the 'Organization Name' Global Attribute value of '{0}' will be used when this template is sent. <small><span class='tip tip-lava'></span></small>", globalFromName );
 
             string globalFrom = globalAttributes.GetValue( "OrganizationEmail" );
-            tbFrom.Help = string.Format( "If a From Address value is not entered the 'Organization Email' Global Attribute value of '{0}' will be used when this template is sent.", globalFrom );
+            tbFrom.Help = string.Format( "If a From Address value is not entered the 'Organization Email' Global Attribute value of '{0}' will be used when this template is sent. <small><span class='tip tip-lava'></span></small>", globalFrom );
 
             tbTo.Help = "You can specify multiple email addresses by separating them with commas or semi-colons.";
 


### PR DESCRIPTION
# Context

We have the need to cc emails to addresses dynamically (Person attributes, Transaction attributes etc).  We also have times we would like to set the cc/bcc field via the communication entry form.
# Goal

Set Cc and Bcc fields with Lava.
# Strategy

This moves the CC/Bcc fields down into the recipient section so we can merge lava fields for each recipient iteration.  It also add's the ability to use lava in all the fields.  Lastly it adds CC and Bcc fields to the Email Communication control and allows for setting it to show or not show based on a CommunicationEntry block attribute.
# Possible Implications

_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
# Screenshots

This is the communication entry page when the CC/Bcc functionality is enabled:
![image](https://cloud.githubusercontent.com/assets/1248118/19822899/d90e4074-9d33-11e6-94e5-64eab853d39d.png)