### PR TITLE
Fix inconsistent check-in behavior that's not returning selected GroupTypes in CheckInPerson.cs

### DIFF
--- a/Rock/CheckIn/CheckInPerson.cs
+++ b/Rock/CheckIn/CheckInPerson.cs
@@ -209,13 +209,8 @@ namespace Rock.CheckIn
         {
             if ( selectedOnly )
             {
-                if ( PossibleSchedules.Any() )
-                {
-                    var selectedScheduleIds = SelectedSchedules.Select( s => s.Schedule.Id ).ToList();
-                    return GroupTypes.Where( t => t.SelectedForSchedule.Any( s => selectedScheduleIds.Contains( s ) ) ).ToList();
-                }
-
-                return GroupTypes.Where( t => t.Selected ).ToList();
+                var selectedScheduleIds = SelectedSchedules.Select( s => s.Schedule.Id ).ToList();
+                return GroupTypes.Where( t => t.Selected || t.SelectedForSchedule.Any( s => selectedScheduleIds.Contains( s ) ) ).ToList();
             }
 
             return GroupTypes;
@@ -288,17 +283,17 @@ namespace Rock.CheckIn
         [Rock.Data.LavaIgnore]
         public object this[object key]
         {
-           get
+            get
             {
-               switch( key.ToStringSafe() )
-               {
+                switch ( key.ToStringSafe() )
+                {
                     case "FamilyMember": return FamilyMember;
                     case "LastCheckIn": return LastCheckIn;
                     case "FirstTime": return FirstTime;
                     case "SecurityCode": return SecurityCode;
                     case "GroupTypes": return GetGroupTypes( true );
                     default: return Person[key];
-               }
+                }
             }
         }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes.

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When using the new `PossibleSchedules` and `SelectedForSchedule` fields to implement check-in room balancing, I wasn't getting back the GroupTypes that had been selected.  

This was because CheckInPerson.GetGroupTypes is inconsistent with the pattern used in [CheckInGroup.GetLocations](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock/CheckIn/CheckInGroup.cs#L143), [CheckInLocation.GetSchedules](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock/CheckIn/CheckInLocation.cs#L201), etc.

# Goal
_What will this pull request achieve and how will this fix the problem?_

This solves the issue of CheckInPerson not returning selected GroupTypes and makes the behavior consistent with the other CheckIn methods.

# Strategy
_How have you implemented your solution?_

Removed the check for `if ( PossibleSchedules.Any() )` and changed to the pattern consistent with the other CheckInModels:
``` 
if ( selectedOnly ) 
{
    return GroupTypes.Where( t => t.Selected || t.SelectedForSchedule.Any( s => selectedScheduleIds.Contains( s ) ) ).ToList();
}
```

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Unknown why this method was written differently.  This behaves as expected once fixed.


