### PR TITLE
Performance improvement to GetByDevice and GetAllDescendents (sp)

### DIFF
--- a/Rock/Model/LocationService.Partial.cs
+++ b/Rock/Model/LocationService.Partial.cs
@@ -357,12 +357,13 @@ namespace Rock.Model
             return ExecuteQuery( string.Format(
                 @"
                 WITH CTE AS (
-                    SELECT * FROM [Location] WHERE [ParentLocationId]={0}
+                    SELECT Id FROM [Location] WHERE [ParentLocationId]={0}
                     UNION ALL
-                    SELECT [a].* FROM [Location] [a]
-                    INNER JOIN  CTE pcte ON pcte.Id = [a].[ParentLocationId]
+                    SELECT [a].Id FROM [Location] [a]
+                    INNER JOIN CTE pcte ON pcte.Id = [a].[ParentLocationId]
                 )
-                SELECT * FROM CTE
+                SELECT L.* FROM CTE
+                INNER JOIN [Location] L ON L.[Id] = CTE.[Id]
                 ", parentLocationId ) );
         }
 
@@ -433,7 +434,7 @@ namespace Rock.Model
         /// </summary>
         /// <param name="locationId">The location identifier.</param>
         /// <returns></returns>
-        public int? GetCampusIdForLocation( int? locationId)
+        public int? GetCampusIdForLocation( int? locationId )
         {
             if ( !locationId.HasValue )
             {
@@ -502,8 +503,8 @@ namespace Rock.Model
 
         UNION ALL
 
-        SELECT [a].*
-        FROM [Location] [a]
+        SELECT [a].Id
+	    FROM [Location] [a]
         INNER JOIN  CTE pcte ON pcte.Id = [a].[ParentLocationId]
         WHERE [a].[ParentLocationId] IS NOT NULL
 " : "";
@@ -511,14 +512,15 @@ namespace Rock.Model
             return ExecuteQuery( string.Format(
                 @"
     WITH CTE AS (
-        SELECT L.*
+        SELECT L.Id
         FROM [DeviceLocation] D
         INNER JOIN [Location] L ON L.[Id] = D.[LocationId]
         WHERE D.[DeviceId] = {0}
 {1}
     )
 
-    SELECT * FROM CTE
+    SELECT L.* FROM CTE
+    INNER JOIN [Location] L ON L.[Id] = CTE.[Id]
             ", deviceId, childQuery ) );
         }
     }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes.

# Context
_What is the problem you encountered that lead to you creating this pull request?_

While profiling check-in queries during our Christmas services, I noticed the device and location lookups were some of the most expensive queries being run.  We have ~4k active locations assigned across 16 campuses (and ~180k total locations) so this is particularly problematic.

Under the original structure/execution plan, there was an index scan on Location: 

![screen shot 2017-01-04 at 7 38 13 pm](https://cloud.githubusercontent.com/assets/1210933/21665431/8123c3a4-d2ba-11e6-8ec4-696abcacf099.png)

Average execution time was ~5500ms using a cold cache or OPTION RECOMPILE.

# Goal
_What will this pull request achieve and how will this fix the problem?_

This PR seeks to optimize those device and location lookups.

# Strategy
_How have you implemented your solution?_

Instead of requesting all location fields while traversing the Device or Descendant tree, I've limited the traversal to only include the Location.Id.  Once the traversal is finished and a much smaller result set is returned, a lookup fires to get the necessary Location information. 

With the new structure/execution plan, SQL Server chooses an index seek instead:  

![screen shot 2017-01-04 at 7 54 45 pm](https://cloud.githubusercontent.com/assets/1210933/21665443/8d709326-d2ba-11e6-88b7-739241d06532.png)

Average execution time is now ~150ms using a cold cache or OPTION RECOMPILE.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

I've confirmed this change returns the same result set for Rock v6.0 running on SQL 2012 and SQL 2016,  as well as testing with Rock v6.1 from the Rock demo site. 
