### PR TITLE
Fix htmleditor rockpickers sometimes not working

### DIFF
--- a/RockWeb/Scripts/summernote/plugins/RockFileBrowser.js
+++ b/RockWeb/Scripts/summernote/plugins/RockFileBrowser.js
@@ -23,9 +23,9 @@
 
                 $modalPopupIFrame.contents().off('click');
 
-                $modalPopupIFrame.contents().on('click', '.js-select-file-button', function () {
+                $modalPopupIFrame.contents().on('click', '.js-select-file-button', function (e) {
                     Rock.controls.modal.close();
-                    var fileResult = $('body iframe').contents().find('.js-filebrowser-result input[type=hidden]').val();
+                    var fileResult = $(e.target).closest('body').find('.js-filebrowser-result input[type=hidden]').val();
                     if (fileResult) {
 
                         // iframe returns the result in the format "href|text"

--- a/RockWeb/Scripts/summernote/plugins/RockImageBrowser.js
+++ b/RockWeb/Scripts/summernote/plugins/RockImageBrowser.js
@@ -25,9 +25,9 @@
 
                 $modalPopupIFrame.contents().off('click');
 
-                $modalPopupIFrame.contents().on('click', '.js-select-file-button', function () {
+                $modalPopupIFrame.contents().on('click', '.js-select-file-button', function (e) {
                     Rock.controls.modal.close();
-                    var fileResult = $('body iframe').contents().find('.js-filebrowser-result input[type=hidden]').val();
+                    var fileResult = $(e.target).closest('body').find('.js-filebrowser-result input[type=hidden]').val();
                     if (fileResult) {
                         // iframe returns the result in the format "imageSrcUrl|imageAltText"
                         var resultParts = fileResult.split('|');


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yep!

# Context
_What is the problem you encountered that lead to you creating this pull request?_
In some situations, the Rock File Picker would fail to paste the link when a File was selected.  We narrowed it down to cases when there was a Vimeo already in the HTML

# Goal
_What will this pull request achieve and how will this fix the problem?_
This pull request will fix it so that a File and an Image can be picked even if there is a Vimeo already in it (or whatever)

# Strategy
_How have you implemented your solution?_
Narrowed it down to a javascript 'Access Denied' that sometimes occurred when trying to JQuery something inside an IFRAME.  There are some situations where this isn't allowed.  So, the function was rewritten to avoid JQuerying into an IFRAME, so this type of problem won't occur

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
I tested this in IE, FF, and Chrome for both the Image and File Picker and it still works.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
