### PR TITLE
Group Schedule Delete Issue

### DIFF
--- a/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
@@ -388,7 +388,12 @@ namespace RockWeb.Blocks.Groups
                     var schedule = scheduleService.Get( group.ScheduleId.Value );
                     if ( schedule != null && schedule.ScheduleType != ScheduleType.Named )
                     {
-                        scheduleService.Delete( schedule );
+
+                        // Make sure this is the only group trying to use this schedule.
+                        if ( !groupService.Queryable().Where( g => g.ScheduleId == schedule.Id && g.Id != group.Id ).Any() )
+                        {
+                            scheduleService.Delete( schedule );
+                        }
                     }
                 }
 
@@ -619,7 +624,11 @@ namespace RockWeb.Blocks.Groups
                     var schedule = scheduleService.Get( oldScheduleId.Value );
                     if ( schedule != null && string.IsNullOrEmpty( schedule.Name ) )
                     {
-                        scheduleService.Delete( schedule );
+                        // Make sure this is the only group trying to use this schedule.
+                        if ( !groupService.Queryable().Where( g => g.ScheduleId == schedule.Id && g.Id != group.Id ).Any() )
+                        {
+                            scheduleService.Delete( schedule );
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
We copied some groups in the DB and didn't copy their schedules.  When we try to update or delete the groups we are getting errors now.  This resolves the issue.

# Goal
This checks to verify that this is, indeed, the only group using a schedule.  This situation shouldn't ever happen using Rock but we have some customizations that copied groups without also copying their schedules and this fixes it.

# Strategy
Just run a quick query to make sure the schedule isn't used on any other groups.

# Possible Implications
None.  This should not break anything in existing Rock implementations.

# Screenshots
No UI Changes.

# Documentation
N/A

