### PR TITLE
Fixes #1912 - Change lava conditional to || operator

### DIFF
--- a/RockWeb/Themes/Stark/Assets/Lava/PodcastMessageDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/PodcastMessageDetail.lava
@@ -26,9 +26,9 @@
 				{{ item.Content }}
 			</div>
 			<div class="col-md-4">
-				{% if videoLink != '' && audioLink != '' %}
+				{% if videoLink != '' || audioLink != '' %}
 					<div class="panel panel-default">
-						<div class="panel-heading">Downloads & Resources</div>
+						<div class="panel-heading">Downloads &amp; Resources</div>
 						<div class="list-group">
 							
 							{% if videoLink != '' %}


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
Fixes #1912 ,an incorrect lava operator that caused podcast content not to show. Also fixes ampersand html encoding.

# Goal
Change && to ||, which allows resources to display without triggering both 

# Strategy


# Possible Implications
N/A

# Screenshots
NA

# Documentation
NA
