### PR TITLE
Have ShowMiddleName use the ViewState

### DIFF
--- a/Rock/Web/UI/Controls/NewFamily/MembersRow.cs
+++ b/Rock/Web/UI/Controls/NewFamily/MembersRow.cs
@@ -129,14 +129,6 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether [show middle name].
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if [show middle name]; otherwise, <c>false</c>.
-        /// </value>
-        public bool ShowMiddleName { get; set; }
-
-        /// <summary>
         /// Gets or sets the last name.
         /// </summary>
         /// <value>
@@ -295,6 +287,18 @@ namespace Rock.Web.UI.Controls
         {
             get { return ViewState["ShowGradePicker"] as bool? ?? false; }
             set { ViewState["ShowGradePicker"] = value; }
+        }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether [show middle name].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [show middle name]; otherwise, <c>false</c>.
+        /// </value>
+        public bool ShowMiddleName
+        {
+            get { return ViewState["ShowMiddleName"] as bool? ?? false; }
+            set { ViewState["ShowMiddleName"] = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

# Context
_What is the problem you encountered that lead to you creating this pull request?_

I happened to have made a nearly identical change only to find it when I merged pre-alpha-release. Checked with Mike Peterson and he agreed ShowMiddleName should use the ViewState just like ShowGradePicker and ShowGradeColumn do.

# Goal
_What will this pull request achieve and how will this fix the problem?_

# Strategy
_How have you implemented your solution?_

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
