### PR TITLE
Fixes #1912 - incorrect lava operators per @azturner

### DIFF
--- a/RockWeb/Themes/Flat/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/GroupDetail.lava
@@ -1,4 +1,4 @@
-{% if AllowedActions.View == true || AllowedActions.Edit == true || AllowedActions.Administrate == true %}
+{% if AllowedActions.View == true or AllowedActions.Edit == true or AllowedActions.Administrate == true %}
 
 	{% assign countActive = -1 %}
 	{% assign countInactive = -1 %}

--- a/RockWeb/Themes/Flat/Assets/Lava/PodcastMessageDetail.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/PodcastMessageDetail.lava
@@ -26,7 +26,7 @@
 				{{ item.Content }}
 			</div>
 			<div class="col-md-4">
-				{% if videoLink != '' || audioLink != '' %}
+				{% if videoLink != '' or audioLink != '' %}
 					<div class="panel panel-default">
 						<div class="panel-heading">Downloads &amp; Resources</div>
 						<div class="list-group">

--- a/RockWeb/Themes/Rock/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/GroupDetail.lava
@@ -1,4 +1,4 @@
-{% if AllowedActions.View == true || AllowedActions.Edit == true || AllowedActions.Administrate == true %}
+{% if AllowedActions.View == true or AllowedActions.Edit == true or AllowedActions.Administrate == true %}
 
 	{% assign countActive = -1 %}
 	{% assign countInactive = -1 %}

--- a/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
@@ -1,4 +1,4 @@
-{% if AllowedActions.View == true || AllowedActions.Edit == true || AllowedActions.Administrate == true %}
+{% if AllowedActions.View == true or AllowedActions.Edit == true or AllowedActions.Administrate == true %}
 
 	{% assign countActive = -1 %}
 	{% assign countInactive = -1 %}

--- a/RockWeb/Themes/Stark/Assets/Lava/PodcastMessageDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/PodcastMessageDetail.lava
@@ -26,7 +26,7 @@
 				{{ item.Content }}
 			</div>
 			<div class="col-md-4">
-				{% if videoLink != '' || audioLink != '' %}
+				{% if videoLink != '' or audioLink != '' %}
 					<div class="panel panel-default">
 						<div class="panel-heading">Downloads &amp; Resources</div>
 						<div class="list-group">


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
Removes `||` operator from all lava files and replaces with or

# Goal
Bring lava in line with coding standards

# Strategy
Find and replace :)

# Possible Implications
N/A

# Screenshots
N/A

# Documentation
N/A

