### PR TITLE
Added new person data filter for Postal Codes

### DIFF
--- a/Rock/Reporting/DataFilter/Person/PostalCodeFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/PostalCodeFilter.cs
@@ -1,0 +1,294 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Web.UI;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.UI.Controls;
+
+namespace Rock.Reporting.DataFilter.Person
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [Description( "Filter people based on the zipcode of their family." )]
+    [Export( typeof( DataFilterComponent ) )]
+    [ExportMetadata( "ComponentName", "Person Postal Filter" )]
+    public class PostalCodeFilter : DataFilterComponent
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the entity type that filter applies to.
+        /// </summary>
+        /// <value>
+        /// The entity that filter applies to.
+        /// </value>
+        public override string AppliesToEntityType
+        {
+            get { return typeof( Rock.Model.Person ).FullName; }
+        }
+
+        /// <summary>
+        /// Gets the section.
+        /// </summary>
+        /// <value>
+        /// The section.
+        /// </value>
+        public override string Section
+        {
+            get { return "Additional Filters"; }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Gets the title.
+        /// </summary>
+        /// <param name="entityType"></param>
+        /// <returns></returns>
+        /// <value>
+        /// The title.
+        /// </value>
+        public override string GetTitle( Type entityType )
+        {
+            return "Postal Code";
+        }
+
+        /// <summary>
+        /// Formats the selection on the client-side.  When the filter is collapsed by the user, the Filterfield control
+        /// will set the description of the filter to whatever is returned by this property.  If including script, the
+        /// controls parent container can be referenced through a '$content' variable that is set by the control before 
+        /// referencing this property.
+        /// </summary>
+        /// <value>
+        /// The client format script.
+        /// </value>
+        public override string GetClientFormatSelection( Type entityType )
+        {
+            return @"
+function() {
+    var result = 'Postal Code';
+    var compareTypeText = $('.js-filter-compare :selected', $content).text();
+    if ( $('.js-filter-control', $content).is(':visible') ) {
+        var compareValueSingle = $('.js-filter-control', $content).val()    
+        result += ' ' + compareTypeText + ' ' + (compareValueSingle || '');
+    }
+    else {
+        result += ' ' + compareTypeText;
+    }
+
+    return result;
+}
+";
+        }
+
+        /// <summary>
+        /// Formats the selection.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="selection">The selection.</param>
+        /// <returns></returns>
+        public override string FormatSelection( Type entityType, string selection )
+        {
+            var values = selection.Split( '|' );
+            if ( values.Length >= 2 )
+            {
+                ComparisonType comparisonType = values[0].ConvertToEnum<ComparisonType>( ComparisonType.EqualTo );
+                switch ( comparisonType )
+                {
+                    case ComparisonType.EqualTo:
+                    case ComparisonType.NotEqualTo:
+                    case ComparisonType.StartsWith:
+                    case ComparisonType.Contains:
+                    case ComparisonType.DoesNotContain:
+                    case ComparisonType.EndsWith:
+                        return string.Format( "Postal Code {0} {1}", comparisonType.ConvertToString(), values[1] );
+                    case ComparisonType.IsBlank:
+                    case ComparisonType.IsNotBlank:
+                        return string.Format( "Postal Code {0}", comparisonType.ConvertToString() );
+                    default:
+                        break;
+                }
+            }
+            return "Postal code filter";
+        }
+
+        /// <summary>
+        /// The GroupPicker
+        /// </summary>
+        private RockTextBox tbPostalCode = null;
+        private RockDropDownList ddlStringFilterComparison = null;
+
+        /// <summary>
+        /// Creates the child controls.
+        /// </summary>
+        /// <returns></returns>
+        public override Control[] CreateChildControls( Type entityType, FilterField filterControl )
+        {
+            var controls = new List<Control>();
+
+            ddlStringFilterComparison = ComparisonHelper.ComparisonControl( ComparisonHelper.StringFilterComparisonTypes );
+            ddlStringFilterComparison.ID = string.Format( "{0}_{1}", filterControl.ID, controls.Count() );
+            ddlStringFilterComparison.AddCssClass( "js-filter-compare" );
+            filterControl.Controls.Add( ddlStringFilterComparison );
+            controls.Add( ddlStringFilterComparison );
+
+
+            tbPostalCode = new RockTextBox();
+            tbPostalCode.ID = filterControl.ID + "_tbPostalCode";
+            tbPostalCode.AddCssClass( "js-filter-control" );
+            filterControl.Controls.Add( tbPostalCode );
+            controls.Add( tbPostalCode );
+
+            return controls.ToArray();
+        }
+
+        /// <summary>
+        /// Renders the controls.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="filterControl">The filter control.</param>
+        /// <param name="writer">The writer.</param>
+        /// <param name="controls">The controls.</param>
+        public override void RenderControls( Type entityType, FilterField filterControl, HtmlTextWriter writer, Control[] controls )
+        {
+
+            if ( controls.Count() >= 2 )
+            {
+                RockDropDownList ddlCompare = controls[0] as RockDropDownList;
+                RockTextBox tbPostalCode = controls[1] as RockTextBox;
+                writer.AddAttribute( "class", "row field-criteria" );
+                writer.RenderBeginTag( HtmlTextWriterTag.Div );
+                writer.AddAttribute( "class", "col-md-4" );
+                writer.RenderBeginTag( HtmlTextWriterTag.Div );
+                ddlCompare.RenderControl( writer );
+                writer.RenderEndTag();
+
+                writer.AddAttribute( "class", "col-md-8" );
+                writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+                tbPostalCode.RenderControl( writer );
+                writer.RenderEndTag();
+
+                writer.RenderEndTag();  // row
+                RegisterFilterCompareChangeScript( filterControl );
+            }
+        }
+
+        /// <summary>
+        /// Gets the selection.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="controls">The controls.</param>
+        /// <returns></returns>
+        public override string GetSelection( Type entityType, Control[] controls )
+        {
+            RockDropDownList ddlCompare = controls[0] as RockDropDownList;
+            RockTextBox nbPostalBox = controls[1] as RockTextBox;
+            return string.Format( "{0}|{1}", ddlCompare.SelectedValue, nbPostalBox.Text );
+        }
+
+        /// <summary>
+        /// Sets the selection.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="controls">The controls.</param>
+        /// <param name="selection">The selection.</param>
+        public override void SetSelection( Type entityType, Control[] controls, string selection )
+        {
+            var values = selection.Split( '|' );
+            if ( values.Length >= 2 )
+            {
+                ( controls[0] as RockDropDownList ).SelectedValue = values[0];
+                ( controls[1] as RockTextBox ).Text = values[1];
+            }
+        }
+
+        /// <summary>
+        /// Gets the expression.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="serviceInstance">The service instance.</param>
+        /// <param name="parameterExpression">The parameter expression.</param>
+        /// <param name="selection">The selection.</param>
+        /// <returns></returns>
+        public override Expression GetExpression( Type entityType, IService serviceInstance, ParameterExpression parameterExpression, string selection )
+        {
+            var values = selection.Split( '|' );
+
+            ComparisonType comparisonType = values[0].ConvertToEnum<ComparisonType>( ComparisonType.EqualTo );
+            string postalCode = values[1];
+
+            var familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid();
+
+            var groupLocationQry = new GroupLocationService( ( RockContext ) serviceInstance.Context ).Queryable();
+
+            switch ( comparisonType )
+            {
+                case ComparisonType.EqualTo:
+                    groupLocationQry = groupLocationQry.Where( gl => gl.Location.PostalCode == postalCode );
+                    break;
+                case ComparisonType.NotEqualTo:
+                    groupLocationQry = groupLocationQry.Where( gl => gl.Location.PostalCode != postalCode );
+                    break;
+                case ComparisonType.StartsWith:
+                    groupLocationQry = groupLocationQry.Where( gl => gl.Location.PostalCode.StartsWith( postalCode ) );
+                    break;
+                case ComparisonType.Contains:
+                    groupLocationQry = groupLocationQry.Where( gl => gl.Location.PostalCode.Contains( postalCode ) );
+                    break;
+                case ComparisonType.DoesNotContain:
+                    groupLocationQry = groupLocationQry.Where( gl => !gl.Location.PostalCode.Contains( postalCode ) );
+                    break;
+                case ComparisonType.IsBlank:
+                    groupLocationQry = groupLocationQry
+                        .Where( gl => gl.Location.PostalCode == null || gl.Location.PostalCode == string.Empty );
+                    break;
+                case ComparisonType.IsNotBlank:
+                    groupLocationQry = groupLocationQry
+                        .Where( gl => gl.Location.PostalCode != null && gl.Location.PostalCode != string.Empty );
+                    break;
+                case ComparisonType.EndsWith:
+                    groupLocationQry = groupLocationQry.Where( gl => gl.Location.PostalCode.EndsWith( postalCode ) );
+                    break;
+                default:
+                    break;
+            }
+
+            var groupMemberQry = groupLocationQry.Select( gl => gl.Group )
+                .Where( g => g.GroupType.Guid == familyGroupTypeGuid )
+                .SelectMany( g => g.Members );
+
+            var qry = new PersonService( ( RockContext ) serviceInstance.Context ).Queryable()
+                .Where( p => groupMemberQry.Any( xx => xx.PersonId == p.Id ) );
+
+            Expression extractedFilterExpression = FilterExpressionExtractor.Extract<Rock.Model.Person>( qry, parameterExpression, "p" );
+
+            return extractedFilterExpression;
+        }
+
+        #endregion
+    }
+}

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -956,6 +956,7 @@
     <Compile Include="Model\WorkflowActionService.Partial.cs" />
     <Compile Include="PersonProfile\Badge\InDataView.cs" />
     <Compile Include="Reporting\DataFilter\Person\InLocationGeofenceFilter.cs" />
+    <Compile Include="Reporting\DataFilter\Person\PostalCodeFilter.cs" />
     <Compile Include="Reporting\DataSelect\GroupMember\GroupLinkSelect.cs" />
     <Compile Include="Search\Other\Universal.cs" />
     <Compile Include="Reporting\DataFilter\Person\InRegistrationInstanceFilter.cs" />


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
We often need to filter our dataviews by zipcode. We can create a location filter, and then filter by that dataview, but this doesn't work so well in a dynamic report.

# Goal
This will allow us to filter by zipcode.

# Strategy
I created a new postal code filter. It works with 5 digit, 9 digit, or alphanumeric postal codes.

# Possible Implications
None. 