### PR TITLE
Bugfix in ContributionStatementLava Pledges

### DIFF
--- a/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
@@ -301,6 +301,14 @@ namespace RockWeb.Blocks.Finance
                                     .OrderBy(p => p.FamilyRoleOrder).ThenBy(p => p.Gender)
                                     .ToList();
 
+            // make a list of person ids in the giving group
+            List<int> givingGroupIdsOnly = new List<int>();
+            foreach (var x in givingGroup)
+            {
+                givingGroupIdsOnly.Add(x.PersonId);
+            }
+
+
             string salutation = string.Empty;
 
             if (givingGroup.GroupBy(g => g.LastName).Count() == 1 )
@@ -367,6 +375,7 @@ namespace RockWeb.Blocks.Finance
                 pledge.AmountGiven = new FinancialTransactionDetailService( rockContext ).Queryable()
                                             .Where( t =>
                                                  t.AccountId == pledge.AccountId
+                                                 && givingGroupIdsOnly.Contains(t.Transaction.AuthorizedPersonAlias.PersonId)
                                                  && t.Transaction.TransactionDateTime >= pledge.PledgeStartDate
                                                  && t.Transaction.TransactionDateTime <= adjustedPedgeEndDate )
                                             .Sum( t => t.Amount );

--- a/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
@@ -65,7 +65,7 @@ namespace RockWeb.Blocks.Finance
 <h4>
 {{ Salutation }} <br />
 {{ StreetAddress1 }} <br />
-{% if StreetAddress2 != '' %}
+{% if StreetAddress2 and StreetAddress2 != '' %}
     {{ StreetAddress2 }} <br />
 {% endif %}
 {{ City }}, {{ State }} {{ PostalCode }}


### PR DESCRIPTION
# Context
On the ContributionStatementLava block, the pledge amount given number is incorrect - it showed ALL gifts to that fund, not just for the individual/giving group.

# Goal
Fix ContributionStatementLava.ascx.cs so only pledges for current giving group are shown.
# Strategy
Alter the LINQ statement to only get transaction for the current giving group.

# Possible Implications
none
