### PR TITLE
Added badge type which displays if person is in dataview

### DIFF
--- a/Rock/PersonProfile/Badge/InDataView.cs
+++ b/Rock/PersonProfile/Badge/InDataView.cs
@@ -1,0 +1,75 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Data.Entity;
+
+using Rock.Attribute;
+using Rock.Model;
+using Rock.Web.UI.Controls;
+using Rock.Data;
+using System.Collections.Generic;
+using System.Data;
+using System;
+using System.Diagnostics;
+using Rock.Web.Cache;
+
+namespace Rock.PersonProfile.Badge
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [Description( "Displays if the person has an alert note." )]
+    [Export( typeof( BadgeComponent ) )]
+    [ExportMetadata( "ComponentName", "In Data View" )]
+
+    [DataViewField( "Data View", "The dataview to look at.", order: 0 )]
+    [CodeEditorField( "Badge Content", "The text or HTML of the badge to display. <span class='tip tip-lava'></span>", CodeEditorMode.Lava, CodeEditorTheme.Rock, 200, true, "<div class='badge badge-icon'><i class='fa fa-smile-o'></i></div>", order: 1 )]
+    public class InDataView : BadgeComponent
+    {
+
+        /// <summary>
+        /// Renders the specified writer.
+        /// </summary>
+        /// <param name="badge">The badge.</param>
+        /// <param name="writer">The writer.</param>
+        public override void Render( PersonBadgeCache badge, System.Web.UI.HtmlTextWriter writer )
+        {
+            RockContext rockContext = new RockContext();
+            var dataViewAttributeGuid = GetAttributeValue( badge, "DataView" ).AsGuid();
+            var dataViewService = new DataViewService( rockContext );
+            if ( dataViewAttributeGuid != Guid.Empty )
+            {
+                var dataView = dataViewService.Get( dataViewAttributeGuid );
+                if ( dataView != null )
+                {
+                    var errors = new List<string>();
+                    var qry = dataView.GetQuery( null, 30, out errors );
+                    if ( qry != null && qry.Where( e => e.Id == Person.Id ).Any() )
+                    {
+                        Dictionary<string, object> mergeValues = new Dictionary<string, object>();
+                        mergeValues.Add( "Person", Person );
+                        writer.Write( GetAttributeValue( badge, "BadgeContent" ).ResolveMergeFields( mergeValues ) );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Rock/PersonProfile/Badge/InDataView.cs
+++ b/Rock/PersonProfile/Badge/InDataView.cs
@@ -36,11 +36,11 @@ namespace Rock.PersonProfile.Badge
     /// <summary>
     /// 
     /// </summary>
-    [Description( "Displays if the person has an alert note." )]
+    [Description( "Displays a badge if person is in a chosen DataView." )]
     [Export( typeof( BadgeComponent ) )]
     [ExportMetadata( "ComponentName", "In Data View" )]
 
-    [DataViewField( "Data View", "The dataview to look at.", order: 0 )]
+    [DataViewField( "Data View", "The dataview to use as the source for the query. Only those people in the DataView will be given the badge.", true, entityTypeName: "Rock.Model.Person", order: 0 )]
     [CodeEditorField( "Badge Content", "The text or HTML of the badge to display. <span class='tip tip-lava'></span>", CodeEditorMode.Lava, CodeEditorTheme.Rock, 200, true, "<div class='badge badge-icon'><i class='fa fa-smile-o'></i></div>", order: 1 )]
     public class InDataView : BadgeComponent
     {


### PR DESCRIPTION
# Context
We wanted to add a badge to a person's profile if they are safe to work with children. We have an existing data view which we use extensively. Rather than recreating and managing parallel Lava any changes to the data view can appear on the badge as well.

# Goal
This will allow churches to use data views to show badges. 

# Strategy
I created a badge type that displays lava enabled output if the person is in the data view.

# Possible Implications
There should be none, except for many complex badges at the same time.

