### PR TITLE
Fix loss of keyboard focus when selecting/switching the auth provider

### DIFF
--- a/RockWeb/Blocks/Security/UserLoginList.ascx.cs
+++ b/RockWeb/Blocks/Security/UserLoginList.ascx.cs
@@ -269,12 +269,12 @@ namespace RockWeb.Blocks.Security
                         // keep looking until we find the next available one 
                         int numericSuffix = 1;
                         string nextAvailableUserName = newUserName + numericSuffix.ToString();
-                        while (service.GetByUserName(nextAvailableUserName) != null)
+                        while ( service.GetByUserName( nextAvailableUserName ) != null )
                         {
                             numericSuffix++;
                             nextAvailableUserName = newUserName + numericSuffix.ToString();
                         }
-                        
+
                         nbErrorMessage.NotificationBoxType = NotificationBoxType.Warning;
                         nbErrorMessage.Title = "Invalid User Name";
                         nbErrorMessage.Text = "The User Name you selected already exists. Next available username: " + nextAvailableUserName;
@@ -559,6 +559,7 @@ namespace RockWeb.Blocks.Security
                     {
                         tbPassword.Enabled = true;
                         tbPasswordConfirm.Enabled = true;
+                        tbPassword.Focus();
 
                         if ( hfIdValue.Value == "0" )
                         {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes.

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When tabbing through the User Account screen, any selection of the authentication provider will trigger a postback to load the new provider's detail/attributes.  However, this destroys the current form's focus.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Restores the keyboard focus to the next field (Password) after postback.  If the provider doesn't support a password field (PIN auth), then nothing is focused.

# Strategy
_How have you implemented your solution?_

Set focus to the password field after a password-based auth provider loads.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None, fixed usability.
