### PR TITLE
Added Workflow action to get person's head of household 

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -1874,21 +1874,13 @@ namespace Rock.Lava
         /// <returns></returns>
         public static Person Spouse( DotLiquid.Context context, object input )
         {
-            if ( input == null )
+            var person = GetPerson( input );
+
+            if ( person == null )
             {
                 return null;
             }
-
-            int personAliasId = -1;
-
-            if ( !Int32.TryParse( input.ToString(), out personAliasId ) )
-            {
-                return null;
-            }
-
-            var rockContext = new RockContext();
-
-            return new PersonAliasService( rockContext ).GetPerson( personAliasId ).GetSpouse();
+            return person.GetSpouse();
         }
 
         /// <summary>
@@ -1899,21 +1891,13 @@ namespace Rock.Lava
         /// <returns></returns>
         public static Person HeadOfHousehold( DotLiquid.Context context, object input )
         {
-            if ( input == null )
+            var person = GetPerson( input );
+
+            if ( person == null )
             {
                 return null;
             }
-
-            int personAliasId = -1;
-
-            if ( !Int32.TryParse( input.ToString(), out personAliasId ) )
-            {
-                return null;
-            }
-
-            var rockContext = new RockContext();
-
-            return new PersonAliasService( rockContext ).GetPerson( personAliasId ).GetHeadOfHousehold();
+            return person.GetHeadOfHousehold();
         }
 
         /// <summary>

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -1867,6 +1867,56 @@ namespace Rock.Lava
         }
 
         /// <summary>
+        /// Gets the Spouse of the selected person 
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="input">The input.</param>
+        /// <returns></returns>
+        public static Person Spouse( DotLiquid.Context context, object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            int personAliasId = -1;
+
+            if ( !Int32.TryParse( input.ToString(), out personAliasId ) )
+            {
+                return null;
+            }
+
+            var rockContext = new RockContext();
+
+            return new PersonAliasService( rockContext ).GetPerson( personAliasId ).GetSpouse();
+        }
+
+        /// <summary>
+        /// Gets the Head of Household of the selected person 
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="input">The input.</param>
+        /// <returns></returns>
+        public static Person HeadOfHousehold( DotLiquid.Context context, object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            int personAliasId = -1;
+
+            if ( !Int32.TryParse( input.ToString(), out personAliasId ) )
+            {
+                return null;
+            }
+
+            var rockContext = new RockContext();
+
+            return new PersonAliasService( rockContext ).GetPerson( personAliasId ).GetHeadOfHousehold();
+        }
+
+        /// <summary>
         /// Gets an number for a person object
         /// </summary>
         /// <param name="context">The context.</param>

--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -2821,6 +2821,19 @@ namespace Rock.Model
         }
 
         /// <summary>
+        /// Gets the <see cref="Rock.Model.Person" /> entity of the provided Person's spouse.
+        /// </summary>
+        /// <param name="person">The <see cref="Rock.Model.Person" /> entity of the Person to retrieve the spouse of.</param>
+        /// <param name="rockContext">The rock context.</param>
+        /// <returns>
+        /// The <see cref="Rock.Model.  1Person" /> entity containing the provided Person's head of houseold. If the provided Person's head of houseold is not found, this value will be null.
+        /// </returns>
+        public static Person GetHeadOfHouseold( this Person person, RockContext rockContext = null )
+        {
+            return new PersonService( rockContext ?? new RockContext() ).GetHeadOfHouseold( person );
+        }
+
+        /// <summary>
         /// Gets the family role (adult or child).
         /// </summary>
         /// <param name="person">The person.</param>

--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -2821,16 +2821,16 @@ namespace Rock.Model
         }
 
         /// <summary>
-        /// Gets the <see cref="Rock.Model.Person" /> entity of the provided Person's spouse.
+        /// Gets the <see cref="Rock.Model.Person" /> entity of the provided Person's head of household.
         /// </summary>
-        /// <param name="person">The <see cref="Rock.Model.Person" /> entity of the Person to retrieve the spouse of.</param>
+        /// <param name="person">The <see cref="Rock.Model.Person" /> entity of the Person to retrieve the head of household of.</param>
         /// <param name="rockContext">The rock context.</param>
         /// <returns>
-        /// The <see cref="Rock.Model.  1Person" /> entity containing the provided Person's head of houseold. If the provided Person's head of houseold is not found, this value will be null.
+        /// The <see cref="Rock.Model.  1Person" /> entity containing the provided Person's head of household. If the provided Person's head of houseold is not found, this value will be null.
         /// </returns>
-        public static Person GetHeadOfHouseold( this Person person, RockContext rockContext = null )
+        public static Person GetHeadOfHousehold( this Person person, RockContext rockContext = null )
         {
-            return new PersonService( rockContext ?? new RockContext() ).GetHeadOfHouseold( person );
+            return new PersonService( rockContext ?? new RockContext() ).GetHeadOfHousehold( person );
         }
 
         /// <summary>

--- a/Rock/Model/PersonService.Partial.cs
+++ b/Rock/Model/PersonService.Partial.cs
@@ -1385,6 +1385,26 @@ namespace Rock.Model
                 .FirstOrDefault();
         }
 
+        /// <summary>
+        /// Gets the <see cref="Rock.Model.Person"/> entity of the provided Person's spouse.
+        /// </summary>
+        /// <param name="person">The <see cref="Rock.Model.Person"/> entity of the Person to retrieve the head of houseold of.</param>
+        /// <returns>The <see cref="Rock.Model.Person"/> entity containing the provided Person's head of houseold. If the provided Person's family head of houseold is not found, this value will be null.</returns>
+        public Person GetHeadOfHouseold( Person person )
+        {
+            var family = GetFamilies( person.Id ).FirstOrDefault();
+            if ( family == null )
+            {
+                return null;
+            }
+            return GetFamilyMembers( family, person.Id )
+                .OrderBy( m => m.GroupRole.Order )
+                .ThenBy( m => m.Person.Gender )
+                .Select( a => a.Person )
+                .FirstOrDefault();
+        }
+
+
         #endregion
 
         /// <summary>

--- a/Rock/Model/PersonService.Partial.cs
+++ b/Rock/Model/PersonService.Partial.cs
@@ -1386,11 +1386,11 @@ namespace Rock.Model
         }
 
         /// <summary>
-        /// Gets the <see cref="Rock.Model.Person"/> entity of the provided Person's spouse.
+        /// Gets the <see cref="Rock.Model.Person"/> entity of the provided Person's head of household.
         /// </summary>
-        /// <param name="person">The <see cref="Rock.Model.Person"/> entity of the Person to retrieve the head of houseold of.</param>
-        /// <returns>The <see cref="Rock.Model.Person"/> entity containing the provided Person's head of houseold. If the provided Person's family head of houseold is not found, this value will be null.</returns>
-        public Person GetHeadOfHouseold( Person person )
+        /// <param name="person">The <see cref="Rock.Model.Person"/> entity of the Person to retrieve the head of household of.</param>
+        /// <returns>The <see cref="Rock.Model.Person"/> entity containing the provided Person's head of household. If the provided Person's family head of household is not found, this value will be null.</returns>
+        public Person GetHeadOfHousehold( Person person )
         {
             var family = GetFamilies( person.Id ).FirstOrDefault();
             if ( family == null )

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1603,7 +1603,7 @@
     <Compile Include="Workflow\Action\Groups\UpdateGroupMemberStatus.cs" />
     <Compile Include="Workflow\Action\People\GetPersonFromFields.cs" />
     <Compile Include="Workflow\Action\People\PersonAddressUpdate.cs" />
-    <Compile Include="Workflow\Action\People\PersonGetHeadOfHouseold.cs" />
+    <Compile Include="Workflow\Action\People\PersonGetHeadOfHousehold.cs" />
     <Compile Include="Workflow\Action\People\PersonGetSpouse.cs" />
     <Compile Include="Workflow\Action\People\PersonNoteAdd.cs" />
     <Compile Include="Workflow\Action\People\PersonPhoneUpdate.cs" />

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1603,6 +1603,7 @@
     <Compile Include="Workflow\Action\Groups\UpdateGroupMemberStatus.cs" />
     <Compile Include="Workflow\Action\People\GetPersonFromFields.cs" />
     <Compile Include="Workflow\Action\People\PersonAddressUpdate.cs" />
+    <Compile Include="Workflow\Action\People\PersonGetHeadOfHouseold.cs" />
     <Compile Include="Workflow\Action\People\PersonGetSpouse.cs" />
     <Compile Include="Workflow\Action\People\PersonNoteAdd.cs" />
     <Compile Include="Workflow\Action\People\PersonPhoneUpdate.cs" />

--- a/Rock/Workflow/Action/People/PersonGetHeadOfHousehold.cs
+++ b/Rock/Workflow/Action/People/PersonGetHeadOfHousehold.cs
@@ -33,13 +33,13 @@ namespace Rock.Workflow.Action
     /// Sets an attribute's value to the selected person 
     /// </summary>
     [ActionCategory( "People" )]
-    [Description( "Get's the Head of houseold of the selected person." )]
+    [Description( "Get's the Head of household of the selected person." )]
     [Export( typeof( ActionComponent ) )]
-    [ExportMetadata( "ComponentName", "Person Get head of houseold" )]
+    [ExportMetadata( "ComponentName", "Person Get head of household" )]
 
     [WorkflowAttribute( "Person", "Workflow attribute that contains the person to get the head of the house for.", true, "", "", 0, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
-    [WorkflowAttribute( "HeadOfHouseold Attribute", "The workflow attribute to assign the head of houseold to.  head of houseold is deemed to be the other group memmber on the first family.", true, "", "", 1, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
-    public class PersonGetHeadOfHouseold : ActionComponent
+    [WorkflowAttribute( "HeadOfHousehold Attribute", "The workflow attribute to assign the head of household to.  head of household is deemed to be the other group memmber on the first family.", true, "", "", 1, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
+    public class PersonGetHeadOfHousehold : ActionComponent
     {
         /// <summary>
         /// Executes the specified workflow.
@@ -58,23 +58,23 @@ namespace Rock.Workflow.Action
             var person = GetPersonAliasFromActionAttribute( "Person", rockContext, action, errorMessages );
             if ( person != null )
             {
-                string HeadOfHouseoldAttributeValue = GetAttributeValue( action, "HeadOfHouseoldAttribute" );
-                Guid? headOfHouseoldGuid = HeadOfHouseoldAttributeValue.AsGuidOrNull();
-                if ( headOfHouseoldGuid.HasValue )
+                string HeadOfHouseholdAttributeValue = GetAttributeValue( action, "HeadOfHouseholdAttribute" );
+                Guid? headOfHouseholdGuid = HeadOfHouseholdAttributeValue.AsGuidOrNull();
+                if ( headOfHouseholdGuid.HasValue )
                 {
-                    var headofHouseoldAttribute = AttributeCache.Read( headOfHouseoldGuid.Value, rockContext );
-                    if ( headofHouseoldAttribute != null )
+                    var headofHouseholdAttribute = AttributeCache.Read( headOfHouseholdGuid.Value, rockContext );
+                    if ( headofHouseholdAttribute != null )
                     {
-                        var headOfHouse = person.GetHeadOfHouseold( rockContext );
-                        if ( headOfHouse != null )
+                        var headOfHousehold = person.GetHeadOfHousehold( rockContext );
+                        if ( headOfHousehold != null )
                         {
-                            action.Activity.Workflow.SetAttributeValue( headofHouseoldAttribute.Key, headOfHouse.PrimaryAlias.Guid.ToString() );
-                            action.AddLogEntry( string.Format( "Set Head Of Houseold attribute '{0}' attribute to '{1}'.", headofHouseoldAttribute.Name, headOfHouse.FullName ) );
+                            action.Activity.Workflow.SetAttributeValue( headofHouseholdAttribute.Key, headOfHousehold.PrimaryAlias.Guid.ToString() );
+                            action.AddLogEntry( string.Format( "Set Head Of Household attribute '{0}' attribute to '{1}'.", headofHouseholdAttribute.Name, headOfHousehold.FullName ) );
                             return true;
                         }
                         else
                         {
-                            action.AddLogEntry( string.Format( "No head of houseold found for {0}.", person.FullName ) );
+                            action.AddLogEntry( string.Format( "No head of Household found for {0}.", person.FullName ) );
                         }
                     }
                 }

--- a/Rock/Workflow/Action/People/PersonGetHeadOfHouseold.cs
+++ b/Rock/Workflow/Action/People/PersonGetHeadOfHouseold.cs
@@ -1,0 +1,133 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Data.Entity;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Sets an attribute's value to the selected person 
+    /// </summary>
+    [ActionCategory( "People" )]
+    [Description( "Get's the Head of houseold of the selected person." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Person Get head of houseold" )]
+
+    [WorkflowAttribute( "Person", "Workflow attribute that contains the person to get the head of the house for.", true, "", "", 0, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
+    [WorkflowAttribute( "HeadOfHouseold Attribute", "The workflow attribute to assign the head of houseold to.  head of houseold is deemed to be the other group memmber on the first family.", true, "", "", 1, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
+    public class PersonGetHeadOfHouseold : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            var adultRoleGuid = SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid();
+
+            var person = GetPersonAliasFromActionAttribute( "Person", rockContext, action, errorMessages );
+            if ( person != null )
+            {
+                string HeadOfHouseoldAttributeValue = GetAttributeValue( action, "HeadOfHouseoldAttribute" );
+                Guid? headOfHouseoldGuid = HeadOfHouseoldAttributeValue.AsGuidOrNull();
+                if ( headOfHouseoldGuid.HasValue )
+                {
+                    var headofHouseoldAttribute = AttributeCache.Read( headOfHouseoldGuid.Value, rockContext );
+                    if ( headofHouseoldAttribute != null )
+                    {
+                        var headOfHouse = person.GetHeadOfHouseold( rockContext );
+                        if ( headOfHouse != null )
+                        {
+                            action.Activity.Workflow.SetAttributeValue( headofHouseoldAttribute.Key, headOfHouse.PrimaryAlias.Guid.ToString() );
+                            action.AddLogEntry( string.Format( "Set Head Of Houseold attribute '{0}' attribute to '{1}'.", headofHouseoldAttribute.Name, headOfHouse.FullName ) );
+                            return true;
+                        }
+                        else
+                        {
+                            action.AddLogEntry( string.Format( "No head of houseold found for {0}.", person.FullName ) );
+                        }
+                    }
+                }
+            }
+            else
+            {
+                errorMessages.Add( "No person was provided." );
+                return false;
+            }
+            errorMessages.ForEach( m => action.AddLogEntry( m, true ) );
+
+            return true;
+        }
+
+        private Person GetPersonAliasFromActionAttribute( string key, RockContext rockContext, WorkflowAction action, List<string> errorMessages )
+        {
+            string value = GetAttributeValue( action, key );
+            Guid guidPersonAttribute = value.AsGuid();
+            if ( !guidPersonAttribute.IsEmpty() )
+            {
+                var attributePerson = AttributeCache.Read( guidPersonAttribute, rockContext );
+                if ( attributePerson != null )
+                {
+                    string attributePersonValue = action.GetWorklowAttributeValue( guidPersonAttribute );
+                    if ( !string.IsNullOrWhiteSpace( attributePersonValue ) )
+                    {
+                        if ( attributePerson.FieldType.Class == "Rock.Field.Types.PersonFieldType" )
+                        {
+                            Guid personAliasGuid = attributePersonValue.AsGuid();
+                            if ( !personAliasGuid.IsEmpty() )
+                            {
+                                PersonAliasService personAliasService = new PersonAliasService( rockContext );
+                                return personAliasService.Queryable().AsNoTracking()
+                                    .Where( a => a.Guid.Equals( personAliasGuid ) )
+                                    .Select( a => a.Person )
+                                    .FirstOrDefault();
+                            }
+                            else
+                            {
+                                errorMessages.Add( string.Format( "Person could not be found for selected value ('{0}')!", guidPersonAttribute.ToString() ) );
+                                return null;
+                            }
+                        }
+                        else
+                        {
+                            errorMessages.Add( string.Format( "The attribute used for {0} to provide the person was not of type 'Person'.", key ) );
+                            return null;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement]

Yes

# Context
This workflow action will take a person, passed through an action attribute, find the person’s head of household (which they could be them), and set a person attribute with that person.

Added Spouse and HeadOfHousehold to RockFilter and will take Person as input.

# Goal
What will this pull request achieve and how will this fix the problem?

This will help us to get the Person's head of the Household.


# Strategy
How have you implemented your solution?
Yes

#Documentation

**Spouse  Filter**

{% assign spouse = CurrentPerson | Spouse %} 
<p>{{spouse .FullName}} </p>

**HeadOfHousehold  Filter**

{% assign headofHousehold= CurrentPerson | HeadofHousehold %} 
<p>{{headofHousehold.FullName}} </p>

