### PR TITLE
Fix Group Member Remove Workflow Action removing all groups

### DIFF
--- a/Rock/Workflow/Action/Groups/RemovePersonFromGroup.cs
+++ b/Rock/Workflow/Action/Groups/RemovePersonFromGroup.cs
@@ -129,7 +129,7 @@ namespace Rock.Workflow.Action
             {
                 try {
                     var groupMemberService = new GroupMemberService( rockContext );
-                    var groupMembers = groupMemberService.Queryable().Where( m => m.PersonId == person.Id );
+                    var groupMembers = groupMemberService.Queryable().Where( m => m.PersonId == person.Id && m.GroupId == group.Id );
 
                     if ( groupRoleId.HasValue )
                     {


### PR DESCRIPTION
# Context
The "Group Member Remove from Specified Group" Workflow Action ignores the specified group and instead removes group memberships from all groups.

# Goal
Only remove group members from the specified group.

# Strategy
Add the group Id to the groupMembers filter.