### PR TITLE
Added autocomplete attributes to address control

### DIFF
--- a/Rock/Web/UI/Controls/AddressControl.cs
+++ b/Rock/Web/UI/Controls/AddressControl.cs
@@ -662,6 +662,7 @@ namespace Rock.Web.UI.Controls
                 writer.AddAttribute( "class", "form-group " + ( this.Required ? "required" : string.Empty ) );
                 writer.RenderBeginTag( HtmlTextWriterTag.Div );
                 _tbStreet1.Attributes["placeholder"] = showAddressLine2 ? "Address Line 1" : "Address";
+                _tbStreet1.Attributes["autocomplete"] = showAddressLine2 ? "address-line1" : "street-address";
                 _tbStreet1.RenderControl( writer );
                 writer.RenderEndTag();  // div.form-group
 
@@ -670,6 +671,7 @@ namespace Rock.Web.UI.Controls
                     writer.AddAttribute( "class", "form-group" );
                     writer.RenderBeginTag( HtmlTextWriterTag.Div );
                     _tbStreet2.Attributes["placeholder"] = "Address Line 2";
+                    _tbStreet2.Attributes["autocomplete"] = "address-line2";
                     _tbStreet2.RenderControl( writer );
                     writer.RenderEndTag();  // div.form-group
                 }
@@ -680,6 +682,7 @@ namespace Rock.Web.UI.Controls
                 writer.AddAttribute( "class", ( ShowCounty ? "form-group col-sm-3" : "form-group col-sm-6" ) );
                 writer.RenderBeginTag( HtmlTextWriterTag.Div );
                 _tbCity.Attributes["placeholder"] = cityLabel;
+                _tbCity.Attributes["autocomplete"] = "address-level2";
                 _tbCity.RenderControl( writer );
                 writer.RenderEndTag();  // div.form-group
 
@@ -688,6 +691,7 @@ namespace Rock.Web.UI.Controls
                     writer.AddAttribute( "class", "form-group col-sm-3" );
                     writer.RenderBeginTag( HtmlTextWriterTag.Div );
                     _tbCounty.Attributes["placeholder"] = "County";
+                    _tbCounty.Attributes["autocomplete"] = "country";
                     _tbCounty.RenderControl( writer );
                     writer.RenderEndTag();  // div.form-group
                 }
@@ -695,6 +699,7 @@ namespace Rock.Web.UI.Controls
                 writer.AddAttribute( "class", "form-group col-sm-3" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Div );
                 _tbState.Attributes["placeholder"] = stateLabel;
+                _tbState.Attributes["autocomplete"] = "address-level1";
                 _tbState.RenderControl( writer );
                 _ddlState.RenderControl( writer );
                 writer.RenderEndTag();  // div.form-group
@@ -702,6 +707,7 @@ namespace Rock.Web.UI.Controls
                 writer.AddAttribute( "class", "form-group col-sm-3" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Div );
                 _tbPostalCode.Attributes["placeholder"] = postalCodeLabel;
+                _tbPostalCode.Attributes["autocomplete"] = "postal-code";
                 _tbPostalCode.RenderControl( writer );
                 writer.RenderEndTag();  // div.form-group
 


### PR DESCRIPTION
# Contributor Agreement
[x] _Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

# Context
Per issue #1827 when address 2 is shown; chrome and Safari force autocomplete to fill-in address 1 in both the address 1 and address 2 field. This adds autocomplete attributes from the HTML5 spec to the form controls.

# Goal
Prevent bad data and failed address validations from event signups.

# Strategy
The autocomplete attribute.

# Possible Implications
None

# Screenshots
None

# Documentation
N/A

