### PR TITLE
Multiple improvements to grid export files

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1135,6 +1135,7 @@
     <Compile Include="UniversalSearch\SearchFieldCriteria.cs" />
     <Compile Include="UniversalSearch\SearchResultModel.cs" />
     <Compile Include="Utility\DebugHelper.cs" />
+    <Compile Include="Utility\ExcelHelper.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Web\UI\RockTheme.cs" />
     <Compile Include="Web\Cache\AttributeValueCache.cs" />

--- a/Rock/Utility/ExcelHelper.cs
+++ b/Rock/Utility/ExcelHelper.cs
@@ -10,6 +10,9 @@ using System.Linq;
 
 namespace Rock.Utility
 {
+    /// <summary>
+    /// Methods that facilitate generating Excel files
+    /// </summary>
     public static class ExcelHelper
     {
         public const string GeneralFormat = "General";
@@ -44,6 +47,11 @@ namespace Rock.Utility
             return excel;
         }
 
+        /// <summary>
+        /// Adds a worksheet from a DataTable
+        /// </summary>
+        /// <param name="excel">The ExcelPackage object to add a worksheet to</param>
+        /// <param name="data">The DataTable to populate the worksheet with. The TableName of the DataTable will be the header and Tab name of the worksheet.</param>
         public static void AddWorksheet( this ExcelPackage excel, DataTable data )
         {
             var worksheet = excel.Workbook.Worksheets.Add( data.TableName );
@@ -82,6 +90,14 @@ namespace Rock.Utility
             worksheet.FormatWorksheet( data.TableName, headerRows, rowCounter, columnCounter );
         }
 
+        /// <summary>
+        /// Apply the default Rock worksheet formatting
+        /// </summary>
+        /// <param name="worksheet">The worksheet to be formatted</param>
+        /// <param name="title">The title to display in the worksheet header</param>
+        /// <param name="headerRows">The number of rows to use for the header</param>
+        /// <param name="rows">The number of rows populated in the worksheet</param>
+        /// <param name="columns">The number of columns populated in the worksheet</param>
         public static void FormatWorksheet( this ExcelWorksheet worksheet, string title, int headerRows, int rows, int columns )
         {
             var range = worksheet.Cells[headerRows, 1, rows, columns];
@@ -161,7 +177,7 @@ namespace Rock.Utility
         /// <summary>
         /// Sets the default formatting for an excel column based on the data type
         /// </summary>
-        /// <param name="type"></param>
+        /// <param name="type">The data type of the column</param>
         /// <returns></returns>
         public static string DefaultColumnFormat( Type type )
         {
@@ -188,8 +204,8 @@ namespace Rock.Utility
         /// <summary>
         /// Sets the default formatting for an excel column based on the field type and data type
         /// </summary>
-        /// <param name="field"></param>
-        /// <param name="exportValue"></param>
+        /// <param name="field">The grid field</param>
+        /// <param name="exportValue">An example value for this column; you can use the data from the first row</param>
         /// <returns></returns>
         public static string DefaultColumnFormat( IRockGridField field, object exportValue )
         {
@@ -204,8 +220,8 @@ namespace Rock.Utility
         /// <summary>
         /// Updates the excel column format based on the level of detail in the data
         /// </summary>
-        /// <param name="exportValue"></param>
-        /// <param name="defaultFormat"></param>
+        /// <param name="exportValue">The cell value to use for formatting</param>
+        /// <param name="defaultFormat">The existing column format to use if no changes are to be made</param>
         /// <returns></returns>
         public static string FinalColumnFormat( object exportValue, string defaultFormat )
         {
@@ -253,6 +269,14 @@ namespace Rock.Utility
             }
         }
 
+        /// <summary>
+        /// Saves an ExcelPackage as a BinaryFile and stores it in the database
+        /// </summary>
+        /// <param name="excel">The ExcelPackage object to save</param>
+        /// <param name="fileName">The filename to save the workbook as</param>
+        /// <param name="rockContext">The RockContext to use</param>
+        /// <param name="binaryFileType">Optionally specifies the BinaryFileType to apply to this file for security purposes</param>
+        /// <returns></returns>
         public static BinaryFile Save( ExcelPackage excel, string fileName, RockContext rockContext, BinaryFileType binaryFileType = null )
         {
             if ( binaryFileType == null )
@@ -278,6 +302,11 @@ namespace Rock.Utility
             return binaryFile;
         }
 
+        /// <summary>
+        /// Convert an ExcelPackage to a MemoryStream
+        /// </summary>
+        /// <param name="excel">The ExcelPackage</param>
+        /// <returns></returns>
         public static MemoryStream ToMemoryStream( this ExcelPackage excel )
         {
             MemoryStream ms = new MemoryStream();
@@ -285,11 +314,22 @@ namespace Rock.Utility
             return ms;
         }
 
+        /// <summary>
+        /// Convert an ExcelPackage to a ByteArray
+        /// </summary>
+        /// <param name="excel">The ExcelPackage</param>
+        /// <returns></returns>
         public static byte[] ToByteArray( this ExcelPackage excel )
         {
             return excel.ToMemoryStream().ToArray();
         }
 
+        /// <summary>
+        /// Sends an Excel workbook to the user
+        /// </summary>
+        /// <param name="excel">The ExcelPackage to send</param>
+        /// <param name="page">The current Page object</param>
+        /// <param name="filename">The filename to send the file as</param>
         public static void SendToBrowser( this ExcelPackage excel, System.Web.UI.Page page, string filename )
         {
             page.EnableViewState = false;

--- a/Rock/Utility/ExcelHelper.cs
+++ b/Rock/Utility/ExcelHelper.cs
@@ -1,0 +1,306 @@
+﻿using System;
+using System.Data;
+using OfficeOpenXml;
+using Rock.Model;
+using Rock.Data;
+using System.IO;
+using System.Drawing;
+using Rock.Web.UI.Controls;
+using System.Linq;
+
+namespace Rock.Utility
+{
+    public static class ExcelHelper
+    {
+        public const string GeneralFormat = "General";
+        public const string CurrencyFormat = "_($* #,##0.00_);_($* (#,##0.00);_($* \"-\"??_);_(@_)";
+        public const string AccountingFormat = "_(* #,##0.00_);_(* (#,##0.00);_(* \"-\"??_);_(@_)";
+        public const string AccountingNoCentsFormat = "_(* #,##0_);_(* (#,##0);_(* \"-\"??_);_(@_)";
+        public const string DateFormat = "MM/dd/yyyy";
+        public const string DateTimeFormat = "MM/dd/yyyy hh:mm";
+        public const string TextFormat = "@";
+        public const string UnformattedNumberFormat = "0";
+        public const string DecimalFormat = "#,##0.00";
+        public const string FormattedNumberFormat = "#,##0";
+
+        /// <summary>
+        /// Creates an Excel Workbook from a DataSet
+        /// </summary>
+        /// <param name="sqlResults">The DataSet to populate a workbook with. The TableName of each DataTable will be the header and Tab name of each sheet.</param>
+        /// <param name="title">The Title of the workbook</param>
+        /// <returns></returns>
+        public static ExcelPackage CreateNewFile( DataSet sqlResults = null, string title = null )
+        {
+            var excel = new ExcelPackage();
+            excel.Workbook.Properties.Title = title;
+            excel.Workbook.Properties.Author = UserLoginService.GetCurrentUser()?.Person?.FullName ?? "Rock";
+
+            // Create the worksheet(s)
+            foreach ( DataTable data in sqlResults.Tables )
+            {
+                excel.AddWorksheet( data );
+            }
+
+            return excel;
+        }
+
+        public static void AddWorksheet( this ExcelPackage excel, DataTable data )
+        {
+            var worksheet = excel.Workbook.Worksheets.Add( data.TableName );
+
+            var headerRows = 3;
+            var rowCounter = headerRows;
+            var columnCounter = 0;
+
+            // Set up the columns
+            foreach ( DataColumn column in data.Columns )
+            {
+                columnCounter++;
+
+                // Print column headings
+                worksheet.Cells[rowCounter, columnCounter].Value = column.ColumnName.SplitCase();
+
+                // Set the initial column format
+                worksheet.Column( columnCounter ).Style.Numberformat.Format = DefaultColumnFormat( column.DataType );
+            }
+
+            // Populate the cells with data
+            foreach ( DataRow row in data.Rows )
+            {
+                rowCounter++;
+
+                for ( int i = 0; i < data.Columns.Count; i++ )
+                {
+                    var value = row[i];
+                    SetExcelValue( worksheet.Cells[rowCounter, i + 1], value );
+
+                    // Update column formatting based on data
+                    worksheet.Column( i + 1 ).Style.Numberformat.Format = FinalColumnFormat( value, worksheet.Column( i + 1 ).Style.Numberformat.Format );
+                }
+            }
+
+            worksheet.FormatWorksheet( data.TableName, headerRows, rowCounter, columnCounter );
+        }
+
+        public static void FormatWorksheet( this ExcelWorksheet worksheet, string title, int headerRows, int rows, int columns )
+        {
+            var range = worksheet.Cells[headerRows, 1, rows, columns];
+
+            // align text to the top of the cell
+            range.Style.VerticalAlignment = OfficeOpenXml.Style.ExcelVerticalAlignment.Top;
+
+            // use conditionalFormatting to create the alternate row style
+            var conditionalFormatting = range.ConditionalFormatting.AddExpression();
+            conditionalFormatting.Formula = "MOD(ROW()+1,2)=0";
+            conditionalFormatting.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+            conditionalFormatting.Style.Fill.BackgroundColor.Color = Color.FromArgb( 240, 240, 240 );
+
+            var table = worksheet.Tables.Add( range, title.Replace( " ", "" ) );
+
+            // ensure each column in the table has a unique name
+            var columnNames = worksheet.Cells[headerRows, 1, headerRows, columns].Select( a => new { OrigColumnName = a.Text, Cell = a } ).ToList();
+            columnNames.Reverse();
+            foreach ( var col in columnNames )
+            {
+                int duplicateSuffix = 0;
+                string uniqueName = col.OrigColumnName;
+
+                // increment the suffix by 1 until there is only one column with that name
+                while ( columnNames.Where( a => a.Cell.Text == uniqueName ).Count() > 1 )
+                {
+                    duplicateSuffix++;
+                    uniqueName = col.OrigColumnName + duplicateSuffix.ToString();
+                    col.Cell.Value = uniqueName;
+                }
+            }
+
+            table.ShowFilter = true;
+            table.TableStyle = OfficeOpenXml.Table.TableStyles.None;
+
+            // Format header range
+            using ( ExcelRange r = worksheet.Cells[headerRows, 1, headerRows, columns] )
+            {
+                r.Style.Font.Bold = true;
+                r.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+                r.Style.Fill.BackgroundColor.SetColor( Color.FromArgb( 223, 223, 223 ) );
+                r.Style.Font.Color.SetColor( Color.Black );
+                r.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Left;
+            }
+
+            // Format and set title
+            worksheet.Cells[1, 1].Value = title;
+            using ( ExcelRange r = worksheet.Cells[1, 1, 1, columns] )
+            {
+                r.Merge = true;
+                r.Style.Font.SetFromFont( new Font( "Calibri", 22, FontStyle.Regular ) );
+                r.Style.Font.Color.SetColor( Color.White );
+                r.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Left;
+                r.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+                r.Style.Fill.BackgroundColor.SetColor( Color.FromArgb( 34, 41, 55 ) );
+
+                // set border
+                r.Style.Border.Left.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
+                r.Style.Border.Right.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
+                r.Style.Border.Top.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
+                r.Style.Border.Bottom.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
+            }
+
+            // TODO: add image to worksheet
+
+            worksheet.View.FreezePanes( headerRows + 1, 1 );
+
+            worksheet.Cells.AutoFitColumns();
+
+            // TODO: add alternating highlights
+
+            // set some footer text
+            worksheet.HeaderFooter.OddHeader.CenteredText = title;
+            worksheet.HeaderFooter.OddFooter.RightAlignedText = string.Format( "Page {0} of {1}", ExcelHeaderFooter.PageNumber, ExcelHeaderFooter.NumberOfPages );
+        }
+
+        /// <summary>
+        /// Sets the default formatting for an excel column based on the data type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static string DefaultColumnFormat( Type type )
+        {
+            if ( type == typeof( DateTime ) || type == typeof( DateTime? ) )
+            {
+                return DateFormat;
+            }
+            else if ( type == typeof( decimal ) || type == typeof( decimal? )
+                || type == typeof( double ) || type == typeof( double? )
+                || type == typeof( float ) || type == typeof( float? ) )
+            {
+                return FormattedNumberFormat;
+            }
+            else if ( type == typeof( int ) || type == typeof( int? )
+                || type == typeof( long ) || type == typeof( long? )
+                || type == typeof( short ) || type == typeof( short? ) )
+            {
+                return UnformattedNumberFormat;
+            }
+
+            return GeneralFormat;
+        }
+
+        /// <summary>
+        /// Sets the default formatting for an excel column based on the field type and data type
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="exportValue"></param>
+        /// <returns></returns>
+        public static string DefaultColumnFormat( IRockGridField field, object exportValue )
+        {
+            if ( field is CurrencyField )
+            {
+                return DecimalFormat;
+            }
+
+            return DefaultColumnFormat( exportValue?.GetType() );
+        }
+
+        /// <summary>
+        /// Updates the excel column format based on the level of detail in the data
+        /// </summary>
+        /// <param name="exportValue"></param>
+        /// <param name="defaultFormat"></param>
+        /// <returns></returns>
+        public static string FinalColumnFormat( object exportValue, string defaultFormat )
+        {
+            var dateValue = exportValue as DateTime?;
+            if ( dateValue != null && dateValue.Value.TimeOfDay.TotalSeconds > 0 )
+            {
+                return DateTimeFormat;
+            }
+
+            var numValue = exportValue as decimal?;
+            if ( numValue != null && numValue.Value - Math.Round( numValue.Value ) != 0 )
+            {
+                return DecimalFormat;
+            }
+
+            return defaultFormat;
+        }
+
+        /// <summary>
+        /// Formats the export value.
+        /// </summary>
+        /// <param name="range">The range.</param>
+        /// <param name="exportValue">The export value.</param>
+        public static void SetExcelValue( ExcelRange range, object exportValue )
+        {
+            if ( exportValue != null &&
+                ( exportValue is decimal || exportValue is decimal? ||
+                exportValue is int || exportValue is int? ||
+                exportValue is short || exportValue is short? ||
+                exportValue is long || exportValue is long? ||
+                exportValue is double || exportValue is double? ||
+                exportValue is float || exportValue is float? ||
+                exportValue is DateTime || exportValue is DateTime? ) )
+            {
+                range.Value = exportValue;
+            }
+            else
+            {
+                string value = exportValue != null ? exportValue.ToString().ConvertBrToCrLf().Replace( "&nbsp;", " " ).TrimEnd( '\r', '\n' ) : string.Empty;
+                range.Value = value;
+                if ( value.Contains( Environment.NewLine ) )
+                {
+                    range.Style.WrapText = true;
+                }
+            }
+        }
+
+        public static BinaryFile Save( ExcelPackage excel, string fileName, RockContext rockContext, BinaryFileType binaryFileType = null )
+        {
+            if ( binaryFileType == null )
+            {
+                binaryFileType = new BinaryFileTypeService( rockContext ).Get( Rock.SystemGuid.BinaryFiletype.DEFAULT.AsGuid() );
+            }
+
+            var ms = excel.ToMemoryStream();
+
+            var binaryFile = new BinaryFile()
+            {
+                Guid = Guid.NewGuid(),
+                IsTemporary = true,
+                BinaryFileTypeId = binaryFileType.Id,
+                MimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                FileName = fileName,
+                ContentStream = ms
+            };
+
+            var binaryFileService = new BinaryFileService( rockContext );
+            binaryFileService.Add( binaryFile );
+            rockContext.SaveChanges();
+            return binaryFile;
+        }
+
+        public static MemoryStream ToMemoryStream( this ExcelPackage excel )
+        {
+            MemoryStream ms = new MemoryStream();
+            excel.SaveAs( ms );
+            return ms;
+        }
+
+        public static byte[] ToByteArray( this ExcelPackage excel )
+        {
+            return excel.ToMemoryStream().ToArray();
+        }
+
+        public static void SendToBrowser( this ExcelPackage excel, System.Web.UI.Page page, string filename )
+        {
+            page.EnableViewState = false;
+            page.Response.Clear();
+            page.Response.ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            page.Response.AppendHeader( "Content-Disposition", "attachment; filename=" + filename );
+
+            page.Response.Charset = string.Empty;
+            page.Response.BinaryWrite( excel.ToByteArray() );
+            page.Response.Flush();
+            page.Response.End();
+        }
+    }
+}

--- a/Rock/Utility/ExtensionMethods/ObjectExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/ObjectExtensions.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Rock.Web.Cache;
 
 namespace Rock
 {
@@ -74,12 +75,12 @@ namespace Rock
 
             try
             {
-                while (propPath.Any())
+                while ( propPath.Any() )
                 {
                     elementName = propPath.First();
 
                     PropertyInfo property = objType.GetProperty( elementName );
-                    if (property != null)
+                    if ( property != null )
                     {
                         objType = property.PropertyType;
                         propPath = propPath.Skip( 1 ).ToList();
@@ -91,7 +92,7 @@ namespace Rock
                 }
 
             }
-            catch (Exception)
+            catch ( Exception )
             {
                 throw new Exception( string.Format( "GetPropertyType failed. Could not resolve element \"{0}\" in path \"{1}.{2}\".", elementName, rootType.Name, propertyPathName ) );
             }
@@ -124,7 +125,45 @@ namespace Rock
         {
             var attrType = typeof( T );
             var property = instance.GetType().GetProperty( propertyName );
-            return (T)property.GetCustomAttributes( attrType, false ).First();
+            return ( T ) property.GetCustomAttributes( attrType, false ).First();
+        }
+
+
+        /// <summary>
+        /// If input is a string that has been formatted as currency, return the decimal value. Otherwise return the object unchanged.
+        /// </summary>
+        /// <param name="input">A value that may be a currency-formatted string.</param>
+        /// <returns></returns>
+        public static object ReverseCurrencyFormatting( this object input )
+        {
+            var exportValueString = input as string;
+
+            // If the object is a string...
+            if ( exportValueString != null )
+            {
+                var currencySymbol = GlobalAttributesCache.Value( "CurrencySymbol" );
+
+                // ... that contains the currency symbol ...
+                if ( exportValueString.Contains( currencySymbol ) )
+                {
+                    var decimalString = exportValueString.Replace( currencySymbol, string.Empty );
+                    decimal exportValueDecimal;
+
+                    // ... and the value without the currency symbol is a valid decimal value ...
+                    if ( decimal.TryParse( decimalString, out exportValueDecimal ) )
+                    {
+                        // ... that matches the input string when formatted as currency ...
+                        if ( exportValueDecimal.FormatAsCurrency() == exportValueString )
+                        {
+                            // ... return the input as a decimal
+                            return exportValueDecimal;
+                        }
+                    }
+                }
+            }
+
+            // Otherwise just return the input back out
+            return input;
         }
 
         #endregion
@@ -164,7 +203,7 @@ namespace Rock
                         {
                             byte[] temp = new byte[readBuffer.Length * 2];
                             Buffer.BlockCopy( readBuffer, 0, temp, 0, readBuffer.Length );
-                            Buffer.SetByte( temp, totalBytesRead, (byte)nextByte );
+                            Buffer.SetByte( temp, totalBytesRead, ( byte ) nextByte );
                             readBuffer = temp;
                             totalBytesRead++;
                         }

--- a/Rock/Web/UI/Controls/Grid/Grid.cs
+++ b/Rock/Web/UI/Controls/Grid/Grid.cs
@@ -20,18 +20,17 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Data.Entity;
-using System.Drawing;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
-using DotLiquid;
 using OfficeOpenXml;
 using Rock.Data;
 using Rock.Web.Cache;
+using Rock;
+using Rock.Utility;
 
 namespace Rock.Web.UI.Controls
 {
@@ -190,7 +189,7 @@ namespace Rock.Web.UI.Controls
             get
             {
                 object exportSource = this.ViewState["ExportSource"];
-                return exportSource != null ? (ExcelExportSource)exportSource : ExcelExportSource.DataSource;
+                return exportSource != null ? ( ExcelExportSource ) exportSource : ExcelExportSource.DataSource;
             }
 
             set
@@ -212,6 +211,10 @@ namespace Rock.Web.UI.Controls
             get
             {
                 string exportFilename = ViewState["ExportFilename"] as string;
+                if (string.IsNullOrWhiteSpace(exportFilename))
+                {
+                    exportFilename = $"{( Page as RockPage )?.PageTitle}.xlsx";
+                }
                 if ( string.IsNullOrWhiteSpace( exportFilename ) )
                 {
                     exportFilename = "RockExport.xlsx";
@@ -275,7 +278,7 @@ namespace Rock.Web.UI.Controls
             get
             {
                 object displayType = this.ViewState["DisplayType"];
-                return displayType != null ? (GridDisplayType)displayType : GridDisplayType.Full;
+                return displayType != null ? ( GridDisplayType ) displayType : GridDisplayType.Full;
             }
 
             set
@@ -664,7 +667,7 @@ namespace Rock.Web.UI.Controls
                             }
                             else
                             {
-                                string value = Page.Request.Form[cb.UniqueID.Replace( cb.ID, ( (RockRadioButton)cb ).GroupName )];
+                                string value = Page.Request.Form[cb.UniqueID.Replace( cb.ID, ( ( RockRadioButton ) cb ).GroupName )];
                                 if ( value == cb.ID )
                                 {
                                     col.SelectedKeys.Add( this.DataKeys[row.RowIndex].Value );
@@ -754,7 +757,7 @@ namespace Rock.Web.UI.Controls
         /// <param name="writer">The <see cref="T:System.Web.UI.HtmlTextWriter" /> object that receives the control content.</param>
         public override void RenderControl( HtmlTextWriter writer )
         {
-           
+
             if ( this.EnableResponsiveTable )
             {
                 writer.AddAttribute( HtmlTextWriterAttribute.Class, "table-responsive" );
@@ -766,7 +769,7 @@ namespace Rock.Web.UI.Controls
             }
 
             writer.RenderBeginTag( HtmlTextWriterTag.Div );
-            
+
 
             this.AddCssClass( "grid-table" );
             this.AddCssClass( "table" );
@@ -914,7 +917,7 @@ namespace Rock.Web.UI.Controls
                 // get data priority from column
                 if ( column is IPriorityColumn )
                 {
-                    _columnDataPriorities.Add( i, ( (IPriorityColumn)column ).ColumnPriority.ConvertToInt().ToString() );
+                    _columnDataPriorities.Add( i, ( ( IPriorityColumn ) column ).ColumnPriority.ConvertToInt().ToString() );
                 }
                 else
                 {
@@ -1073,7 +1076,7 @@ namespace Rock.Web.UI.Controls
         {
             base.OnRowDataBound( e );
 
-            if ( e.Row.RowType == DataControlRowType.Header)
+            if ( e.Row.RowType == DataControlRowType.Header )
             {
                 //add data priority
                 for ( int i = 0; i < e.Row.Cells.Count; i++ )
@@ -1208,7 +1211,7 @@ namespace Rock.Web.UI.Controls
         /// <param name="e">The <see cref="Rock.Web.UI.Controls.NumericalEventArgs"/> instance containing the event data.</param>
         public void pagerTemplate_NavigateClick( object sender, NumericalEventArgs e )
         {
-            if ( e.Number < 0  )
+            if ( e.Number < 0 )
             {
                 this.PageIndex = 0;
             }
@@ -1216,7 +1219,7 @@ namespace Rock.Web.UI.Controls
             {
                 this.PageIndex = this.PageCount - 1;
             }
-            else 
+            else
             {
                 this.PageIndex = e.Number;
             }
@@ -1429,14 +1432,21 @@ namespace Rock.Web.UI.Controls
             // if the grid has a caption customize on it
             if ( !string.IsNullOrEmpty( this.Caption ) )
             {
-                excel.Workbook.Properties.Title = this.Caption;
                 workSheetName = this.Caption;
                 title = this.Caption;
             }
+            // otherwise use the page title
             else
             {
-                excel.Workbook.Properties.Title = "Rock Export";
+                var pageTitle = ( Page as RockPage )?.PageTitle;
+
+                if ( !string.IsNullOrEmpty( pageTitle ) )
+                {
+                    workSheetName = pageTitle;
+                    title = pageTitle;
+                }
             }
+            excel.Workbook.Properties.Title = title;
 
             // add author info
             Rock.Model.UserLogin userLogin = Rock.Model.UserLoginService.GetCurrentUser();
@@ -1457,7 +1467,8 @@ namespace Rock.Web.UI.Controls
             //// write data to worksheet there are three supported data sources
             //// DataTables, DataViews and ILists
 
-            int rowCounter = 4;
+            var headerRows = 3;
+            int rowCounter = headerRows;
             int columnCounter = 1;
 
             if ( this.ExportSource == ExcelExportSource.ColumnOutput )
@@ -1481,7 +1492,7 @@ namespace Rock.Web.UI.Controls
                 columnCounter = 1;
                 foreach ( var col in gridColumns )
                 {
-                    worksheet.Cells[3, columnCounter].Value = col.Value.HeaderText;
+                    worksheet.Cells[rowCounter, columnCounter].Value = col.Value.HeaderText;
                     columnCounter++;
                 }
 
@@ -1495,6 +1506,7 @@ namespace Rock.Web.UI.Controls
                 var selectedKeys = SelectedKeys.ToList();
                 for ( int i = 0; i < dataItems.Count; i++ )
                 {
+                    rowCounter++;
                     var dataItem = dataItems[i];
                     var gridViewRow = gridViewRows[i];
 
@@ -1527,107 +1539,225 @@ namespace Rock.Web.UI.Controls
                             var textControls = fieldCell.ControlsOfTypeRecursive<Control>().OfType<ITextControl>();
                             if ( textControls.Any() )
                             {
-                                exportValue = textControls.Select( a => a.Text ).Where( t => !string.IsNullOrWhiteSpace( t ) ).ToList().AsDelimited( string.Empty );
+                                exportValue = textControls.Select( a => a.Text ).Where( t => !string.IsNullOrWhiteSpace( t ) ).ToList().AsDelimited( string.Empty ).ReverseCurrencyFormatting();
                             }
                         }
 
-                        SetExcelValue( worksheet.Cells[rowCounter, columnCounter], exportValue );
+                        ExcelHelper.SetExcelValue( worksheet.Cells[rowCounter, columnCounter], exportValue );
 
-                        if ( col.Value is CurrencyField )
+                        // Set the initial column format when processing the first row of data
+                        // This is done here because a value is needed to determine the data types
+                        if ( rowCounter == headerRows + 1 )
                         {
-                            worksheet.Cells[rowCounter, columnCounter].Style.Numberformat.Format = "0.00";
+                            worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.DefaultColumnFormat( col.Value, exportValue );
                         }
 
-                        if ( exportValue != null && exportValue is DateTime )
-                        {
-                            worksheet.Cells[rowCounter, columnCounter].Style.Numberformat.Format = "MM/dd/yyyy hh:mm";
-                        }
+                        // Update column formatting based on data
+                        worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.FinalColumnFormat( exportValue, worksheet.Column( columnCounter ).Style.Numberformat.Format );
                     }
+                }
+            }
+            else if ( this.DataSourceAsDataTable != null )
+            {
+                var gridDataFields = this.Columns.OfType<BoundField>().ToList();
+                DataTable data = this.DataSourceAsDataTable;
+                columnCounter = 0;
 
+                // Set up the columns
+                foreach ( DataColumn column in data.Columns )
+                {
+                    columnCounter++;
+
+                    // Print column headings
+                    var gridField = gridDataFields.FirstOrDefault( a => a.DataField == column.ColumnName );
+                    worksheet.Cells[rowCounter, columnCounter].Value = gridField != null ? gridField.HeaderText : column.ColumnName.SplitCase();
+
+                    // Set the initial column format
+                    worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.DefaultColumnFormat( column.DataType );
+                }
+
+                // print data
+                foreach ( DataRowView rowView in data.DefaultView )
+                {
                     rowCounter++;
+
+                    for ( int i = 0; i < data.Columns.Count; i++ )
+                    {
+                        var value = rowView.Row[i].ReverseCurrencyFormatting();
+                        ExcelHelper.SetExcelValue( worksheet.Cells[rowCounter, i + 1], value );
+
+                        // Update column formatting based on data
+                        worksheet.Column( i + 1 ).Style.Numberformat.Format = ExcelHelper.FinalColumnFormat( value, worksheet.Column( i + 1 ).Style.Numberformat.Format );
+                    }
                 }
             }
             else
             {
-                if ( this.DataSourceAsDataTable != null )
+                var definedValueFields = this.Columns.OfType<DefinedValueField>().ToList();
+                var attributeFields = this.Columns.OfType<AttributeField>().ToList();
+                var lavaFields = new List<LiquidField>();
+                var visibleFields = new Dictionary<int, DataControlField>();
+
+                int fieldOrder = 0;
+                foreach ( DataControlField dataField in this.Columns )
                 {
-                    var gridDataFields = this.Columns.OfType<BoundField>().ToList();
-                    DataTable data = this.DataSourceAsDataTable;
-
-                    // print headings
-                    foreach ( DataColumn column in data.Columns )
+                    if ( dataField is LiquidField )
                     {
-                        var gridField = gridDataFields.FirstOrDefault( a => a.DataField == column.ColumnName );
-                        worksheet.Cells[3, columnCounter].Value = gridField != null ? gridField.HeaderText : column.ColumnName.SplitCase();
-                        columnCounter++;
+                        var lavaField = dataField as LiquidField;
+                        lavaFields.Add( lavaField );
+                        visibleFields.Add( fieldOrder++, lavaField );
                     }
-
-                    // print data
-                    foreach ( DataRowView rowView in data.DefaultView )
+                    if ( dataField is BoundField )
                     {
-                        for ( int i = 0; i < data.Columns.Count; i++ )
-                        {
-                            SetExcelValue( worksheet.Cells[rowCounter, i + 1], rowView.Row[i] );
-                        }
-
-                        rowCounter++;
+                        var boundField = dataField as BoundField;
+                        visibleFields.Add( fieldOrder++, boundField );
                     }
                 }
-                else
+
+                var oType = GetDataSourceObjectType();
+
+                // get all properties of the objects in the grid
+                IList<PropertyInfo> allprops = new List<PropertyInfo>( oType.GetProperties() );
+
+                // Inspect the collection of Fields that appear in the Grid and add the corresponding data item properties to the set of fields to be exported.
+                // The fields are exported in the same order as they appear in the Grid.
+                var props = new List<PropertyInfo>();
+                foreach ( PropertyInfo prop in allprops )
                 {
-                    var definedValueFields = this.Columns.OfType<DefinedValueField>().ToList();
-                    var attributeFields = this.Columns.OfType<AttributeField>().ToList();
-                    var lavaFields = new List<LiquidField>();
-                    var visibleFields = new Dictionary<int, DataControlField>();
-
-                    int fieldOrder = 0;
-                    foreach( DataControlField dataField in this.Columns )
+                    // skip over virtual properties that aren't shown in the grid since they are probably lazy loaded and it is too late to get them
+                    if ( prop.GetGetMethod().IsVirtual && prop.GetCustomAttributes( typeof( Rock.Data.PreviewableAttribute ) ).Count() == 0 )
                     {
-                        if ( dataField is LiquidField )
+                        continue;
+                    }
+
+                    // Skip the lava property (is added through columns)
+                    if ( prop.Name.StartsWith( "Data_Lava_" ) )
+                    {
+                        continue;
+                    }
+
+                    props.Add( prop );
+                }
+
+                var lavaDataFields = new Dictionary<string, LiquidFieldTemplate.DataFieldInfo>();
+
+                // Grid column headings
+                var boundPropNames = new List<string>();
+                foreach ( DataControlField dataField in visibleFields.OrderBy( f => f.Key ).Select( f => f.Value ) )
+                {
+                    worksheet.Cells[rowCounter, columnCounter].Value = dataField.HeaderText;
+
+                    var boundField = dataField as BoundField;
+                    if ( boundField != null )
+                    {
+                        var prop = props.FirstOrDefault( p => boundField.DataField == p.Name || boundField.DataField.StartsWith( p.Name + "." ) );
+                        if ( prop != null )
                         {
-                            var lavaField = dataField as LiquidField;
-                            lavaFields.Add( lavaField );
-                            visibleFields.Add( fieldOrder++, lavaField );
-                        }
-                        if ( dataField is BoundField )
-                        {
-                            var boundField = dataField as BoundField;
-                            visibleFields.Add( fieldOrder++, boundField );
+                            if ( lavaFields.Any() )
+                            {
+                                var mergeFieldName = boundField.HeaderText.Replace( " ", string.Empty ).RemoveSpecialCharacters();
+                                lavaDataFields.AddOrIgnore( mergeFieldName, new LiquidFieldTemplate.DataFieldInfo { PropertyInfo = prop, GridField = boundField } );
+                            }
+
+                            boundPropNames.Add( prop.Name );
+
+                            // Set the initial column format
+                            worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.DefaultColumnFormat( prop.PropertyType );
                         }
                     }
 
-                    var oType = GetDataSourceObjectType();
+                    columnCounter++;
+                }
 
-                    // get all properties of the objects in the grid
-                    IList<PropertyInfo> allprops = new List<PropertyInfo>( oType.GetProperties() );
-
-                    // Inspect the collection of Fields that appear in the Grid and add the corresponding data item properties to the set of fields to be exported.
-                    // The fields are exported in the same order as they appear in the Grid.
-                    var props = new List<PropertyInfo>();
-                    foreach ( PropertyInfo prop in allprops )
+                // headings for data not associated with a bound field
+                foreach ( var prop in props.Where( p => !boundPropNames.Contains( p.Name ) ) )
+                {
+                    if ( lavaFields.Any() )
                     {
-                        // skip over virtual properties that aren't shown in the grid since they are probably lazy loaded and it is too late to get them
-                        if ( prop.GetGetMethod().IsVirtual && prop.GetCustomAttributes( typeof( Rock.Data.PreviewableAttribute ) ).Count() == 0 )
-                        {
-                            continue;
-                        }
-
-                        // Skip the lava property (is added through columns)
-                        if ( prop.Name.StartsWith( "Data_Lava_"))
-                        {
-                            continue;
-                        }
-
-                        props.Add( prop );
+                        var mergeFieldName = prop.Name;
+                        lavaDataFields.AddOrIgnore( mergeFieldName, new LiquidFieldTemplate.DataFieldInfo { PropertyInfo = prop, GridField = null } );
                     }
 
-                    var lavaDataFields = new Dictionary<string, LiquidFieldTemplate.DataFieldInfo>();
+                    worksheet.Cells[rowCounter, columnCounter].Value = prop.Name.SplitCase();
+                    worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.DefaultColumnFormat( prop.PropertyType );
 
-                    // Grid column headings
-                    var boundPropNames = new List<string>();
-                    foreach ( DataControlField dataField in visibleFields.OrderBy( f => f.Key ).Select( f => f.Value ) )
+                    columnCounter++;
+                }
+
+                string appRoot = ( ( RockPage ) Page ).ResolveRockUrl( "~/" );
+                string themeRoot = ( ( RockPage ) Page ).ResolveRockUrl( "~~/" );
+
+                // print data
+                int dataIndex = 0;
+
+                IList data = this.DataSourceAsList;
+
+                var selectedKeys = SelectedKeys.ToList();
+                foreach ( var item in data )
+                {
+                    if ( selectedKeys.Any() && this.DataKeyNames.Count() == 1 )
                     {
-                        worksheet.Cells[3, columnCounter].Value = dataField.HeaderText;
+                        var dataKeyValue = item.GetPropertyValue( this.DataKeyNames[0] );
+                        if ( !selectedKeys.Contains( dataKeyValue ) )
+                        {
+                            // if there are specific rows selected, skip over rows that aren't selected
+                            dataIndex++;
+                            continue;
+                        }
+                    }
+
+                    Rock.Attribute.IHasAttributes dataItemWithAttributes = null;
+                    if ( attributeFields.Any() )
+                    {
+                        // First check to see if there is an object list
+                        if ( ObjectList != null )
+                        {
+                            // If an object list exists, check to see if the associated object has attributes
+                            string key = DataKeys[dataIndex].Value.ToString();
+                            if ( !string.IsNullOrWhiteSpace( key ) && ObjectList.ContainsKey( key ) )
+                            {
+                                dataItemWithAttributes = ObjectList[key] as Rock.Attribute.IHasAttributes;
+                            }
+                        }
+
+                        // Then check if DataItem has attributes
+                        if ( dataItemWithAttributes == null )
+                        {
+                            dataItemWithAttributes = item as Rock.Attribute.IHasAttributes;
+                        }
+
+                        if ( dataItemWithAttributes != null )
+                        {
+                            if ( dataItemWithAttributes.Attributes == null )
+                            {
+                                dataItemWithAttributes.LoadAttributes();
+                            }
+                        }
+                    }
+
+                    columnCounter = 0;
+                    rowCounter++;
+
+                    foreach ( var dataField in visibleFields.OrderBy( f => f.Key ).Select( f => f.Value ) )
+                    {
+                        columnCounter++;
+
+                        var attributeField = dataField as AttributeField;
+                        if ( attributeField != null )
+                        {
+                            bool exists = dataItemWithAttributes.Attributes.ContainsKey( attributeField.DataField );
+                            if ( exists )
+                            {
+                                var attrib = dataItemWithAttributes.Attributes[attributeField.DataField];
+                                string rawValue = dataItemWithAttributes.GetAttributeValue( attributeField.DataField );
+                                string resultHtml = attrib.FieldType.Field.FormatValue( null, rawValue, attrib.QualifierValues, false ).ReverseCurrencyFormatting().ToString();
+                                worksheet.Cells[rowCounter, columnCounter].Value = resultHtml;
+
+                                // Update column formatting based on data
+                                worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.FinalColumnFormat( resultHtml, worksheet.Column( columnCounter ).Style.Numberformat.Format );
+                            }
+                            continue;
+                        }
 
                         var boundField = dataField as BoundField;
                         if ( boundField != null )
@@ -1635,290 +1765,77 @@ namespace Rock.Web.UI.Controls
                             var prop = props.FirstOrDefault( p => boundField.DataField == p.Name || boundField.DataField.StartsWith( p.Name + "." ) );
                             if ( prop != null )
                             {
-                                if ( lavaFields.Any() )
+                                object propValue = prop.GetValue( item, null );
+
+                                if ( dataField is CallbackField )
                                 {
-                                    var mergeFieldName = boundField.HeaderText.Replace( " ", string.Empty ).RemoveSpecialCharacters();
-                                    lavaDataFields.AddOrIgnore( mergeFieldName, new LiquidFieldTemplate.DataFieldInfo { PropertyInfo = prop, GridField = boundField } );
+                                    propValue = ( dataField as CallbackField ).GetFormattedDataValue( propValue );
                                 }
 
-                                boundPropNames.Add( prop.Name );
-                                if ( prop.PropertyType == typeof( DateTime ) || prop.PropertyType == typeof( DateTime? ) )
-                                {
-                                    worksheet.Column( columnCounter ).Style.Numberformat.Format = "MM/dd/yyyy hh:mm";
-                                }
+                                var definedValueAttribute = prop.GetCustomAttributes( typeof( DefinedValueAttribute ), true ).FirstOrDefault();
+
+                                bool isDefinedValue = ( definedValueAttribute != null || definedValueFields.Any( f => f.DataField == prop.Name ) );
+
+                                var cell = worksheet.Cells[rowCounter, columnCounter];
+                                var exportValue = GetExportValue( prop, propValue, isDefinedValue, cell ).ReverseCurrencyFormatting();
+                                ExcelHelper.SetExcelValue( cell, exportValue );
+
+                                // Update column formatting based on data
+                                worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.FinalColumnFormat( exportValue, worksheet.Column( columnCounter ).Style.Numberformat.Format );
                             }
+                            continue;
                         }
 
-                        columnCounter++;
+                        var lavaField = dataField as LiquidField;
+                        if ( lavaField != null )
+                        {
+                            var mergeValues = new Dictionary<string, object>();
+                            foreach ( var dataFieldItem in lavaDataFields )
+                            {
+                                var dataFieldValue = dataFieldItem.Value.PropertyInfo.GetValue( item, null );
+                                if ( dataFieldItem.Value.GridField is DefinedValueField )
+                                {
+                                    var definedValue = ( dataFieldItem.Value.GridField as DefinedValueField ).GetDefinedValue( dataFieldValue );
+                                    dataFieldValue = definedValue != null ? definedValue.Value : null;
+                                }
+                                mergeValues.Add( dataFieldItem.Key, dataFieldValue );
+                            }
+
+                            string resolvedValue = lavaField.LiquidTemplate.ResolveMergeFields( mergeValues );
+                            worksheet.Cells[rowCounter, columnCounter].Value = resolvedValue.Replace( "~~/", themeRoot ).Replace( "~/", appRoot ).ReverseCurrencyFormatting().ToString();
+
+                            // Update column formatting based on data
+                            worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.FinalColumnFormat( worksheet.Cells[rowCounter, columnCounter].Value, worksheet.Column( columnCounter ).Style.Numberformat.Format );
+
+                            continue;
+                        }
                     }
 
-                    // headings for data not associated with a bound field
                     foreach ( var prop in props.Where( p => !boundPropNames.Contains( p.Name ) ) )
                     {
-                        if ( lavaFields.Any() )
-                        {
-                            var mergeFieldName = prop.Name;
-                            lavaDataFields.AddOrIgnore( mergeFieldName, new LiquidFieldTemplate.DataFieldInfo { PropertyInfo = prop, GridField = null } );
-                        }
-
-                        worksheet.Cells[3, columnCounter].Value = prop.Name.SplitCase();
-                        if ( prop.PropertyType == typeof( DateTime ) || prop.PropertyType == typeof( DateTime? ) )
-                        {
-                            worksheet.Column( columnCounter ).Style.Numberformat.Format = "MM/dd/yyyy hh:mm";
-                        }
-
                         columnCounter++;
+                        object propValue = prop.GetValue( item, null );
+
+                        var definedValueAttribute = prop.GetCustomAttributes( typeof( DefinedValueAttribute ), true ).FirstOrDefault();
+
+                        bool isDefinedValue = ( definedValueAttribute != null || definedValueFields.Any( f => f.DataField == prop.Name ) );
+
+                        var cell = worksheet.Cells[rowCounter, columnCounter];
+                        var exportValue = GetExportValue( prop, propValue, isDefinedValue, cell ).ReverseCurrencyFormatting();
+                        ExcelHelper.SetExcelValue( cell, exportValue );
+
+                        // Update column formatting based on data
+                        worksheet.Column( columnCounter ).Style.Numberformat.Format = ExcelHelper.FinalColumnFormat( exportValue, worksheet.Column( columnCounter ).Style.Numberformat.Format );
                     }
 
-                    string appRoot =  ( (RockPage)Page ).ResolveRockUrl( "~/" );
-                    string themeRoot = ( (RockPage)Page ).ResolveRockUrl( "~~/" );
-
-                    // print data
-                    int dataIndex = 0;
-
-                    IList data = this.DataSourceAsList;
-
-                    var selectedKeys = SelectedKeys.ToList();
-                    foreach ( var item in data )
-                    {
-                        if ( selectedKeys.Any() && this.DataKeyNames.Count() == 1 )
-                        {
-                            var dataKeyValue = item.GetPropertyValue( this.DataKeyNames[0] );
-                            if ( !selectedKeys.Contains( dataKeyValue ) )
-                            {
-                                // if there are specific rows selected, skip over rows that aren't selected
-                                dataIndex++;
-                                continue;
-                            }
-                        }
-
-                        Rock.Attribute.IHasAttributes dataItemWithAttributes = null;
-                        if ( attributeFields.Any() )
-                        {
-                            // First check to see if there is an object list
-                            if ( ObjectList != null )
-                            {
-                                // If an object list exists, check to see if the associated object has attributes
-                                string key = DataKeys[dataIndex].Value.ToString();
-                                if ( !string.IsNullOrWhiteSpace( key ) && ObjectList.ContainsKey( key ) )
-                                {
-                                    dataItemWithAttributes = ObjectList[key] as Rock.Attribute.IHasAttributes;
-                                }
-                            }
-
-                            // Then check if DataItem has attributes
-                            if ( dataItemWithAttributes == null )
-                            {
-                                dataItemWithAttributes = item as Rock.Attribute.IHasAttributes;
-                            }
-
-                            if ( dataItemWithAttributes != null )
-                            {
-                                if ( dataItemWithAttributes.Attributes == null )
-                                {
-                                    dataItemWithAttributes.LoadAttributes();
-                                }
-                            }
-                        }
-
-                        columnCounter = 0;
-
-                        foreach( var dataField in visibleFields.OrderBy( f => f.Key ).Select( f => f.Value ) )
-                        {
-                            columnCounter++;
-
-                            var attributeField = dataField as AttributeField;
-                            if ( attributeField != null )
-                            {
-                                bool exists = dataItemWithAttributes.Attributes.ContainsKey( attributeField.DataField );
-                                if ( exists )
-                                {
-                                    var attrib = dataItemWithAttributes.Attributes[attributeField.DataField];
-                                    string rawValue = dataItemWithAttributes.GetAttributeValue( attributeField.DataField );
-                                    string resultHtml = attrib.FieldType.Field.FormatValue( null, rawValue, attrib.QualifierValues, false );
-                                    worksheet.Cells[rowCounter, columnCounter].Value = resultHtml;
-                                }
-                                continue;
-                            }
-
-                            var boundField = dataField as BoundField;
-                            if ( boundField != null )
-                            {
-                                var prop = props.FirstOrDefault( p => boundField.DataField == p.Name || boundField.DataField.StartsWith( p.Name + "." ) );
-                                if ( prop != null )
-                                {
-                                    object propValue = prop.GetValue( item, null );
-
-                                    if ( dataField is CallbackField )
-                                    {
-                                        propValue = ( dataField as CallbackField ).GetFormattedDataValue( propValue );
-                                    }
-
-                                    var definedValueAttribute = prop.GetCustomAttributes( typeof( DefinedValueAttribute ), true ).FirstOrDefault();
-
-                                    bool isDefinedValue = ( definedValueAttribute != null || definedValueFields.Any( f => f.DataField == prop.Name ) );
-
-                                    var cell = worksheet.Cells[rowCounter, columnCounter];
-                                    SetExcelValue( cell, this.GetExportValue( prop, propValue, isDefinedValue, cell ) );
-                                }
-                                continue;
-                            }
-
-                            var lavaField = dataField as LiquidField;
-                            if ( lavaField != null )
-                            {
-                                var mergeValues = new Dictionary<string, object>();
-                                foreach ( var dataFieldItem in lavaDataFields )
-                                {
-                                    var dataFieldValue = dataFieldItem.Value.PropertyInfo.GetValue( item, null );
-                                    if ( dataFieldItem.Value.GridField is DefinedValueField )
-                                    {
-                                        var definedValue = ( dataFieldItem.Value.GridField as DefinedValueField ).GetDefinedValue( dataFieldValue );
-                                        dataFieldValue = definedValue != null ? definedValue.Value : null;
-                                    }
-                                    mergeValues.Add( dataFieldItem.Key, dataFieldValue );
-                                }
-
-                                string resolvedValue = lavaField.LiquidTemplate.ResolveMergeFields( mergeValues );
-                                worksheet.Cells[rowCounter, columnCounter].Value = resolvedValue.Replace( "~~/", themeRoot ).Replace( "~/", appRoot );
-
-                                continue;
-                            }
-                        }
-
-                        foreach ( var prop in props.Where( p => !boundPropNames.Contains( p.Name ) ) )
-                        {
-                            columnCounter++;
-                            object propValue = prop.GetValue( item, null );
-
-                            var definedValueAttribute = prop.GetCustomAttributes( typeof( DefinedValueAttribute ), true ).FirstOrDefault();
-
-                            bool isDefinedValue = ( definedValueAttribute != null || definedValueFields.Any( f => f.DataField == prop.Name ) );
-
-                            var cell = worksheet.Cells[rowCounter, columnCounter];
-                            SetExcelValue( cell, this.GetExportValue( prop, propValue, isDefinedValue, cell ) );
-                        }
-
-                        rowCounter++;
-                        dataIndex++;
-                    }
+                    dataIndex++;
                 }
             }
 
-            var range = worksheet.Cells[3, 1, rowCounter, columnCounter];
-
-            // use conditionalFormatting to create the alternate row style
-            var conditionalFormatting = range.ConditionalFormatting.AddExpression();
-            conditionalFormatting.Formula = "MOD(ROW()+1,2)=0";
-            conditionalFormatting.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
-            conditionalFormatting.Style.Fill.BackgroundColor.Color = Color.FromArgb( 240, 240, 240 );
-            
-            var table = worksheet.Tables.Add( range, "table1" );
-            
-            // ensure each column in the table has a unique name
-            var columnNames = worksheet.Cells[3, 1, 3, columnCounter].Select( a => new { OrigColumnName = a.Text, Cell = a } ).ToList();
-            columnNames.Reverse();
-            foreach ( var col in columnNames )
-            {
-                int duplicateSuffix = 0;
-                string uniqueName = col.OrigColumnName;
-                
-                // increment the suffix by 1 until there is only one column with that name
-                while ( columnNames.Where(a => a.Cell.Text == uniqueName ).Count() > 1 )
-                {
-                    duplicateSuffix++;
-                    uniqueName = col.OrigColumnName + duplicateSuffix.ToString();
-                    col.Cell.Value = uniqueName;
-                }
-            }
-
-            table.ShowFilter = true;
-            table.TableStyle = OfficeOpenXml.Table.TableStyles.None;
-
-            // format header range
-            using ( ExcelRange r = worksheet.Cells[3, 1, 3, columnCounter] )
-            {
-                r.Style.Font.Bold = true;
-                r.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
-                r.Style.Fill.BackgroundColor.SetColor( Color.FromArgb( 223, 223, 223 ) );
-                r.Style.Font.Color.SetColor( Color.Black );
-                r.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Left;
-            }
-
-            // format and set title
-            worksheet.Cells[1, 1].Value = title;
-            using ( ExcelRange r = worksheet.Cells[1, 1, 1, columnCounter] )
-            {
-                r.Merge = true;
-                r.Style.Font.SetFromFont( new Font( "Calibri", 22, FontStyle.Regular ) );
-                r.Style.Font.Color.SetColor( Color.White );
-                r.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Left;
-                r.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
-                r.Style.Fill.BackgroundColor.SetColor( Color.FromArgb( 34, 41, 55 ) );
-
-                // set border
-                r.Style.Border.Left.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
-                r.Style.Border.Right.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
-                r.Style.Border.Top.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
-                r.Style.Border.Bottom.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thin;
-            }
-
-            // TODO: add image to worksheet
-
-            // freeze panes
-            worksheet.View.FreezePanes( 3, 1 );
-
-            // autofit columns for all cells
-            worksheet.Cells.AutoFitColumns( 0 );
-
-            // add alternating highlights
-
-            // set some footer text
-            worksheet.HeaderFooter.OddHeader.CenteredText = title;
-            worksheet.HeaderFooter.OddFooter.RightAlignedText = string.Format( "Page {0} of {1}", ExcelHeaderFooter.PageNumber, ExcelHeaderFooter.NumberOfPages );
-            byte[] byteArray;
-            using ( MemoryStream ms = new MemoryStream() )
-            {
-                excel.SaveAs( ms );
-                byteArray = ms.ToArray();
-            }
+            worksheet.FormatWorksheet( title, headerRows, rowCounter, columnCounter );
 
             // send the spreadsheet to the browser
-            this.Page.EnableViewState = false;
-            this.Page.Response.Clear();
-            this.Page.Response.ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-            this.Page.Response.AppendHeader( "Content-Disposition", "attachment; filename=" + filename );
-
-            this.Page.Response.Charset = string.Empty;
-            this.Page.Response.BinaryWrite( byteArray );
-            this.Page.Response.Flush();
-            this.Page.Response.End();
-        }
-
-        /// <summary>
-        /// Formats the export value.
-        /// </summary>
-        /// <param name="range">The range.</param>
-        /// <param name="exportValue">The export value.</param>
-        private void SetExcelValue( ExcelRange range, object exportValue )
-        {
-            if ( exportValue != null &&
-                ( exportValue is decimal || exportValue is decimal? ||
-                exportValue is int || exportValue is int? ||
-                exportValue is double || exportValue is double? ||
-                exportValue is DateTime || exportValue is DateTime? ) )
-            {
-                range.Value = exportValue;
-            }
-            else
-            {
-                string value = exportValue != null ? exportValue.ToString().ConvertBrToCrLf().Replace( "&nbsp;", " " ) : string.Empty;
-                range.Value = value;
-                if ( value.Contains( Environment.NewLine ) )
-                {
-                    range.Style.WrapText = true;
-                }
-            }
+            excel.SendToBrowser( this.Page, filename );
         }
 
         /// <summary>
@@ -1962,11 +1879,11 @@ namespace Rock.Web.UI.Controls
 
                         if ( prop.PropertyType == typeof( int ) )
                         {
-                            definedValueId = (int)propValue;
+                            definedValueId = ( int ) propValue;
                         }
                         else
                         {
-                            definedValueId = (int?)propValue ?? 0;
+                            definedValueId = ( int? ) propValue ?? 0;
                         }
 
                         if ( definedValueId > 0 )
@@ -2026,11 +1943,11 @@ namespace Rock.Web.UI.Controls
                         try
                         {
                             var aNode = HtmlAgilityPack.HtmlNode.CreateNode( propValue.ToString() );
-                            if (aNode != null && aNode.NodeType != HtmlAgilityPack.HtmlNodeType.Element)
+                            if ( aNode != null && aNode.NodeType != HtmlAgilityPack.HtmlNodeType.Element )
                             {
                                 aNode = aNode.NextSibling;
                             }
-                            
+
                             // Select the hyperlink tag
                             if ( aNode.Attributes["href"] != null )
                             {
@@ -2039,8 +1956,8 @@ namespace Rock.Web.UI.Controls
                                 return aNode.InnerText;
                             }
                         }
-                        catch 
-                        { 
+                        catch
+                        {
                             // ignore
                         }
                     }
@@ -2219,7 +2136,7 @@ namespace Rock.Web.UI.Controls
                                 {
                                     if ( eventArg.MergeValues != null )
                                     {
-                                        foreach( var mergeValue in eventArg.MergeValues )
+                                        foreach ( var mergeValue in eventArg.MergeValues )
                                         {
                                             if ( !CommunicateMergeFields.Contains( mergeValue.Key ) )
                                             {
@@ -2283,10 +2200,10 @@ namespace Rock.Web.UI.Controls
                                 var personIdObjTree = new List<object>();
                                 personIdObjTree.Add( item );
                                 bool propFound = true;
-                                foreach( var prop in personIdProp )
+                                foreach ( var prop in personIdProp )
                                 {
                                     object obj = prop.GetValue( personIdObjTree.Last(), null );
-                                    if (obj != null )
+                                    if ( obj != null )
                                     {
                                         personIdObjTree.Add( obj );
                                     }
@@ -2299,8 +2216,8 @@ namespace Rock.Web.UI.Controls
 
                                 if ( propFound && personIdObjTree.Last() is int )
                                 {
-                                    int personId = (int)personIdObjTree.Last();
-                                    int id = (int)idProp.GetValue( item, null );
+                                    int personId = ( int ) personIdObjTree.Last();
+                                    int id = ( int ) idProp.GetValue( item, null );
 
                                     // Add the personId if none are selected or if it's one of the selected items.
                                     if ( !keysSelected.Any() || keysSelected.Contains( id ) )
@@ -2327,7 +2244,10 @@ namespace Rock.Web.UI.Controls
                                                     {
                                                         CommunicateMergeFields.Add( mergeValue.Key );
                                                     }
-                                                    mergeValues.Add( mergeValue.Key, mergeValue.Value );
+                                                    if ( !mergeValues.ContainsKey( mergeValue.Key ) )
+                                                    {
+                                                        mergeValues.Add( mergeValue.Key, mergeValue.Value );
+                                                    }
                                                 }
                                             }
                                         }
@@ -2362,11 +2282,11 @@ namespace Rock.Web.UI.Controls
                     try
                     {
                         var item = new Rock.Model.EntitySetItem();
-                        item.EntityId = (int)key.Key;
+                        item.EntityId = ( int ) key.Key;
                         entitySet.Items.Add( item );
                     }
-                    catch 
-                    { 
+                    catch
+                    {
                         // ignore
                     }
                 }
@@ -2417,11 +2337,11 @@ namespace Rock.Web.UI.Controls
             {
                 if ( this.DataSource is DataTable )
                 {
-                    return (DataTable)this.DataSource;
+                    return ( DataTable ) this.DataSource;
                 }
                 else if ( this.DataSource is DataView )
                 {
-                    return ( (DataView)this.DataSource ).Table;
+                    return ( ( DataView ) this.DataSource ).Table;
                 }
 
                 return null;
@@ -2464,10 +2384,10 @@ namespace Rock.Web.UI.Controls
             {
                 entitySet.EntityTypeId = null;
             }
-            
+
             bool isPersonEntitySet = this.EntityTypeId == EntityTypeCache.GetId<Rock.Model.Person>();
             string dataKeyField = this.DataKeyNames.FirstOrDefault() ?? "Id";
-            if ( isPersonEntitySet && !string.IsNullOrEmpty(this.PersonIdField) )
+            if ( isPersonEntitySet && !string.IsNullOrEmpty( this.PersonIdField ) )
             {
                 dataKeyField = this.PersonIdField;
             }
@@ -2503,8 +2423,8 @@ namespace Rock.Web.UI.Controls
 
                     entitySet.Items.Add( item );
                 }
-                catch 
-                { 
+                catch
+                {
                     // ignore
                 }
             }
@@ -2688,8 +2608,8 @@ namespace Rock.Web.UI.Controls
 
                     entitySet.Items.Add( item );
                 }
-                catch 
-                { 
+                catch
+                {
                     // ignore
                 }
             }
@@ -2744,8 +2664,8 @@ namespace Rock.Web.UI.Controls
                     }
                 }
             }
-            catch 
-            { 
+            catch
+            {
                 // ignore
             }
 
@@ -3064,7 +2984,7 @@ namespace Rock.Web.UI.Controls
         /// </summary>
         /// <param name="row">The row.</param>
         /// <param name="isExporting">if set to <c>true</c> [is exporting].</param>
-        public RockGridViewRowEventArgs( GridViewRow row, bool isExporting ) : base( row)
+        public RockGridViewRowEventArgs( GridViewRow row, bool isExporting ) : base( row )
         {
             IsExporting = isExporting;
         }
@@ -3434,7 +3354,7 @@ namespace Rock.Web.UI.Controls
                 ItemLink[i] = new LinkButton();
                 ItemLinkListItem[i].Controls.Add( ItemLink[i] );
                 ItemLink[i].ID = string.Format( "ItemLink{0}", i );
-                ItemLink[i].Text = ( 5 * Math.Pow(10, i + 1) ).ToString( "N0" );
+                ItemLink[i].Text = ( 5 * Math.Pow( 10, i + 1 ) ).ToString( "N0" );
                 ItemLink[i].CausesValidation = false;
                 ItemLink[i].Click += new EventHandler( lbItems_Click );
             }
@@ -3482,8 +3402,8 @@ namespace Rock.Web.UI.Controls
             {
                 if ( pageCount > 1 )
                 {
-                    int totalGroups = (int)( ( pageCount - 1 ) / 10 ) + 1;
-                    int currentGroupIndex = (int)( pageIndex / 10 );
+                    int totalGroups = ( int ) ( ( pageCount - 1 ) / 10 ) + 1;
+                    int currentGroupIndex = ( int ) ( pageIndex / 10 );
 
                     int prevPageIndex = ( ( currentGroupIndex - 1 ) * 10 ) + 9;
                     if ( prevPageIndex < 0 )


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Initially, I found that exporting a Dynamic Data Block resulted in a spreadsheet that did not have any Date or Number formatting. I also found that a single formatting for Dates and Numbers did not always make sense, such as showing the hours and minutes on a BirthDate column, or showing some currency columns with decimal and others as text with a dollar sign. Finally, I found some other miscellaneous bugs such as extra rows/columns being added, and the column headers not being included in the frozen header section.

# Goal
_What will this pull request achieve and how will this fix the problem?_

All grids will intelligently format their exported spreadsheets in a common way, no matter what kind of data source is used to populate the grid.

# Strategy
_How have you implemented your solution?_

* Improved formatting of dates and numbers to choose the most logical formatting based on the data in the column
	- Column will be formatted to show the date only (no time) if none of the fields in the column have a time component
	- Column will show decimal places only if there is a decimal value in any of the cells of the column, or it's a currency field
	- Template fields that are populated using the FormatAsCurrency() function will format the value as a decimal rather than text using the ReverseCurrencyFormatting() function
* Added proper formatting of dates and numbers for dynamic data block exports
* Worksheet title, header text, and file name will now use title of the page the grid is on if there is no grid caption set.
* No longer adds an extra row and column in some cases
* Now correctly includes the column headers in the frozen header section
* Created an ExcelHelper class to house common Excel exporting functionality (see https://github.com/SparkDevNetwork/Rock/pull/1852)

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

I tried to think of the most common uses of number columns and format them in a meaningful way. I'm sure that not every possibility has been covered here, but the result should be an improvement over totally unformatted columns. The only place the data itself is being exported differently is for grids like the Event Registration grid where dollar amounts are displayed as text in a template field, but are now exported as decimals.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._
## Example 1
Example showing Data View of pledge data
**Before**
![image](https://cloud.githubusercontent.com/assets/383807/20493846/ab1c59b0-afd7-11e6-8040-e0f516dc0617.png)
> Note the position of the freeze pane (light gray line) above the header on the third row.

**After**
![image](https://cloud.githubusercontent.com/assets/383807/20493879/c429a3b8-afd7-11e6-928a-3688432787be.png)
> Note the corrected position of the freeze pane (light gray line) _below_ the header on the third row.

## Example 2
Showing Report based on previous example's Data View.
**Before**
![image](https://cloud.githubusercontent.com/assets/383807/20494361/c61adc12-afd9-11e6-8c8c-0c5a6c6ee33d.png)

**After**
![image](https://cloud.githubusercontent.com/assets/383807/20494376/d97dae2e-afd9-11e6-9322-d6c2b8dac021.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
