### PR TITLE
- Added the ability to pass parameters into the SQL used to generate the DynamicChart charts.

### DIFF
--- a/RockWeb/Blocks/Reporting/DynamicChart.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicChart.ascx.cs
@@ -94,6 +94,7 @@ order by YValue desc
 
             var pageReference = new Rock.Web.PageReference( this.PageCache.Id );
             pageReference.QueryString = new System.Collections.Specialized.NameValueCollection();
+            pageReference.QueryString.Add( this.Request.QueryString );
             pageReference.QueryString.Add( "GetChartData", "true" );
             pageReference.QueryString.Add( "GetChartDataBlockId", this.BlockId.ToString() );
             pageReference.QueryString.Add( "TimeStamp", RockDateTime.Now.ToJavascriptMilliseconds().ToString() );

--- a/RockWeb/Blocks/Reporting/DynamicChart.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicChart.ascx.cs
@@ -69,7 +69,7 @@ order by YValue desc
 </pre>
 </code>",
               CodeEditorMode.Sql )]
-    [TextField( "SQL Params", "Parameters to pass to query", false, "" )]
+    [TextField( "Query Params", "The parameters that the stored procedure expects in the format of 'param1=value;param2=value'. Any parameter with the same name as a page parameter (i.e. querystring, form, or page route) will have it's value replaced with the page's current value. A parameter with the name of 'CurrentPersonId' will have it's value replaced with the currently logged in person's id.", false, "" )]
     [IntegerField( "Chart Height", "", false, 200 )]
     [DefinedValueField( Rock.SystemGuid.DefinedType.CHART_STYLES, "Chart Style", order: 3 )]
 
@@ -335,7 +335,7 @@ function labelFormatter(label, series) {
         /// <returns></returns>
         private Dictionary<string, object> GetParameters()
         {
-            string[] queryParams = GetAttributeValue( "SQLParams" ).SplitDelimitedValues();
+            string[] queryParams = GetAttributeValue( "QueryParams" ).SplitDelimitedValues();
             if ( queryParams.Length > 0 )
             {
                 var parameters = new Dictionary<string, object>();


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
We're working on generating campus-specific dashboard pages that contain DynamicChart blocks, and wanted the ability to pass in campus Ids so that we could generate charts specific to that campus.

# Goal
This change allows users to pass in custom parameters into the SQL used to generate DynamicCharts. Not only does this allow users to pass in page parameters, but it also allows them to pass in lava-based parameters such as DateTime values, etc.

# Strategy
We implemented this by copying the same functionality that the DynamicData block uses over to the DynamicChart block.

# Possible Implications
Depending on how you set up your parameters in the block setting, you could potentially cause your sql to error out (e.g.) passing an nvarchar parameter where your sql is expecting a datetime value). These are the same implications that already exist in the DynamicData block.

# Screenshots
![image](https://cloud.githubusercontent.com/assets/5482014/20276507/be7adc3a-aa59-11e6-8440-593adeb3a6ff.png)


# Documentation
This does not affect any of the UI screenshots or descriptions in the documentation / user guides.