### PR TITLE
Add alt text to lava theme images to improve accessibility

### DIFF
--- a/RockWeb/Themes/Flat/Assets/Lava/AdDetails.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/AdDetails.lava
@@ -1,6 +1,6 @@
 ﻿{% for item in Items %}
   {% if item.DetailImage_unformatted != '' %}
-  <img src="/GetImage.ashx?Guid={{ item.DetailImage_unformatted }}" class="title-image img-responsive">
+  <img alt="{{ item.Title }}" src="/GetImage.ashx?Guid={{ item.DetailImage_unformatted }}" class="title-image img-responsive">
     {% endif %}
     <h1>{{ item.Title }}</h1>{{ item.Content }}
 {% endfor -%}

--- a/RockWeb/Themes/Flat/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/GroupDetail.lava
@@ -103,7 +103,7 @@
 		{% if countPending > -1 %}
 			{% assign icountPending = 0 %}
 
-			
+
 
 			{% for member in Group.Members %}
 
@@ -121,7 +121,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -189,7 +189,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -256,7 +256,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -322,4 +322,3 @@
 		<div class='alert alert-warning'>You do not have persmission to view this group.</div>
 	{% endif %}
 {% endif %}
-

--- a/RockWeb/Themes/Rock/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/GroupDetail.lava
@@ -103,7 +103,7 @@
 		{% if countPending > -1 %}
 			{% assign icountPending = 0 %}
 
-			
+
 
 			{% for member in Group.Members %}
 
@@ -121,7 +121,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -189,7 +189,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -256,7 +256,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -322,4 +322,3 @@
 		<div class='alert alert-warning'>You do not have persmission to view this group.</div>
 	{% endif %}
 {% endif %}
-

--- a/RockWeb/Themes/Rock/Assets/Lava/OpportunitySearch.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/OpportunitySearch.lava
@@ -15,7 +15,7 @@
     </div>
     <div class="panel-body">
       <div class="col-md-2">
-          <img src="{{opportunity.PhotoUrl}}" class="title-image img-responsive margin-b-md">
+          <img alt="Image for {{ opportunity.PublicName }}" src="{{opportunity.PhotoUrl}}" class="title-image img-responsive margin-b-md">
       </div>
       <div class="col-md-10">
         <p>{{opportunity.Summary}}</p>

--- a/RockWeb/Themes/Stark/Assets/Lava/AdDetails.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/AdDetails.lava
@@ -1,7 +1,7 @@
 ﻿{% for item in Items %}
 {% assign detailImageGuid = item | Attribute:'DetailImage','RawValue' %}
 {% if detailImageGuid != '' %}
-<img src="/GetImage.ashx?Guid={{ detailImageGuid }}" class="title-image img-responsive">
+<img alt="{{ item.Title }}" src="/GetImage.ashx?Guid={{ detailImageGuid }}" class="title-image img-responsive">
   {% endif %}
   <h1>{{ item.Title }}</h1>{{ item.Content }}
   {% endfor -%}

--- a/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
@@ -103,7 +103,7 @@
 		{% if countPending > -1 %}
 			{% assign icountPending = 0 %}
 
-			
+
 
 			{% for member in Group.Members %}
 
@@ -121,7 +121,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -189,7 +189,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -256,7 +256,7 @@
 						{% if LinkedPages.PersonDetailPage %}
 							<a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ member.PersonId }}">
 						{% endif %}
-						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" />
+						<img src="{{ member.Person.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
 						<div class="pull-left">
 							<strong>{{ member.Person.FullName }}</strong>
 							<small>({{ member.GroupRole.Name}})</small>
@@ -322,4 +322,3 @@
 		<div class='alert alert-warning'>You do not have persmission to view this group.</div>
 	{% endif %}
 {% endif %}
-

--- a/RockWeb/Themes/Stark/Assets/Lava/OpportunityDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/OpportunityDetail.lava
@@ -4,7 +4,7 @@
 <div class="row">
     {% if Opportunity.PhotoId %}
         <div class="col-md-4">
-            <img src="/GetImage.ashx?id={{ Opportunity.PhotoId }}" style="width: 100%;" />
+            <img alt="Image for {{ opportunity.PublicName }}" src="/GetImage.ashx?id={{ Opportunity.PhotoId }}" style="width: 100%;" />
         </div>
     {% endif %}
     <div class="col-md-8">
@@ -25,7 +25,3 @@
 
     </div>
 </div>
-
-
-
-	

--- a/RockWeb/Themes/Stark/Assets/Lava/OpportunitySearch.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/OpportunitySearch.lava
@@ -15,7 +15,7 @@
     </div>
     <div class="panel-body">
       <div class="col-md-2">
-          <img src="{{opportunity.PhotoUrl}}" class="title-image img-responsive margin-b-md">
+          <img alt="Image for {{ opportunity.PublicName }}" src="{{opportunity.PhotoUrl}}" class="title-image img-responsive margin-b-md">
       </div>
       <div class="col-md-10">
         <p>{{opportunity.Summary}}</p>


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
We have a few people that are visually impaired and wanted to improve their experience using Rock. While every screen reader works a little differently, adding the alt tag helps readers know to ignore a image, and is in use by twitter and facebook for their avatars. (See https://davidwalsh.name/accessibility-tip-empty-alt-attributes)

# Goal
Add alt tags to theme lava files. Where relevant the title of what the image is used for some minimal SEO gain, for profile images use blank alt tags.

# Strategy
Adding alt text

# Possible Implications
None? 
