### PR TITLE
- Fix the Copy feature for EventItemOccurrence so that it doesn't poi…

### DIFF
--- a/RockWeb/Blocks/Event/EventItemOccurrenceDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/EventItemOccurrenceDetail.ascx.cs
@@ -846,6 +846,10 @@ namespace RockWeb.Blocks.Event
                             LinkageState.Id = 0;
                             LinkageState.Guid = Guid.NewGuid();
                             LinkageState.RegistrationInstance = linkage.RegistrationInstance != null ? linkage.RegistrationInstance.Clone( false ) : new RegistrationInstance();
+                            LinkageState.RegistrationInstanceId = null;
+                            LinkageState.RegistrationInstance.Id = 0;
+                            LinkageState.RegistrationInstance.Guid = Guid.NewGuid();
+
                             LinkageState.RegistrationInstance.RegistrationTemplate =
                                 linkage.RegistrationInstance != null && linkage.RegistrationInstance.RegistrationTemplate != null ?
                                 linkage.RegistrationInstance.RegistrationTemplate.Clone( false ) : new RegistrationTemplate();


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
not yet

# Context
_What is the problem you encountered that lead to you creating this pull request?_
![image](https://cloud.githubusercontent.com/assets/2430748/20284732/9e3ab5fe-aa7b-11e6-9642-ae31af7c0134.png)


# Goal
Fix it so that the copy uses the New Registration Instance instead of saving it back to point to the original

# Strategy
Set the new RegistrationInstance ID to null and GUID as NewGuid() so that SaveChanges recognizes it as a new RegistrationInstance that it needs to be associated with

# Possible Implications
Anybody that has previously use the Copy feature prior to the fix will have an issue with editing the EventItemOccurrence's RegistrationInstance Name.  The name change will impact the source and any copies of the EventItemOccurrence

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

…nt the copy's RegistrationInstance back to the original