### PR TITLE
Feature mp person search fix

### DIFF
--- a/RockWeb/Blocks/Crm/PersonSearch.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonSearch.ascx.cs
@@ -262,7 +262,13 @@ namespace RockWeb.Blocks.Crm
                         }
                 }
 
-                var personIdList = people.Select( p => p.Id ).ToList();
+                IEnumerable<int> personIdList = people.Select( p => p.Id );
+
+                // just leave the personIdList as a Queryable if it is over 10000 so that we don't throw a SQL exception due to the big list of ids
+                if (people.Count() < 10000)
+                {
+                    personIdList = personIdList.ToList();
+                }
 
                 people = personService.Queryable(true).Where( p => personIdList.Contains( p.Id ) );
 				
@@ -276,8 +282,11 @@ namespace RockWeb.Blocks.Crm
                     people = people.OrderBy( p => p.LastName ).ThenBy( p => p.FirstName );
                 }
 
-                Guid familyGuid = new Guid( Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY );
-                Guid homeAddressTypeGuid = new Guid( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME );
+                var familyGroupType = GroupTypeCache.GetFamilyGroupType();
+                int familyGroupTypeId = familyGroupType != null ? familyGroupType.Id : 0;
+
+                var groupLocationTypeHome = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME.AsGuid() );
+                int homeAddressTypeId = groupLocationTypeHome != null ? groupLocationTypeHome.Id : 0;
 
                 var personList = people.Select( p => new PersonSearchResult
                 {
@@ -299,14 +308,14 @@ namespace RockWeb.Blocks.Crm
                     PhotoId = p.PhotoId,
                     CampusIds = p.Members
                         .Where( m =>
-                            m.Group.GroupType.Guid.Equals( familyGuid ) &&
+                            m.Group.GroupTypeId == familyGroupTypeId &&
                             m.Group.CampusId.HasValue )
                         .Select( m => m.Group.CampusId.Value )
                         .ToList(),
                     HomeAddresses = p.Members
-                        .Where( m => m.Group.GroupType.Guid == familyGuid )
+                        .Where( m => m.Group.GroupTypeId == familyGroupTypeId )
                         .SelectMany( m => m.Group.GroupLocations )
-                        .Where( gl => gl.GroupLocationTypeValue.Guid.Equals( homeAddressTypeGuid ) )
+                        .Where( gl => gl.GroupLocationTypeValueId == homeAddressTypeId )
                         .Select( gl => gl.Location )
                 } ).ToList();
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_
PersonSearch would throw a SQL Exception if there were a large number of matches.  For example, if searching for a single letter "s", which returns 33000 matches on our database

# Goal
_What will this pull request achieve and how will this fix the problem?_
Make it so that it doesn't throw the exception if there is a large number of matches, but still perform quickly

# Strategy
_How have you implemented your solution?_
I borrowed an idea from SECC to cut-off using a static list of Ids if the list is over 10000 and use an IQueryable instead (see https://github.com/SparkDevNetwork/Rock/pull/1905)  I also updated the LINQ to use ID instead of GUID when querying for Campus and Home Address (this made it much faster).

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
There shouldn't be any negative impact or issues with backwards compatibility.


# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
