### PR TITLE
Added "In Registration Template(s)" DataFilter

### DIFF
--- a/Rock/Reporting/DataFilter/Person/InRegistrationInstanceRegistrationTemplateFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/InRegistrationInstanceRegistrationTemplateFilter.cs
@@ -182,7 +182,7 @@ namespace Rock.Reporting.DataFilter.Person
             SlidingDateRangePicker registeredOnDateRangePicker = new SlidingDateRangePicker();
             registeredOnDateRangePicker.ID = pwAdvanced.ID + "_addedOnDateRangePicker";
             registeredOnDateRangePicker.AddCssClass( "js-sliding-date-range" );
-            registeredOnDateRangePicker.Label = "Date Added:";
+            registeredOnDateRangePicker.Label = "Date Registered:";
             registeredOnDateRangePicker.Help = "Select the date range that the person was registered. Leaving this blank will not restrict results to a date range.";
             pwAdvanced.Controls.Add( registeredOnDateRangePicker );
 

--- a/Rock/Reporting/DataFilter/Person/InRegistrationInstanceRegistrationTemplateFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/InRegistrationInstanceRegistrationTemplateFilter.cs
@@ -1,0 +1,376 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.UI.Controls;
+
+namespace Rock.Reporting.DataFilter.Person
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [Description( "Filter people on whether they are in a registration instance of the specified registration template or templates" )]
+    [Export( typeof( DataFilterComponent ) )]
+    [ExportMetadata( "ComponentName", "Person In Registration Template(s) Filter" )]
+    public class InRegistrationInstanceRegistrationTemplateFilter : DataFilterComponent
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the entity type that filter applies to.
+        /// </summary>
+        /// <value>
+        /// The entity that filter applies to.
+        /// </value>
+        public override string AppliesToEntityType
+        {
+            get { return typeof( Rock.Model.Person ).FullName; }
+        }
+
+        /// <summary>
+        /// Gets the section.
+        /// </summary>
+        /// <value>
+        /// The section.
+        /// </value>
+        public override string Section
+        {
+            get { return "Additional Filters"; }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Gets the title.
+        /// </summary>
+        /// <param name="entityType"></param>
+        /// <returns></returns>
+        /// <value>
+        /// The title.
+        /// </value>
+        public override string GetTitle( Type entityType )
+        {
+            return "In Registration Template(s)";
+        }
+
+        /// <summary>
+        /// Formats the selection on the client-side.  When the filter is collapsed by the user, the Filterfield control
+        /// will set the description of the filter to whatever is returned by this property.  If including script, the
+        /// controls parent container can be referenced through a '$content' variable that is set by the control before 
+        /// referencing this property.
+        /// </summary>
+        /// <value>
+        /// The client format script.
+        /// </value>
+        public override string GetClientFormatSelection( Type entityType )
+        {
+            return "Rock.reporting.formatFilterForRegistrationTemplateFilterField('In templates:', $content)";
+        }
+
+        /// <summary>
+        /// Formats the selection.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="selection">The selection.</param>
+        /// <returns></returns>
+        public override string FormatSelection( Type entityType, string selection )
+        {
+            string result = "Registrant";
+            string[] selectionValues = selection.Split( '|' );
+            if ( selectionValues.Length >= 1 )
+            {
+                var rockContext = new RockContext();
+                var registrationTemplateGuids = selectionValues[0].Split( ',' ).AsGuidList();
+                var registrationTemplates = new RegistrationTemplateService( rockContext ).GetByGuids( registrationTemplateGuids );
+
+                SlidingDateRangePicker fakeSlidingDateRangePicker = null;
+
+                bool includeInactiveRegistrationInstances = false;
+                if ( selectionValues.Length >= 2 )
+                {
+                    includeInactiveRegistrationInstances = selectionValues[1].AsBooleanOrNull() ?? false;
+
+                    if ( selectionValues.Length >= 3 )
+                    {
+                        fakeSlidingDateRangePicker = new SlidingDateRangePicker();
+
+                        // convert comma delimited to pipe
+                        fakeSlidingDateRangePicker.DelimitedValues = selectionValues[2].Replace( ',', '|' );
+                    }
+                }
+
+                if ( registrationTemplates != null )
+                {
+                    result = string.Format( registrationTemplates.Count() > 0 ? "In Registration Templates: {0}" : "In a Registration", registrationTemplates.Select( a => a.Name ).ToList().AsDelimited( ", ", " or " ) );
+
+                    if ( includeInactiveRegistrationInstances )
+                    {
+                        result += ", including inactive registration instances";
+                    }
+
+                    if ( fakeSlidingDateRangePicker != null )
+                    {
+                        result += string.Format( ", registered in Date Range: {0}", SlidingDateRangePicker.FormatDelimitedValues( fakeSlidingDateRangePicker.DelimitedValues ) );
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// The RegistrationTemplatePicker
+        /// </summary>
+        private RegistrationTemplatePicker rp = null;
+
+        /// <summary>
+        /// The "Include Inactive" checkbox
+        /// </summary>
+        private RockCheckBox cbIncludeInactiveRegistrationInstances = null;
+
+        /// <summary>
+        /// Creates the child controls.
+        /// </summary>
+        /// <returns></returns>
+        public override Control[] CreateChildControls( Type entityType, FilterField filterControl )
+        {
+            rp = new RegistrationTemplatePicker();
+            rp.ID = filterControl.ID + "_rp";
+            rp.Label = "RegistrationTemplate(s)";
+            rp.CssClass = "js-group-picker";
+            rp.AllowMultiSelect = true;
+            rp.Help = "Select the registration templates that you want the registrants for. Leaving this blank will not restrict results to a registration template.";
+            filterControl.Controls.Add( rp );
+
+            cbIncludeInactiveRegistrationInstances = new RockCheckBox();
+            cbIncludeInactiveRegistrationInstances.ID = filterControl.ID + "_cbIncludeInactiveRegistrationInstances";
+            cbIncludeInactiveRegistrationInstances.Text = "Include Inactive Registration Instances";
+            cbIncludeInactiveRegistrationInstances.CssClass = "js-include-inactive-groups";
+            cbIncludeInactiveRegistrationInstances.AutoPostBack = true;
+            filterControl.Controls.Add( cbIncludeInactiveRegistrationInstances );
+
+            PanelWidget pwAdvanced = new PanelWidget();
+            filterControl.Controls.Add( pwAdvanced );
+            pwAdvanced.ID = filterControl.ID + "_pwAttributes";
+            pwAdvanced.Title = "Advanced Filters";
+            pwAdvanced.CssClass = "advanced-panel";
+
+            SlidingDateRangePicker registeredOnDateRangePicker = new SlidingDateRangePicker();
+            registeredOnDateRangePicker.ID = pwAdvanced.ID + "_addedOnDateRangePicker";
+            registeredOnDateRangePicker.AddCssClass( "js-sliding-date-range" );
+            registeredOnDateRangePicker.Label = "Date Added:";
+            registeredOnDateRangePicker.Help = "Select the date range that the person was registered. Leaving this blank will not restrict results to a date range.";
+            pwAdvanced.Controls.Add( registeredOnDateRangePicker );
+
+            return new Control[4] { rp, cbIncludeInactiveRegistrationInstances, registeredOnDateRangePicker, pwAdvanced };
+        }
+
+        /// <summary>
+        /// Renders the controls.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="filterControl">The filter control.</param>
+        /// <param name="writer">The writer.</param>
+        /// <param name="controls">The controls.</param>
+        public override void RenderControls( Type entityType, FilterField filterControl, HtmlTextWriter writer, Control[] controls )
+        {
+            if ( controls.Count() < 4 )
+            {
+                return;
+            }
+
+            RegistrationTemplatePicker registrationTemplatePicker = controls[0] as RegistrationTemplatePicker;
+            RockCheckBox cbIncludeInactiveRegistrationInstances = controls[1] as RockCheckBox;
+            PanelWidget pwAdvanced = controls[3] as PanelWidget;
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "row" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "col-md-6" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            registrationTemplatePicker.RenderControl( writer );
+
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+            cbIncludeInactiveRegistrationInstances.ContainerCssClass = "margin-l-md";
+            cbIncludeInactiveRegistrationInstances.RenderControl( writer );
+            writer.RenderEndTag();
+
+            writer.RenderEndTag();
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "col-md-6" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            pwAdvanced.RenderControl( writer );
+            writer.RenderEndTag();
+
+            writer.RenderEndTag();
+        }
+
+        /// <summary>
+        /// Gets the selection.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="controls">The controls.</param>
+        /// <returns></returns>
+        public override string GetSelection( Type entityType, Control[] controls )
+        {
+            if ( controls.Count() < 3 )
+            {
+                return null;
+            }
+
+            RegistrationTemplatePicker registrationTemplatePicker = controls[0] as RegistrationTemplatePicker;
+            RockCheckBox cbInactiveRegistrationInstances = controls[1] as RockCheckBox;
+            SlidingDateRangePicker registeredOnDateRangePicker = controls[2] as SlidingDateRangePicker;
+
+            List<int> registrationTemplateIdList = registrationTemplatePicker.SelectedValues.AsIntegerList();
+            var registrationTemplateGuids = new RegistrationTemplateService( new RockContext() ).GetByIds( registrationTemplateIdList ).Select( a => a.Guid ).Distinct().ToList();
+
+            // convert pipe to comma delimited
+            var delimitedValues = registeredOnDateRangePicker.DelimitedValues.Replace( "|", "," );
+
+            return string.Format(
+                "{0}|{1}|{2}",
+                registrationTemplateGuids.AsDelimited( "," ),
+                cbIncludeInactiveRegistrationInstances.Checked.ToString(),
+                delimitedValues );
+        }
+
+        /// <summary>
+        /// Sets the selection.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="controls">The controls.</param>
+        /// <param name="selection">The selection.</param>
+        public override void SetSelection( Type entityType, Control[] controls, string selection )
+        {
+            if ( controls.Count() < 3 )
+            {
+                return;
+            }
+
+            RegistrationTemplatePicker registrationTemplatePicker = controls[0] as RegistrationTemplatePicker;
+            RockCheckBox cbIncludeInactive = controls[1] as RockCheckBox;
+            SlidingDateRangePicker registeredOnDateRangePicker = controls[2] as SlidingDateRangePicker;
+
+            string[] selectionValues = selection.Split( '|' );
+            if ( selectionValues.Length >= 1 )
+            {
+                List<Guid> registrationTemplateGuids = selectionValues[0].Split( ',' ).AsGuidList();
+                var registrationTemplates = new RegistrationTemplateService( new RockContext() ).GetByGuids( registrationTemplateGuids );
+                if ( registrationTemplates != null )
+                {
+                    registrationTemplatePicker.SetValues( registrationTemplates );
+                }
+
+                if ( selectionValues.Length >= 2 )
+                {
+                    cbIncludeInactiveRegistrationInstances.Checked = selectionValues[6].AsBooleanOrNull() ?? false;
+                }
+                else
+                {
+                    // if options where saved before this option was added, set to false, even though it would have included inactive before
+                    cbIncludeInactiveRegistrationInstances.Checked = false;
+                }
+
+                if ( selectionValues.Length >= 3 )
+                {
+                    // convert comma delimited to pipe
+                    registeredOnDateRangePicker.DelimitedValues = selectionValues[7].Replace( ',', '|' );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the expression.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="serviceInstance">The service instance.</param>
+        /// <param name="parameterExpression">The parameter expression.</param>
+        /// <param name="selection">The selection.</param>
+        /// <returns></returns>
+        public override Expression GetExpression( Type entityType, IService serviceInstance, ParameterExpression parameterExpression, string selection )
+        {
+            string[] selectionValues = selection.Split( '|' );
+            if ( selectionValues.Length >= 1 )
+            {
+                List<Guid> registrationTemplateGuids = selectionValues[0].Split( ',' ).AsGuidList();
+                var registrationInstanceService = new RegistrationInstanceService( (RockContext)serviceInstance.Context );
+                var registrationInstanceIds = registrationInstanceService.Queryable().Where( ri => registrationTemplateGuids.Contains( ri.RegistrationTemplate.Guid ) ).Select( ri => ri.Id ).Distinct().ToList();
+
+                RegistrationRegistrantService registrationRegistrantService = new RegistrationRegistrantService( (RockContext)serviceInstance.Context );
+
+
+                bool includeInactiveRegistrationInstances = false;
+
+                if ( selectionValues.Length >= 2 )
+                {
+                    includeInactiveRegistrationInstances = selectionValues[1].AsBooleanOrNull() ?? true; ;
+                }
+                else
+                {
+                    // if options where saved before this option was added, set to false, even though it would have included inactive before
+                    includeInactiveRegistrationInstances = false;
+                }
+
+                var registrationRegistrantServiceQry = registrationRegistrantService.Queryable();
+
+                if ( registrationTemplateGuids.Count > 0 )
+                {
+                    registrationRegistrantServiceQry = registrationRegistrantServiceQry.Where( xx => registrationInstanceIds.Contains( xx.Registration.RegistrationInstanceId ) );
+                }
+
+                if ( selectionValues.Length >= 3 )
+                {
+                    string slidingDelimitedValues = selectionValues[2].Replace( ',', '|' );
+                    DateRange dateRange = SlidingDateRangePicker.CalculateDateRangeFromDelimitedValues( slidingDelimitedValues );
+                    if ( dateRange.Start.HasValue )
+                    {
+                        registrationRegistrantServiceQry = registrationRegistrantServiceQry.Where( xx => xx.CreatedDateTime >= dateRange.Start.Value );
+                    }
+
+                    if ( dateRange.End.HasValue )
+                    {
+                        registrationRegistrantServiceQry = registrationRegistrantServiceQry.Where( xx => xx.CreatedDateTime < dateRange.End.Value );
+                    }
+                }
+
+                var qry = new PersonService( (RockContext)serviceInstance.Context ).Queryable()
+                    .Where( p => registrationRegistrantServiceQry.Any( xx => xx.PersonAlias.PersonId == p.Id ) );
+
+                Expression extractedFilterExpression = FilterExpressionExtractor.Extract<Rock.Model.Person>( qry, parameterExpression, "p" );
+
+                return extractedFilterExpression;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -953,6 +953,7 @@
     <Compile Include="Model\ScheduleService.Partial.cs" />
     <Compile Include="Model\WorkflowActionService.Partial.cs" />
     <Compile Include="PersonProfile\Badge\InDataView.cs" />
+    <Compile Include="Reporting\DataFilter\Person\InRegistrationInstanceRegistrationTemplateFilter.cs" />
     <Compile Include="Reporting\DataFilter\Person\InLocationGeofenceFilter.cs" />
     <Compile Include="Reporting\DataSelect\GroupMember\GroupLinkSelect.cs" />
     <Compile Include="Search\Other\Universal.cs" />
@@ -1172,6 +1173,7 @@
     <Compile Include="Utility\DebugHelper.cs" />
     <Compile Include="Utility\ExcelHelper.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
+    <Compile Include="Web\UI\Controls\Pickers\RegistrationTemplatePicker.cs" />
     <Compile Include="Web\UI\RockTheme.cs" />
     <Compile Include="Web\Cache\AttributeValueCache.cs" />
     <Compile Include="Web\UI\Controls\WarningBlock.cs" />

--- a/Rock/SystemGuid/EntityType.cs
+++ b/Rock/SystemGuid/EntityType.cs
@@ -153,6 +153,11 @@ namespace Rock.SystemGuid
         public const string PERSON_ALIAS = "90F5E87B-F0D5-4617-8AE9-EB57E673F36F";
 
         /// <summary>
+        /// The guid for the Rock.Model.RegistrationTemplate entity
+        /// </summary>
+        public const string REGISTRATION_TEMPLATE = "A01E3E99-A8AD-4C6C-BAAC-98795738BA70";
+
+        /// <summary>
         /// The LiquidSelect DataSelect field for Reporting
         /// </summary>
         public const string REPORTING_DATASELECT_LIQUIDSELECT = "C130DC52-CA31-45EE-A4F2-6C53A838EF3D";        

--- a/Rock/Web/UI/Controls/Pickers/RegistrationTemplatePicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/RegistrationTemplatePicker.cs
@@ -1,0 +1,142 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.UI.WebControls;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Web.UI.Controls
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RegistrationTemplatePicker : ItemPicker
+    {
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            ItemRestUrlExtraParams = "?getCategorizedItems=true&showUnnamedEntityItems=false&showCategoriesThatHaveNoChildren=false";
+            ItemRestUrlExtraParams += "&entityTypeId=" + EntityTypeCache.Read( Rock.SystemGuid.EntityType.REGISTRATION_TEMPLATE.AsGuid() ).Id;
+            this.IconCssClass = "fa fa-calendar";
+            base.OnInit( e );
+        }
+
+        /// <summary>
+        /// Sets the value.
+        /// </summary>
+        /// <param name="registrationTemplate">The registrationTemplate.</param>
+        public void SetValue( RegistrationTemplate registrationTemplate )
+        {
+            if ( registrationTemplate != null )
+            {
+                ItemId = registrationTemplate.Id.ToString();
+
+                string parentCategoryIds = string.Empty;
+                var parentCategory = registrationTemplate.Category;
+                while ( parentCategory != null )
+                {
+                    parentCategoryIds = parentCategory.Id + "," + parentCategoryIds;
+                    parentCategory = parentCategory.ParentCategory;
+                }
+
+                InitialItemParentIds = parentCategoryIds.TrimEnd( new[] { ',' } );
+                ItemName = registrationTemplate.Name;
+            }
+            else
+            {
+                ItemId = Constants.None.IdValue;
+                ItemName = Constants.None.TextHtml;
+            }
+        }
+
+        /// <summary>
+        /// Sets the values.
+        /// </summary>
+        /// <param name="registrationTemplates">The registrationTemplates.</param>
+        public void SetValues( IEnumerable<RegistrationTemplate> registrationTemplates )
+        {
+            var registrationTemplateList = registrationTemplates.ToList();
+
+            if ( registrationTemplateList.Any() )
+            {
+                var ids = new List<string>();
+                var names = new List<string>();
+                var parentCategoryIds = string.Empty;
+
+                foreach ( var registrationTemplate in registrationTemplateList )
+                {
+                    if ( registrationTemplate != null )
+                    {
+                        ids.Add( registrationTemplate.Id.ToString() );
+                        names.Add( registrationTemplate.Name );
+                        var parentCategory = registrationTemplate.Category;
+
+                        while ( parentCategory != null )
+                        {
+                            parentCategoryIds += parentCategory.Id.ToString() + ",";
+                            parentCategory = parentCategory.ParentCategory;
+                        }
+                    }
+                }
+
+                InitialItemParentIds = parentCategoryIds.TrimEnd( new[] { ',' } );
+                ItemIds = ids;
+                ItemNames = names;
+            }
+            else
+            {
+                ItemId = Constants.None.IdValue;
+                ItemName = Constants.None.TextHtml;
+            }
+        }
+
+        /// <summary>
+        /// Sets the value on select.
+        /// </summary>
+        protected override void SetValueOnSelect()
+        {
+            var registrationTemplate = new RegistrationTemplateService( new RockContext() ).Get( int.Parse( ItemId ) );
+            SetValue( registrationTemplate );
+        }
+
+        /// <summary>
+        /// Sets the values on select.
+        /// </summary>
+        protected override void SetValuesOnSelect()
+        {
+            var registrationTemplates = new RegistrationTemplateService( new RockContext() ).Queryable().Where( g => ItemIds.Contains( g.Id.ToString() ) );
+            this.SetValues( registrationTemplates );
+        }
+
+        /// <summary>
+        /// Gets the item rest URL.
+        /// </summary>
+        /// <value>
+        /// The item rest URL.
+        /// </value>
+        public override string ItemRestUrl
+        {
+            get { return "~/api/Categories/GetChildren/"; }
+        }
+    }
+}


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
Our admins are wanting to run data views on whether a person has signed up for an event (registration instance), whether it be any or one of a particular template.

# Goal
This pull request adds a 'In Registration Template(s) filter (add required background bits) that will filter people that have signed up for a Registration Instance of a specific Registration Template(s). If no templates are selected, it will filter people that have signed up for any registration instance. It also allows you to filter further by 'Date Registered'.

# Strategy
The RegistrationTemplatePicker is modeled after the SchedulePicker, as we needed the ability to ignore if a category was selected rather than a template. The filter itself was modeled after the InGroup and InGroupGroupType filters.  

# Screenshots
![image](https://cloud.githubusercontent.com/assets/5482014/21164698/04e9a808-c158-11e6-87d9-1200df600b77.png)
![image](https://cloud.githubusercontent.com/assets/5482014/21164704/0aa772f2-c158-11e6-97db-9d75a114dc4b.png)
