### PR TITLE
- small optimization the Grid.SetLinqDataSource so that it doesn't ha…

### DIFF
--- a/Rock/Web/UI/Controls/Grid/Grid.cs
+++ b/Rock/Web/UI/Controls/Grid/Grid.cs
@@ -947,7 +947,15 @@ namespace Rock.Web.UI.Controls
                 this.AllowCustomPaging = true;
                 var currentPageData = qry.Skip( this.PageIndex * this.PageSize ).Take( this.PageSize ).ToList();
                 this.DataSource = currentPageData;
-                this.VirtualItemCount = qry.Count();
+                if ( currentPageData.Count < this.PageSize )
+                {
+                    // if the current page has fewer records than the page.size, we are on the last page of records, so we can figure out how many records there are without requerying the database
+                    this.VirtualItemCount = ( this.PageIndex * this.PageSize ) + currentPageData.Count;
+                }
+                else
+                {
+                    this.VirtualItemCount = qry.Count();
+                }
 
                 PreDataBound = false;
                 CurrentPageRows = currentPageData.Count();


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
You betcha

# Context
_What is the problem you encountered that lead to you creating this pull request?_
After doing the SetLinqDataSource originally, we knew that the downside is that it would have to 2nd database call to query the COUNT.  A few months ago, I realized that it wouldn't have to the 2nd call if the Count could be safely determined based on the PageSize, Page, and how many records were fetched.  It didn't make a real big difference, so I just stashed the idea away.

# Goal
_What will this pull request achieve and how will this fix the problem?_
Try to avoid the 2nd COUNT call if it can be done safely.

# Strategy
_How have you implemented your solution?_
If the Grid is on the "LAST" page, and the number of fetched records is less than the page size, then we can calculate the item count without the COUNT call.  In those cases, it would be calculated as follows:

this.VirtualItemCount = ( this.PageIndex * this.PageSize ) + currentPageData.Count;


# Possible Implications
I think the code is pretty safe, but I might have missed something, and in most cases the performance benefit is small. But I wanted throw this out there and see what you guys thought

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

…ve to query the COUNT if it can be determined based on the fetched count (and it is on the "Last" page of data)