### PR TITLE
Add support for ViewState compression with ratio of about 15:1.

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1178,6 +1178,7 @@
     <Compile Include="Utility\DebugHelper.cs" />
     <Compile Include="Utility\ExcelHelper.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
+    <Compile Include="Web\UI\CompressedHiddenFieldPageStatePersister.cs" />
     <Compile Include="Web\UI\RockTheme.cs" />
     <Compile Include="Web\Cache\AttributeValueCache.cs" />
     <Compile Include="Web\UI\Controls\WarningBlock.cs" />

--- a/Rock/Web/UI/CompressedHiddenFieldPageStatePersister.cs
+++ b/Rock/Web/UI/CompressedHiddenFieldPageStatePersister.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Web.Security;
+using System.Web.UI;
+
+namespace Rock.Web.UI
+{
+    /// <summary>
+    /// Optionally compresses the ViewState before storing it into a hidden field on the
+    /// page to increase postback speed.
+    /// </summary>
+    public class CompressedHiddenFieldPageStatePersister : PageStatePersister
+    {
+        /// <summary>
+        /// The size of the ViewState at which to compress it.
+        /// </summary>
+        public int SizeThreshold { get; set; }
+
+        /// <summary>
+        /// Instantiate a new PageStatePersister that will store the ViewState in a hidden field
+        /// and optionally compress the data if it is greater than the size threshold.
+        /// </summary>
+        /// <param name="page">The Page whose ViewState we need to load or save.</param>
+        /// <param name="sizeThreshold">If the length of the base64 encoded ViewState is greater than or equal to this number then it will be encrypted. A value of 0 means never encrypt.</param>
+        public CompressedHiddenFieldPageStatePersister( Page page, int sizeThreshold )
+            : base( page )
+        {
+            SizeThreshold = sizeThreshold;
+        }
+
+        //
+        // Load ViewState and ControlState.
+        //
+        public override void Load()
+        {
+            string viewState = Page.Request.Form["__CVIEWSTATE"];
+            byte[] bytes = Convert.FromBase64String( viewState );
+
+            //
+            // Decrypt.
+            //
+            if ( Page.Request.Form["__CVIEWSTATEENC"] == "1" )
+            {
+                bytes = MachineKey.Unprotect( bytes );
+            }
+
+            //
+            // Uncompress.
+            //
+            if ( Page.Request.Form["__CVIEWSTATESIZE"] != "0" )
+            {
+                using ( MemoryStream output = new MemoryStream() )
+                {
+                    using ( MemoryStream input = new MemoryStream() )
+                    {
+                        input.Write( bytes, 0, bytes.Length );
+                        input.Position = 0;
+                        using ( GZipStream gzip = new GZipStream( input, CompressionMode.Decompress, true ) )
+                        {
+                            gzip.CopyTo( output );
+                        }
+                    }
+
+                    bytes = output.ToArray();
+                }
+            }
+
+            //
+            // Deserialize the data back into ViewState and ControlState.
+            //
+            Pair pair = ( Pair ) new LosFormatter().Deserialize( Convert.ToBase64String( bytes ) );
+            ViewState = pair.First;
+            ControlState = pair.Second;
+        }
+
+        //
+        // Persist any ViewState and ControlState.
+        //
+        public override void Save()
+        {
+            //
+            // Serialize the ViewState and ControlState data for inclusion in the hidden field.
+            //
+            StringWriter writer = new StringWriter();
+            new LosFormatter().Serialize( writer, new Pair( ViewState, ControlState ) );
+            string viewStateString = writer.ToString();
+
+            //
+            // Get the uncompressed size and convert from Base64 to raw data.
+            //
+            int uncompressedSize = viewStateString.Length;
+            byte[] bytes = Convert.FromBase64String( viewStateString );
+
+            //
+            // Compress if the size is past the threshhold.
+            //
+            if ( SizeThreshold != 0 && uncompressedSize >= SizeThreshold )
+            {
+                MemoryStream output = new MemoryStream();
+
+                using ( GZipStream gzip = new GZipStream( output, CompressionMode.Compress, true ) )
+                {
+                    gzip.Write( bytes, 0, bytes.Length );
+                }
+                bytes = output.ToArray();
+
+                ScriptManager.RegisterHiddenField( Page, "__CVIEWSTATESIZE", uncompressedSize.ToString() );
+            }
+            else
+            {
+                ScriptManager.RegisterHiddenField( Page, "__CVIEWSTATESIZE", "0" );
+            }
+
+            //
+            // Encrypt unless we are told not to.
+            //
+            if ( Page.ViewStateEncryptionMode != ViewStateEncryptionMode.Never )
+            {
+                bytes = MachineKey.Protect( bytes );
+                ScriptManager.RegisterHiddenField( Page, "__CVIEWSTATEENC", "1" );
+            }
+            else
+            {
+                ScriptManager.RegisterHiddenField( Page, "__CVIEWSTATEENC", "0" );
+            }
+
+            ScriptManager.RegisterHiddenField( Page, "__CVIEWSTATE", Convert.ToBase64String( bytes ) );
+        }
+    }
+}

--- a/Rock/Web/UI/RockPage.cs
+++ b/Rock/Web/UI/RockPage.cs
@@ -433,6 +433,18 @@ namespace Rock.Web.UI
 
         #endregion
 
+        #region Overridden Properties
+
+        /// <summary>
+        /// Gets the PageStatePersister object associated with the page.
+        /// </summary>
+        protected override PageStatePersister PageStatePersister
+        {
+            get { return new CompressedHiddenFieldPageStatePersister( this, 102400 ); }
+        }
+
+        #endregion
+
         #region Protected Methods
 
         /// <summary>
@@ -1343,7 +1355,11 @@ namespace Rock.Web.UI
                 {
                     string script = @"
 Sys.Application.add_load(function () {
-    $('.js-view-state-stats').html('ViewState Size: ' + ($('#__VIEWSTATE').val().length / 1024).toFixed(0) + ' KB');
+    if ($('#__CVIEWSTATESIZE').length > 0 && $('#__CVIEWSTATESIZE').val() != '0') {
+        $('.js-view-state-stats').html('ViewState Size: ' + ($('#__CVIEWSTATESIZE').val() / 1024).toFixed(0) + ' KB (' + ($('#__CVIEWSTATE').val().length / 1024).toFixed(0) + ' KB Compressed)');
+    } else {
+        $('.js-view-state-stats').html('ViewState Size: ' + ($('#__CVIEWSTATE').val().length / 1024).toFixed(0) + ' KB');
+    }
     $('.js-html-size-stats').html('Html Size: ' + ($('html').html().length / 1024).toFixed(0) + ' KB');
 });
 ";


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Extremely slow postback of pages due to large ViewState size.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Apply GZIP compression to the ViewState.

# Strategy
_How have you implemented your solution?_

A new subclass of PageStatePersister has been added to the Rock.dll and RockPage class has been updated to override the property getter that retrieves it.

Compression of ViewState using GZIP algorithm is performed if the ViewState is greater than 100KB. The achieved compression ratio is between 15:1 and 20:1. A ViewState that was previously 1.5MB becomes 73KB.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Should not impact backwards compatibility beyond a user trying to re-post a page generated from before this patch is applied to a page generated after this patch is applied (unlikely, and would probably throw an exception either way). Security should not be affected as we still encrypt the ViewState with the Machine Key.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img width="409" alt="screen shot 2016-12-28 at 12 40 36 pm" src="https://cloud.githubusercontent.com/assets/1119863/21534098/d7b9c316-cd16-11e6-9c69-b809ca5fa3e0.png">

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

# Comments

This patch works as is, but a possible improvement would be to have a Global Attribute that the Admin could set for the threshold at which to compress ViewState (or disable it completely). That would, however, require migration scripts and I'm not really up to speed enough to tackle that just yet.