### PR TITLE
Improve performance of CampusFilter, CampusesFilter, and CampusSelect

### DIFF
--- a/Rock/Reporting/DataFilter/Person/CampusFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/CampusFilter.cs
@@ -255,10 +255,12 @@ function() {
                 }
 
                 GroupMemberService groupMemberService = new GroupMemberService( rockContext );
+                var groupTypeFamily = GroupTypeCache.GetFamilyGroupType();
+                int groupTypeFamilyId = groupTypeFamily != null ? groupTypeFamily.Id : 0;
 
                 var groupMemberServiceQry = groupMemberService.Queryable()
-                    .Where( xx => xx.Group.GroupType.Guid == new Guid( Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY ) )
-                    .Where( xx => xx.Group.CampusId == campus.Id );
+                    .Where( xx => xx.Group.GroupTypeId == groupTypeFamilyId )
+                    .Where( xx => ( xx.Group.CampusId ?? 0 ) == campus.Id );
 
                 var qry = new PersonService( rockContext ).Queryable()
                     .Where( p => groupMemberServiceQry.Any( xx => xx.PersonId == p.Id ) );

--- a/Rock/Reporting/DataFilter/Person/CampusesFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/CampusesFilter.cs
@@ -256,7 +256,7 @@ function() {
 
                 var groupMemberServiceQry = groupMemberService.Queryable()
                     .Where( xx => xx.Group.GroupTypeId == groupTypeFamilyId )
-                    .Where( xx => xx.Group.CampusId.HasValue && campusIds.Contains( xx.Group.CampusId.Value ) );
+                    .Where( xx => campusIds.Contains( xx.Group.CampusId ?? 0 ) );
 
                 var qry = new PersonService( rockContext ).Queryable()
                     .Where( p => groupMemberServiceQry.Any( xx => xx.PersonId == p.Id ) );

--- a/Rock/Reporting/DataFilter/Person/CampusesFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/CampusesFilter.cs
@@ -251,9 +251,11 @@ function() {
                 }
 
                 GroupMemberService groupMemberService = new GroupMemberService( rockContext );
+                var groupTypeFamily = GroupTypeCache.GetFamilyGroupType();
+                int groupTypeFamilyId = groupTypeFamily != null ? groupTypeFamily.Id : 0;
 
                 var groupMemberServiceQry = groupMemberService.Queryable()
-                    .Where( xx => xx.Group.GroupType.Guid == new Guid( Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY ) )
+                    .Where( xx => xx.Group.GroupTypeId == groupTypeFamilyId )
                     .Where( xx => xx.Group.CampusId.HasValue && campusIds.Contains( xx.Group.CampusId.Value ) );
 
                 var qry = new PersonService( rockContext ).Queryable()


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
YES

# Context
_What is the problem you encountered that lead to you creating this pull request?_
We have a dynamic report that uses the CampusesFilter that is used quite a bit.  It started to get very slow, and even timing out.  I'm not sure why it "Just started happening", but there was no recent code changes that would have caused it.  I'm guessing that our database recently just got just a little bigger and that amplified the problem.

# Goal
_What will this pull request achieve and how will this fix the problem?_
Fix it so that Campus Filters perform reasonably fast.

# Strategy
_How have you implemented your solution?_
I first thought that looking using GroupTypeFamily.Guid instead of GroupTypeFamilyId was having a significant impact on the SQL (since Guid requires an additional Join and Index lookup), but that only made a small improvement.  I next tried tweaking the WHERE clause for CampusId to see if that would help.  I ended up changing the LINQ statement to do a "(CampusId ?? 0) == @campusId)", in other words, have it treat NULL CampusIds as 0.  This had the result of changing the SQL to do a "CASE statement to deal with the null CampusIds instead of doing a "WHERE CampusId is not null AND CampusId == @campusId).  That little change helped a lot!  I'm guessing that SQL was spending a bunch of time dealing with the "WHERE CampusId is NOT null".

This change fixed up our dynamic report so it only took 3-4 seconds instead of timing out (it was taking 7 minutes and still wasn't done!)

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
There should be no risk for this change.  It should perform at least as fast, and often quite a bit faster compared to the current version.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
