### PR TITLE
Adding an adult on the Edit Family screen will correctly set the Giving Group

### DIFF
--- a/RockWeb/Blocks/Crm/PersonDetail/EditGroup.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/EditGroup.ascx.cs
@@ -986,7 +986,7 @@ namespace RockWeb.Blocks.Crm.PersonDetail
                             role = _groupType.Roles.FirstOrDefault();
                         }
 
-                        bool isAdult = role != null && role.Guid.Equals( Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT );
+                        bool isAdult = role != null && role.Guid.Equals( Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() );
 
                         // People added to group (new or from other group )
                         if ( !groupMemberInfo.ExistingGroupMember )


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Many adults in our database were not set to give with the family. I found that this was because adults added from the Edit Family screen are not set to give with the family the way they are if they are added as part of the initial creation of the family.

# Goal
_What will this pull request achieve and how will this fix the problem?_

New adults will now be set to give with their family when created.

# Strategy
_How have you implemented your solution?_

Fixed a bug that was comparing a Guid to a string and expecting them to match.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_