### PR TITLE
- added optimization to ContributionStatementListLava and Contributio…

### DIFF
--- a/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
@@ -267,9 +267,13 @@ namespace RockWeb.Blocks.Finance
                 }
             }
 
-            var qry = financialTransactionDetailService.Queryable().AsNoTracking()
-                        .Where( t => t.Transaction.AuthorizedPersonAlias.Person.GivingId == targetPerson.GivingId );
+            // fetch all the possible PersonAliasIds that have this GivingID to help optimize the SQL
+            var personAliasIds = new PersonAliasService( rockContext ).Queryable().Where( a => a.Person.GivingId == targetPerson.GivingId ).Select( a => a.Id ).ToList();
 
+            // get the transactions for the person or all the members in the person's giving group (Family)
+            var qry = financialTransactionDetailService.Queryable().AsNoTracking()
+                        .Where( t => t.Transaction.AuthorizedPersonAliasId.HasValue && personAliasIds.Contains( t.Transaction.AuthorizedPersonAliasId.Value ) );
+            
             qry = qry.Where( t => t.Transaction.TransactionDateTime.Value.Year == statementYear );
 
             if ( string.IsNullOrWhiteSpace( GetAttributeValue( "Accounts" ) ) )

--- a/RockWeb/Blocks/Finance/ContributionStatementListLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementListLava.ascx.cs
@@ -142,8 +142,12 @@ namespace RockWeb.Blocks.Finance
 
             FinancialTransactionDetailService financialTransactionDetailService = new FinancialTransactionDetailService( rockContext );
 
+            // fetch all the possible PersonAliasIds that have this GivingID to help optimize the SQL
+            var personAliasIds = new PersonAliasService( rockContext ).Queryable().Where( a => a.Person.GivingId == TargetPerson.GivingId ).Select( a => a.Id ).ToList();
+
+            // get the transactions for the person or all the members in the person's giving group (Family)
             var qry = financialTransactionDetailService.Queryable().AsNoTracking()
-                        .Where( t=> t.Transaction.AuthorizedPersonAlias.Person.GivingId == TargetPerson.GivingId);
+                        .Where( t=> t.Transaction.AuthorizedPersonAliasId.HasValue && personAliasIds.Contains( t.Transaction.AuthorizedPersonAliasId.Value ) );
 
             if ( string.IsNullOrWhiteSpace( GetAttributeValue( "Accounts" ) ) )
             {


### PR DESCRIPTION
…nStatementLava to speed up the query

# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
YES

# Context
_What is the problem you encountered that lead to you creating this pull request?_
After upgrading to a recent develop build (November 2016) of Rock, the Contribution Tab on Person Profile was taking an extra 8-10 seconds to load compared to the previous version that we had (July 2016). This was for a person that had several years worth of regular contributions.

# Goal
_What will this pull request achieve and how will this fix the problem?_
Optimize the Linq so that the Statement Lava blocks perform a little better.


# Strategy
_How have you implemented your solution?_
The pull request will fix the problem by using an optimization on the StatementContributionLava query that preloads the PersonAliasIds for the specified GivingId (same optimization that the TransactionList block uses).  On CCV Data using a person with several years of contributions, the Contribution tab now loads in less than 2 seconds (compared to 8-10+ seconds)

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
This is the same optimization that the TransactionList block has been using for a while, so this is a safe change.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
