### PR TITLE
Added null check to valueControl

### DIFF
--- a/Rock/Field/FieldType.cs
+++ b/Rock/Field/FieldType.cs
@@ -286,7 +286,10 @@ namespace Rock.Field
             col2.ID = string.Format( "{0}_col2", id );
             row.Controls.Add( col2 );
             col2.AddCssClass( col2Class );
-            col2.Controls.Add( valueControl );
+            if ( valueControl != null )
+            {
+                col2.Controls.Add( valueControl );
+            }
 
             return row;
         }


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
When adding a group member attribute that is a single select field type, if you do not give it any values and select show in grid, rock will throw an error. This is because the field type value control returns null if there are no values, and filter type does not null check the control before attempting to add it to the parent

# Goal
To keep Rock from exploding in this situation.

# Strategy
I added a null check. I had considered changing the field type to return a control instead of null, but the null check is probably needed anyway.

# Possible Implications
None.


