### PR TITLE
- Add TransactionQueue details to SystemInfo. Handy if you are troubl…

### DIFF
--- a/RockWeb/Blocks/Administration/SystemInfo.ascx
+++ b/RockWeb/Blocks/Administration/SystemInfo.ascx
@@ -96,6 +96,10 @@
         <div class="row">
             <div class="col-md-6">
 
+                <h4>Transaction Queue</h4>
+                <asp:Literal ID="lTransactionQueue" runat="server"></asp:Literal>
+                
+                
                 <h4>Cache</h4>
                 <div id="cache-details">
                     <asp:Literal ID="lCacheOverview" runat="server"></asp:Literal>

--- a/RockWeb/Blocks/Administration/SystemInfo.ascx.cs
+++ b/RockWeb/Blocks/Administration/SystemInfo.ascx.cs
@@ -30,6 +30,7 @@ using System.Web.UI;
 using Rock;
 using Rock.Data;
 using Rock.Model;
+using Rock.Transactions;
 using Rock.VersionInfo;
 
 namespace RockWeb.Blocks.Administration
@@ -72,6 +73,9 @@ namespace RockWeb.Blocks.Administration
 
             lExecLocation.Text = Assembly.GetExecutingAssembly().Location;
             lLastMigrations.Text = GetLastMigrationData();
+
+            var transactionQueueStats = RockQueue.TransactionQueue.ToList().GroupBy( a => a.GetType().Name ).ToList().Select( a => new { Name = a.Key, Count = a.Count() } );
+            lTransactionQueue.Text = transactionQueueStats.Select( a => string.Format( "{0}: {1}", a.Name, a.Count ) ).ToList().AsDelimited( "<br/>" );
 
             lCacheOverview.Text = GetCacheInfo();
             lRoutes.Text = GetRoutesInfo();


### PR DESCRIPTION
# Context

We were trying to figure out why the home internal page wasn't showing anybody logged in.  We thought it could be a problem with PageViews
# Goal

The goal was to be able to see the status of the Queue to see if that might be the issue
# Strategy

Added info about the TransactionQueue to the SystemInfo block.  Now you can see how many of each type of ITransaction are waiting to execute.
# Possible Implications
- none
# Screenshots

![2016-10-28_164827](https://cloud.githubusercontent.com/assets/2430748/19825482/8a399804-9d2e-11e6-9549-ee46e147272a.jpg)

…eshooting why something in the queue hasn't executed yet.
