### PR TITLE
Extended DynamicChart block to allow for arbitrary x-axis values

### DIFF
--- a/RockWeb/Blocks/Reporting/DynamicChart.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicChart.ascx.cs
@@ -191,6 +191,14 @@ function labelFormatter(label, series) {
             public decimal? YValue { get; set; }
 
             /// <summary>
+            /// Gets the y value as a formatted string (for Line and Bar Charts)
+            /// </summary>
+            /// <value>
+            /// The formatted y value.
+            /// </value>
+            public string YValueFormatted { get; set; }
+
+            /// <summary>
             /// Gets or sets the metric title (for pie charts)
             /// </summary>
             /// <value>
@@ -290,9 +298,22 @@ function labelFormatter(label, series) {
                             chartData.YValueTotal = chartData.YValue;
                         }
 
+                        if ( row.Table.Columns.Contains( "YValueFormatted" ) )
+                        {
+                            chartData.YValueFormatted = Convert.ToString( row["YValueFormatted"] );
+                        }
+                        else
+                        {
+                            chartData.YValueFormatted = chartData.YValue.HasValue ? chartData.YValue.Value.ToString( "G29" ) : string.Empty;
+                        }
+
                         if ( row.Table.Columns.Contains( "DateTime" ) )
                         {
                             chartData.DateTimeStamp = ( row["DateTime"] as DateTime? ).Value.ToJavascriptMilliseconds();
+                        }
+                        else if ( row.Table.Columns.Contains( "XValue" ) )
+                        {
+                            chartData.DateTimeStamp = (row["XValue"] as int?).Value;
                         }
 
                         chartDataList.Add( chartData );

--- a/RockWeb/Scripts/Rock/Controls/charts.js
+++ b/RockWeb/Scripts/Rock/Controls/charts.js
@@ -266,6 +266,10 @@
                                 if (item.series.chartData[item.dataIndex].EndDateTimeStamp) {
                                     tooltipText += " to " + new Date(item.series.chartData[item.dataIndex].EndDateTimeStamp).toLocaleDateString();
                                 }
+
+                                if (item.series.chartData[item.dataIndex].MetricTitle) {
+                                    tooltipText = item.series.chartData[item.dataIndex].MetricTitle;
+                                }
                             }
 
                             if (tooltipText) {
@@ -277,7 +281,7 @@
                             }
 
                             if (item.series.chartData) {
-                                var pointValue = item.series.chartData[item.dataIndex].YValue || item.series.chartData[item.dataIndex].YValueTotal || '';
+                                var pointValue = item.series.chartData[item.dataIndex].YValueFormatted || item.series.chartData[item.dataIndex].YValue || item.series.chartData[item.dataIndex].YValueTotal || '';
 
                                 tooltipText += ': ' + pointValue;
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

DynamicChart in Line-mode does not allow for arbitrary X-axis values, they must be in DateTime format. This creates problems when trying to do weekly year-over-year charts. For example, weekly attendance over the past 3 years. Three lines: Current Year, Last Year, 2 Years Ago. X-axis is week numbers, 1-52 (actually 53 because of odd start weeks).

# Goal
_What will this pull request achieve and how will this fix the problem?_

Provide support in the DynamicChart block to allow SQL queries to provide non-DateTime x-axis values.

# Strategy
_How have you implemented your solution?_

Support new XValue column in addition to the existing DateTime column. If DateTime column is provided it is used, otherwise the XValue column is used if it exists.

Additionally, adds support for MetricTitle to be used in the tooltip instead of the DateTime column.

Finally, unrelated to original need but made sense for our use case, adds support for a YValueFormatted column that is used, if present, in the tooltip instead of the YValue. This allows the SQL to format the value in a user-friendly manner, for example as a $12,345.67 dollar amount instead of "12345.67"

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

No security considerations. Only possible break to backwards compatibility would be to a SQL query that provides a MetricTitle column for use in Pie Chart that is switched to Line Chart; but I think the query would not display right as a line to begin with.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img width="1111" alt="sample" src="https://cloud.githubusercontent.com/assets/1119863/20227931/c1028992-a803-11e6-9f02-1a4f499b01fc.png">

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

In-block documentation (sample SQL) might need to be updated. I have not done this as I wasn't sure how to present this new information as optional but not clutter up the example SQL.