### PR TITLE
- Changed ZebraPhoto Lava Filter to use DRAM instead of Flash Memory when saving photo to printer memory.

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -2114,7 +2114,7 @@ namespace Rock.Lava
                     convertedStream.Dispose();
                     initialPhotoStream.Dispose();
 
-                    return string.Format( "^FS ~DYE:LOGO,P,P,{0},,{1} ^FD", content.Length, zplImageData.ToString() );
+                    return string.Format( "^FS ~DYR:LOGO,P,P,{0},,{1} ^FD", content.Length, zplImageData.ToString() );
                 }
             }
             catch


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
Currently the ZebraPhoto Lava Filter is saving photos to the printer's E: (Flash Memory) location, which is typically used to store more static data and is not recommended for repetitive write operations.

# Goal
This pull request will change the filter to store photos in the printer's DRAM instead, which is designed for repetitive functions like this.

# Possible Implications
As the photos are now being stored in R: instead of E:, any labels that use this filter will need to be updated to reflect this by changing their ^XG (Recall Graphic) references to the photo's new R: location (`^XGR:LOGO.PNG,1,1^FS`).