### PR TITLE
- Changed the regex that detects whether a string has any lava fields…

### DIFF
--- a/Rock/Utility/ExtensionMethods/LavaExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/LavaExtensions.cs
@@ -589,13 +589,16 @@ namespace Rock
 
         /// <summary>
         /// Compiled RegEx for detecting if a string has Lava merge fields
+        /// regex from some ideas in 
+        ///  http://stackoverflow.com/a/16538131/1755417 
+        ///  http://stackoverflow.com/a/25776530/1755417 
         /// </summary>
-        private static Regex hasLavaMergeFields = new Regex( @".*\{.+\}.*", RegexOptions.Compiled );
+        private static Regex hasLavaMergeFields = new Regex( @"(?<=\{).+(?<=\})", RegexOptions.Compiled );
 
         /// <summary>
         /// Compiled RegEx for detecting if a string uses the Legacy "GlobalAttribute." syntax
         /// </summary>
-        private static Regex hasLegacyGlobalAttributeLavaMergeFields = new Regex( @".*\{.+GlobalAttribute.+\}.*", RegexOptions.Compiled );
+        private static Regex hasLegacyGlobalAttributeLavaMergeFields = new Regex( @"(?<=\{).+GlobalAttribute.+(?<=\})", RegexOptions.Compiled );
 
         /// <summary>
         /// Determines whether the string potentially has merge fields in it.


### PR DESCRIPTION
# Context
We had a problem at CCV where it had been several hours since an email was processed, even though the SendCommunication job was scheduled to run every 10 minutes.  We eventually narrowed it down to an email where somebody had dragged an image into summernote, which created a base64'd image tag. So, the email content length was around 820KB or so.  When Lava tried to detect if the string had Lava fields in it, the function hung for at least several minutes.

# Goal
The goal is to figure out a way so that Lava doesn't hang when a large amount of text is used.

# Strategy
This changes the core RegEx expression for detecting Lava fields (and Legacy Lava) to avoid RegEx "backtracking".  The "Has Legacy LavaFields" function also had the same problem, so that regex was changed as well.  The new regex now works very fast (just a few milliseconds), even if the text string is really large.  For "normal" size strings, it is actually 10x faster for those too.  100nanoseconds vs 1ms.

# Possible Implications
This regex is used every time that a Lava string is processed, which would be A LOT! I've tested it quite a bit to make sure it returns the same (True/False) result as the old expression, but since it is used so heavily, there is a chance that I missed something.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

…, so that it doesn't have the http://www.regular-expressions.info/catastrophic.html problem.  This fixes an issue where lava would hang if an extremely long string of text was passed into Lava. For example, a 1MB+ email that had a base64 image in it