### PR TITLE
Fixed display of entity attribute qualifiers

### DIFF
--- a/RockWeb/Blocks/Core/Attributes.ascx.cs
+++ b/RockWeb/Blocks/Core/Attributes.ascx.cs
@@ -701,15 +701,11 @@ namespace RockWeb.Blocks.Core
 
             if ( _configuredType )
             {
-                ddlAttrEntityType.Visible = false;
-                tbAttrQualifierField.Visible = false;
-                tbAttrQualifierValue.Visible = false;
+                pnlEntityTypeQualifier.Visible = false;
             }
             else
             {
-                ddlAttrEntityType.Visible = true;
-                tbAttrQualifierField.Visible = true;
-                tbAttrQualifierValue.Visible = true;
+                pnlEntityTypeQualifier.Visible = true;
 
                 ddlAttrEntityType.SetValue( attributeModel.EntityTypeId.HasValue ? attributeModel.EntityTypeId.Value.ToString() : "0" );
                 tbAttrQualifierField.Text = attributeModel.EntityTypeQualifierColumn;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_
The Entity Attribute screen no longer displays Entity Type and Qualifiers.
# Goal
_What will this pull request achieve and how will this fix the problem?_
Entity Type and Qualifier controls will display.
# Strategy
_How have you implemented your solution?_
These controls were added to a panel that was marked visible = false, however the code that was supposed to display them was setting the visible property of the controls themselves rather than the panel. I changed the code to make the panel visible.
# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
If there is some instance where these controls are supposed to be hidden that I'm not aware of, it's possible that I missed somewhere that needs to get updated.
# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

