### PR TITLE
Removed exclamation points from failed recipients

### DIFF
--- a/Rock/Communication/Medium/Email.cs
+++ b/Rock/Communication/Medium/Email.cs
@@ -245,22 +245,22 @@ You can view an online version of this email here:
                     if ( !person.IsEmailActive)
                     {
                         recipient.Status = CommunicationRecipientStatus.Failed;
-                        recipient.StatusNote = "Email is not active!";
+                        recipient.StatusNote = "Email is not active";
                     }
                     if ( person.IsDeceased )
                     {
                         recipient.Status = CommunicationRecipientStatus.Failed;
-                        recipient.StatusNote = "Person is deceased!";
+                        recipient.StatusNote = "Person is deceased";
                     }
                     if ( person.EmailPreference == Model.EmailPreference.DoNotEmail )
                     {
                         recipient.Status = CommunicationRecipientStatus.Failed;
-                        recipient.StatusNote = "Email Preference of 'Do Not Email!'";
+                        recipient.StatusNote = "Email Preference of 'Do Not Email'";
                     }
                     else if ( person.EmailPreference == Model.EmailPreference.NoMassEmails && communication.IsBulkCommunication )
                     {
                         recipient.Status = CommunicationRecipientStatus.Failed;
-                        recipient.StatusNote = "Email Preference of 'No Mass Emails!'";
+                        recipient.StatusNote = "Email Preference of 'No Mass Emails'";
                     }
                 }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
Sending bulk email is stressful, lets make Rock not scare users after they've sent an email by making the error messages a little nicer.

# Goal
Remove exclamation points from the notes displayed next to failed recipients.

# Strategy
Deleting the❗️💥 

# Possible Implications
None

# Screenshots
Removes the exclamations from the communication history/status display seen here:
![screenshot 2016-11-22 18 28 26](https://cloud.githubusercontent.com/assets/374209/20549502/be8aaf6e-b0e1-11e6-905b-753bb4fde38a.png)

# Documentation
Email notes don't appear to be in the documentation yet.

