### PR TITLE
Person Badges on Connection Request Detail.

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx
@@ -27,7 +27,6 @@
                 <Rock:PanelDrawer ID="pdAuditDetails" runat="server"></Rock:PanelDrawer>
 
                 <div class="panel-body">
-
                     <div class="row">
                         <div class="col-md-6">
                             <div class="row">
@@ -39,6 +38,12 @@
                                 <div class="col-md-8">
                                     <Rock:RockLiteral ID="lContactInfo" runat="server" Label="Contact Info" />
                                     <Rock:RockLiteral ID="lConnector" runat="server" Label="Connector" />
+                                    <asp:Panel runat="server" class="form-group static-control" ID="pnlBadges">
+                                        <label class="control-label">Person Info</label>
+                                        <div class="control-wrapper">
+                                            <Rock:PersonProfileBadgeList ID="blStatus" runat="server" />
+					                    </div>
+                                    </asp:Panel>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
We had a request from ministries to show person detail badges on the connection request detail block.  This PR adds the ability to show person badges on the connection request detail.

# Strategy
I had to change the ConnectionRequestDetail block to be a PersonBlock in order to place badges on it.  Then loaded the person from the connection request.

# Possible Implications
One of the changes I had to make was to remove the using around RockContext because the badge needed a person entity that was still attached to an active context just in case attributes and defined values and such needed to be loaded to display the Lava.

# Screenshots
![image](https://cloud.githubusercontent.com/assets/1248118/20841852/518e6d16-b883-11e6-955a-d21c3cf5dd32.png)


# Documentation
The connection request block can be configured to show person badges by editing the block, checking which Person Badges to show, and then saving.  By default no badges are displayed so the Person Info section won't even show up.  We still might need to update the document here:
http://www.rockrms.com/Rock/BookContent/30/79#working-with-requests