### PR TITLE
Add Campus filter and search box to Group Tree View settings panel

### DIFF
--- a/Rock.Rest/Controllers/GroupsController.Partial.cs
+++ b/Rock.Rest/Controllers/GroupsController.Partial.cs
@@ -48,6 +48,8 @@ namespace Rock.Rest.Controllers
         /// <param name="excludedGroupTypeIds">The excluded group type ids.</param>
         /// <param name="includeInactiveGroups">if set to <c>true</c> [include inactive groups].</param>
         /// <param name="includeCounts">if set to <c>true</c> [include counts].</param>
+        /// <param name="campusId">if set it will filter groups based on campus</param>
+        /// <param name="includeNoCampus">if campus set and set to <c>true</c> [include groups with no campus].</param>
         /// <returns></returns>
         [Authenticate, Secured]
         [System.Web.Http.Route( "api/Groups/GetChildren/{id}" )]
@@ -58,7 +60,9 @@ namespace Rock.Rest.Controllers
             string includedGroupTypeIds = "",
             string excludedGroupTypeIds = "",
             bool includeInactiveGroups = false,
-            TreeViewItem.GetCountsType countsType = TreeViewItem.GetCountsType.None )
+            TreeViewItem.GetCountsType countsType = TreeViewItem.GetCountsType.None,
+            int campusId = 0,
+            bool includeNoCampus = false )
         {
             // Enable proxy creation since security is being checked and need to navigate parent authorities
             SetProxyCreation( true );
@@ -71,7 +75,7 @@ namespace Rock.Rest.Controllers
             // if specific group types are specified, show the groups regardless of ShowInNavigation
             bool limitToShowInNavigation = !includedGroupTypeIdList.Any();
 
-            var qry = groupService.GetChildren( id, rootGroupId, limitToSecurityRoleGroups, includedGroupTypeIdList, excludedGroupTypeIdList, includeInactiveGroups, limitToShowInNavigation );
+            var qry = groupService.GetChildren( id, rootGroupId, limitToSecurityRoleGroups, includedGroupTypeIdList, excludedGroupTypeIdList, includeInactiveGroups, limitToShowInNavigation, campusId, includeNoCampus );
 
             List<Group> groupList = new List<Group>();
             List<TreeViewItem> groupNameList = new List<TreeViewItem>();

--- a/Rock/Model/GroupService.Partial.cs
+++ b/Rock/Model/GroupService.Partial.cs
@@ -271,8 +271,10 @@ namespace Rock.Model
         /// <param name="groupTypeExcludedIds">The group type excluded ids.</param>
         /// <param name="includeInactiveGroups">if set to <c>true</c> [include inactive groups].</param>
         /// <param name="limitToShowInNavigation">if set to <c>true</c> [limit to show in navigation].</param>
+        /// <param name="campusId">if set it will filter groups based on campus</param>
+        /// <param name="includeNoCampus">if campus set and set to <c>true</c> [include groups with no campus].</param>
         /// <returns></returns>
-        public IQueryable<Group> GetChildren( int id, int rootGroupId, bool limitToSecurityRoleGroups, List<int> groupTypeIncludedIds, List<int> groupTypeExcludedIds, bool includeInactiveGroups, bool limitToShowInNavigation )
+        public IQueryable<Group> GetChildren( int id, int rootGroupId, bool limitToSecurityRoleGroups, List<int> groupTypeIncludedIds, List<int> groupTypeExcludedIds, bool includeInactiveGroups, bool limitToShowInNavigation, int campusId = 0, bool includeNoCampus = false )
         {
             var qry = Queryable();
 
@@ -300,6 +302,18 @@ namespace Rock.Model
             if ( limitToSecurityRoleGroups )
             {
                 qry = qry.Where( a => a.IsSecurityRole );
+            }
+
+            if ( campusId > 0 )
+            {
+                if ( includeNoCampus )
+                {
+                    qry = qry.Where( a => a.CampusId == campusId || a.Campus == null );
+                }
+                else
+                {
+                    qry = qry.Where( a => a.CampusId == campusId );
+                }
             }
 
             if ( groupTypeIncludedIds.Any() )

--- a/RockWeb/Blocks/Groups/GroupTreeView.ascx
+++ b/RockWeb/Blocks/Groups/GroupTreeView.ascx
@@ -8,6 +8,8 @@
         <asp:HiddenField ID="hfGroupTypesExclude" runat="server" />
         <asp:HiddenField ID="hfIncludeInactiveGroups" runat="server" />
         <asp:HiddenField ID="hfCountsType" runat="server" />
+        <asp:HiddenField ID="hfCampusFilter" runat="server" />
+        <asp:HiddenField ID="hfIncludeNoCampus" runat="server" />
         <asp:HiddenField ID="hfInitialGroupParentIds" runat="server" />
         <asp:HiddenField ID="hfLimitToSecurityRoleGroups" runat="server" />
         <asp:HiddenField ID="hfSelectedGroupId" runat="server" />
@@ -37,6 +39,17 @@
             <div class="js-config-panel" style="display: none" id="pnlConfigPanel" runat="server">
                 <Rock:Toggle ID="tglHideInactiveGroups" runat="server" OnText="Active" OffText="All" Checked="true" ButtonSizeCssClass="btn-xs" OnCheckedChanged="tglHideInactiveGroups_CheckedChanged" Label="Show" />
                 <Rock:RockDropDownList ID="ddlCountsType" runat="server" Label="Show Count For" OnSelectedIndexChanged="ddlCountsType_SelectedIndexChanged" CssClass="input-sm" AutoPostBack="true" />
+                <Rock:CampusPicker ID="ddlCampuses" runat="server" Label="Filter by Campus" OnSelectedIndexChanged="ddlCampuses_SelectedIndexChanged" CssClass="input-sm" AutoPostBack="true" />
+                <Rock:Toggle ID="tglIncludeNoCampus" runat="server" OnText="Yes" OffText="No" ButtonSizeCssClass="btn-xs" OnCheckedChanged="tglIncludeNoCampus_CheckedChanged" Label="Include groups with no campus" />
+                <div class="form-group">
+                    <asp:Label runat="server" AssociatedControlID="tbSearch" Text="Search" CssClass="control-label" />
+                    <asp:Panel ID="pnlSearch" runat="server" DefaultButton="btnSearch" CssClass="input-group">
+                        <asp:TextBox ID="tbSearch" runat="server" CssClass="form-control input-sm" />
+                        <span class="input-group-btn">
+                            <asp:Button ID="btnSearch" runat="server" Text="Go!" CssClass="btn btn-default btn-sm" OnClick="btnSearch_OnClick" />
+                        </span>
+                    </asp:Panel>
+                </div>
             </div>
 
             <div class="treeview-scroll scroll-container scroll-container-horizontal">
@@ -121,7 +134,9 @@
                             + '&includedGroupTypeIds=' + ($('#<%=hfGroupTypesInclude.ClientID%>').val() || '0')
                             + '&excludedGroupTypeIds=' + ($('#<%=hfGroupTypesExclude.ClientID%>').val() || '0')
                             + '&includeInactiveGroups=' + ($('#<%=hfIncludeInactiveGroups.ClientID%>').val() || false)
-                            + '&countsType=' + ($('#<%=hfCountsType.ClientID%>').val() || false),
+                            + '&countsType=' + ($('#<%=hfCountsType.ClientID%>').val() || false)
+                            + '&includeNoCampus=' + ($('#<%=hfIncludeNoCampus.ClientID%>').val() || false)
+                            + '&campusId=' + ($('#<%=hfCampusFilter.ClientID%>').val() || 0),
                         multiSelect: false,
                         selectedIds: $selectedId.val() ? $selectedId.val().split(',') : null,
                         expandedIds: $expandedIds.val() ? $expandedIds.val().split(',') : null

--- a/RockWeb/Blocks/Groups/GroupTreeView.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupTreeView.ascx.cs
@@ -44,6 +44,7 @@ namespace RockWeb.Blocks.Groups
     [GroupField( "Root Group", "Select the root group to use as a starting point for the tree view.", false, order: 4 )]
     [BooleanField( "Limit to Security Role Groups", order: 5 )]
     [BooleanField( "Show Settings Panel", defaultValue: true, key: "ShowFilterOption", order: 6 )]
+    [BooleanField( "Display Inactive Campuses", "Include inactive campuses in the Campus Filter", true )]
     [CustomDropdownListField( "Initial Count Setting", "Select the counts that should be initially shown in the treeview.", "0^None,1^Child Groups,2^Group Members", false, "0", "", 7 )]
     [CustomDropdownListField( "Initial Active Setting", "Select whether to initially show all or just active groups in the treeview", "0^All,1^Active", false, "1", "", 8 )]
     [LinkedPage( "Detail Page", order: 9 )]
@@ -144,6 +145,25 @@ namespace RockWeb.Blocks.Groups
             {
                 ddlCountsType.SetValue( "" );
             }
+
+            ddlCampuses.Campuses = CampusCache.All( GetAttributeValue( "DisplayInactiveCampuses" ).AsBoolean() );
+
+            var CampusFilter = this.GetUserPreference( "CampusFilter" );
+            if ( pnlConfigPanel.Visible )
+            {
+                ddlCampuses.SetValue( CampusFilter );
+            }
+            else
+            {
+                ddlCampuses.SetValue( "" );
+            }
+
+            var IncludeNoCampus = this.GetUserPreference( "IncludeNoCampus" ).AsBoolean();
+            if ( pnlConfigPanel.Visible )
+            {
+                tglIncludeNoCampus.Checked = IncludeNoCampus;
+            }
+
         }
 
         /// <summary>
@@ -323,6 +343,8 @@ namespace RockWeb.Blocks.Groups
 
             hfIncludeInactiveGroups.Value = ( !tglHideInactiveGroups.Checked ).ToTrueFalse();
             hfCountsType.Value = ddlCountsType.SelectedValue;
+            hfCampusFilter.Value = ddlCampuses.SelectedValue;
+            hfIncludeNoCampus.Value = tglIncludeNoCampus.Checked.ToTrueFalse();
         }
 
         /// <summary>
@@ -459,6 +481,43 @@ namespace RockWeb.Blocks.Groups
         }
 
         /// <summary>
+        /// Handles the SelectedIndexChanged event of the ddlCampuses control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ddlCampuses_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            this.SetUserPreference( "CampusFilter", ddlCampuses.SelectedValue );
+
+            // reload the whole page
+            NavigateToPage( this.RockPage.Guid, new Dictionary<string, string>() );
+        }
+
+        /// <summary>
+        /// Handles the CheckedChange event of the cbIncludeNoCampus control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void tglIncludeNoCampus_CheckedChanged( object sender, EventArgs e )
+        {
+            this.SetUserPreference( "IncludeNoCampus", tglIncludeNoCampus.Checked.ToTrueFalse() );
+
+            // reload the whole page
+            NavigateToPage( this.RockPage.Guid, new Dictionary<string, string>() );
+        }
+
+        /// <summary>
+        /// Handles the OnClick event of the btnSearch control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnSearch_OnClick( object sender, EventArgs e )
+        {
+            // redirect to search
+            NavigateToPage( Rock.SystemGuid.Page.GROUP_SEARCH_RESULTS.AsGuid(), new Dictionary<string, string>() { { "SearchType", "name" },{ "SearchTerm", tbSearch.Text.Trim() } } );
+        }
+
+        /// <summary>
         /// Finds the first group.
         /// </summary>
         /// <returns></returns>
@@ -471,7 +530,7 @@ namespace RockWeb.Blocks.Groups
             // if specific group types are specified, show the groups regardless of ShowInNavigation
             bool limitToShowInNavigation = !includedGroupTypeIds.Any();
 
-            var qry = groupService.GetChildren( 0, hfRootGroupId.ValueAsInt(), hfLimitToSecurityRoleGroups.Value.AsBoolean(), includedGroupTypeIds, excludedGroupTypeIds, !tglHideInactiveGroups.Checked, limitToShowInNavigation );
+            var qry = groupService.GetChildren( 0, hfRootGroupId.ValueAsInt(), hfLimitToSecurityRoleGroups.Value.AsBoolean(), includedGroupTypeIds, excludedGroupTypeIds, !tglHideInactiveGroups.Checked, limitToShowInNavigation, hfCampusFilter.ValueAsInt(), tglIncludeNoCampus.Checked );
 
             foreach ( var group in qry.OrderBy( g => g.Name ) )
             {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ 
No

# Context
A church wanted the ability to filter the group tree down based on campus. As well as the ability to search from the group tree.

# Goal
A campus picker and search box will be added to the settings panel to give the user the ability to filter based on campus or run a search from the tree view.

# Strategy
I added the new campus picker (with a toggle to include "no campus set" entries) to the group tree settings panel, with the corresponding api and GroupService updates to support this new data to filter based off of. A group search box input-group was also added to the settings panel to be able to search for a specific group.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None that I could think of. New parameters were added as optional to the GetChildren function so it shouldn’t affect backwards compatibility at all.

# Screenshots
![pasted image at 2016_12_29 02_54 pm](https://cloud.githubusercontent.com/assets/2990519/21556295/9bb654f8-cddc-11e6-969a-597d01db7824.png)

# Documentation
**Filter by Campus** shows only groups assigned to the selected campus.
**Include groups with no campus** is only used when filter by Campus is set and will do as it says.
**Search** allows you to run a search from the group viewer