### PR TITLE
Add Financial Transaction Details Attribute UI to Modal

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx
@@ -192,6 +192,9 @@
                     </div>
                     <div class="col-md-6">
                         <Rock:RockTextBox ID="tbAccountSummary" runat="server" Label="Summary" TextMode="MultiLine" Rows="3" ValidationGroup="Account" />
+                        <div class="attributes">
+                            <asp:PlaceHolder ID="phAccountAttributeEdits" runat="server" EnableViewState="false"></asp:PlaceHolder>
+                        </div>
                     </div>
                 </div>
             </Content>

--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
@@ -230,7 +230,7 @@ namespace RockWeb.Blocks.Finance
             var txnDetail = new FinancialTransactionDetail();
             txnDetail.LoadAttributes();
             phAccountAttributeEdits.Controls.Clear();
-            Helper.AddEditControls( txnDetail, phAccountAttributeEdits, true );
+            Helper.AddEditControls( txnDetail, phAccountAttributeEdits, true, mdAccount.ValidationGroup );
         }
 
         /// <summary>
@@ -1683,7 +1683,7 @@ namespace RockWeb.Blocks.Finance
             }
 
             phAccountAttributeEdits.Controls.Clear();
-            Helper.AddEditControls( txnDetail, phAccountAttributeEdits, true );
+            Helper.AddEditControls( txnDetail, phAccountAttributeEdits, true, mdAccount.ValidationGroup );
 
             ShowDialog( "ACCOUNT" );
 

--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
@@ -226,6 +226,11 @@ namespace RockWeb.Blocks.Finance
                     Helper.AddEditControls(txn.FinancialPaymentDetail, phPaymentAttributeEdits, false);
                 }
             }
+
+            var txnDetail = new FinancialTransactionDetail();
+            txnDetail.LoadAttributes();
+            phAccountAttributeEdits.Controls.Clear();
+            Helper.AddEditControls( txnDetail, phAccountAttributeEdits, true );
         }
 
         /// <summary>
@@ -466,6 +471,14 @@ namespace RockWeb.Blocks.Finance
                         txnDetail.AccountId = editorTxnDetail.AccountId;
                         txnDetail.Amount = newAmount;
                         txnDetail.Summary = editorTxnDetail.Summary;
+
+                        if ( editorTxnDetail.AttributeValues != null )
+                        {
+                            txnDetail.LoadAttributes();
+                            txnDetail.AttributeValues = editorTxnDetail.AttributeValues;
+                            rockContext.SaveChanges();
+                            txnDetail.SaveAttributeValues( rockContext );
+                        }
                     }
 
                     // Delete any transaction images that were removed
@@ -789,6 +802,13 @@ namespace RockWeb.Blocks.Finance
                 txnDetail.Amount = tbAccountAmount.Text.AsDecimal();
                 txnDetail.Summary = tbAccountSummary.Text;
 
+                txnDetail.LoadAttributes();
+                Rock.Attribute.Helper.GetEditValues( phAccountAttributeEdits, txnDetail );
+                foreach ( var attributeValue in txnDetail.AttributeValues )
+                {
+                    txnDetail.SetAttributeValue( attributeValue.Key, attributeValue.Value.Value );
+                }
+                
                 BindAccounts();
             }
 
@@ -1646,13 +1666,24 @@ namespace RockWeb.Blocks.Finance
                 apAccount.SetValue( txnDetail.AccountId );
                 tbAccountAmount.Text = txnDetail.Amount.ToString( "N2" );
                 tbAccountSummary.Text = txnDetail.Summary;
+
+                if ( txnDetail.Attributes == null )
+                {
+                    txnDetail.LoadAttributes();
+                }
             }
             else
             {
                 apAccount.SetValue( null );
                 tbAccountAmount.Text = string.Empty;
                 tbAccountSummary.Text = string.Empty;
+
+                txnDetail = new FinancialTransactionDetail();
+                txnDetail.LoadAttributes();
             }
+
+            phAccountAttributeEdits.Controls.Clear();
+            Helper.AddEditControls( txnDetail, phAccountAttributeEdits, true );
 
             ShowDialog( "ACCOUNT" );
 


### PR DESCRIPTION
# Context
Need to be able to set Financial Transaction Detail Attributes.

# Goal
Add UI to the Modal for Financial Transaction Details.

# Strategy
Used existing code in the FinancialTransactionDetails block to add UI in Details Modal.

# Possible Implications
No foreseeable impact to other areas.

# Screenshots
![capture2](https://cloud.githubusercontent.com/assets/3513589/21276109/f756df88-c39d-11e6-93e3-b6150331a44e.png)
