### PR TITLE
Added transaction code to giving history

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionReport.ascx
+++ b/RockWeb/Blocks/Finance/TransactionReport.ascx
@@ -34,6 +34,7 @@
                         <Columns>
                             <Rock:RockBoundField DataField="TransactionDateTime" DataFormatString="{0:d}" HeaderText="Date" />
                             <Rock:RockBoundField DataField="CurrencyType" HeaderText="Currency Type" HtmlEncode="false" />
+                            <Rock:RockBoundField DataField="TransactionCode" HeaderText="Transaction Code" HtmlEncode="false" />
                             <Rock:RockBoundField DataField="Summary" HeaderText="Summary" HtmlEncode="false" />
                             <Rock:CurrencyField DataField="TotalAmount" HeaderText="Amount" />
                         </Columns>

--- a/RockWeb/Blocks/Finance/TransactionReport.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionReport.ascx.cs
@@ -39,8 +39,8 @@ namespace RockWeb.Blocks.Finance
     [TextField( "Transaction Label", "The label to use to describe the transactions (e.g. 'Gifts', 'Donations', etc.)", true, "Gifts", "", 1 )]
     [TextField( "Account Label", "The label to use to describe accounts.", true, "Accounts", "", 2 )]
     [AccountsField( "Accounts", "List of accounts to allow the person to view", false, "", "", 3 )]
-
-    [DefinedValueField( Rock.SystemGuid.DefinedType.FINANCIAL_TRANSACTION_TYPE, "Transaction Types", "Optional list of transation types to limit the list to (if none are selected all types will be included).", false, true, "", "", 4 )]
+    [BooleanField( "Show Transaction Code", "Show the transaction code column in the table.", true, "", 4, "ShowTransactionCode" )]
+    [DefinedValueField( Rock.SystemGuid.DefinedType.FINANCIAL_TRANSACTION_TYPE, "Transaction Types", "Optional list of transation types to limit the list to (if none are selected all types will be included).", false, true, "", "", 5 )]
     public partial class TransactionReport : Rock.Web.UI.RockBlock
     {
         #region Base Control Methods
@@ -256,9 +256,14 @@ namespace RockWeb.Blocks.Finance
                 t.Id,
                 t.TransactionDateTime,
                 CurrencyType = FormatCurrencyType( t ),
+                t.TransactionCode,
                 Summary = FormatSummary( t ),
                 t.TotalAmount
             } ).ToList();
+
+            gTransactions.Columns
+                .Cast<Rock.Web.UI.Controls.RockBoundField>()
+                .FirstOrDefault( c => c.HeaderText == "Transaction Code" ).Visible = GetAttributeValue( "ShowTransactionCode" ).AsBoolean();
 
             gTransactions.DataBind();
         }


### PR DESCRIPTION
# Contributor Agreement
yes - just sent

# Context
Our accounting dept wanted the transaction code information to display in giving history grid

# Goal
Make accounting happy, and benefit other churches as well who need the same information

# Strategy
Added a block setting that allows for transaction code column to not be shown (shown by default)

# Possible Implications
none

# Screenshots
![transaction code](https://cloud.githubusercontent.com/assets/2584284/20362963/69d458ce-ac0b-11e6-828b-8fc10983b459.JPG)

# Documentation
na

