### PR TITLE
- small tweak to PageViewTransation so that it create the UAParser on…

### DIFF
--- a/Rock/Transactions/PageViewTransaction.cs
+++ b/Rock/Transactions/PageViewTransaction.cs
@@ -102,6 +102,11 @@ namespace Rock.Transactions
         public string PageTitle { get; set; }
 
         /// <summary>
+        /// The ua parser
+        /// </summary>
+        private static Parser uaParser = Parser.GetDefault();
+
+        /// <summary>
         /// Execute method to write transaction to the database.
         /// </summary>
         public void Execute()
@@ -120,8 +125,6 @@ namespace Rock.Transactions
 
                 // get user agent info
                 var clientType = PageViewUserAgent.GetClientType( userAgent );
-
-                Parser uaParser = Parser.GetDefault();
                 ClientInfo client = uaParser.Parse( userAgent );
                 var clientOs = client.OS.ToString();
                 var clientBrowser = client.UserAgent.ToString();
@@ -175,10 +178,10 @@ namespace Rock.Transactions
 
                 pageView.PageId = this.PageId;
                 pageView.SiteId = this.SiteId;
-                pageView.Url = cleanUrl.Left( 500 );
+                pageView.Url = cleanUrl;
                 pageView.DateTimeViewed = this.DateViewed;
                 pageView.PersonAliasId = this.PersonAliasId;
-                pageView.PageTitle = this.PageTitle.Left( 500 );
+                pageView.PageTitle = this.PageTitle;
 
                 pageView.PageViewSessionId = pageViewSessionId.Value;
 


### PR DESCRIPTION
# Context

Giant Backlog of PageViews in our TransactionQueue, we had 17000+ pageviews that were waiting in the TransactionQueue
# Goal

It turns out that the UAParser creation was responsible for half of the overhead of executing a PageViewTransaction.  The goal is to remove this overhead.
# Strategy

Moved the UAParser to be a private static of PageViewTransaction and just create it once in the application. This doubled the speed of PageViewTransactions.
# Possible Implications
- none
# Screenshots

…ce instead of each time there is a page view. In our case, this changed cut the time of pageview inserts from 40ms to 16ms.
