### PR TITLE
Added a block setting and overload to allow user to hide inactive cam…

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionOpportunitySearch.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionOpportunitySearch.ascx.cs
@@ -46,6 +46,7 @@ namespace RockWeb.Blocks.Connection
     [BooleanField( "Set Page Title", "Determines if the block should set the page title with the connection type name.", false )]
     [BooleanField( "Display Name Filter", "Display the name filter", false )]
     [BooleanField( "Display Campus Filter", "Display the campus filter", true )]
+    [BooleanField( "Display Inactive Campuses", "Include inactive campuses in the Campus Filter", true )]
     [BooleanField( "Display Attribute Filters", "Display the attribute filters", true )]
     [LinkedPage( "Detail Page", "The page used to view a connection opportunity." )]
     [IntegerField( "Connection Type Id", "The Id of the connection type whose opportunities are displayed.", true, 1 )]
@@ -302,7 +303,7 @@ namespace RockWeb.Blocks.Connection
                 if ( GetAttributeValue( "DisplayCampusFilter" ).AsBoolean() )
                 {
                     cblCampus.Visible = true;
-                    cblCampus.DataSource = CampusCache.All();
+                    cblCampus.DataSource = CampusCache.All( GetAttributeValue( "DisplayInactiveCampuses" ).AsBoolean() );
                     cblCampus.DataBind();
                 }
                 else


### PR DESCRIPTION
# Context
Needed to hide some "office only" campuses from the Connection Search Filter.

# Goal
Only display Active Campuses to public.

# Strategy
Added block setting and used overload for `CampusCache.All( _blockSetting_ )`.

# Possible Implications
None.  The existing behavior is left the same - defaults to `true`.
