### PR TITLE
Performance improvement to FindRelationships workflow action

### DIFF
--- a/Rock/Workflow/Action/CheckIn/FindRelationships.cs
+++ b/Rock/Workflow/Action/CheckIn/FindRelationships.cs
@@ -96,31 +96,44 @@ namespace Rock.Workflow.Action.CheckIn
 
                     var familyMemberIds = family.People.Select( p => p.Person.Id ).ToList();
 
-                    // Get the Known Relationship group id's for each person in the family
-                    var relationshipGroups = groupMemberService
-                        .Queryable().AsNoTracking()
-                        .Where( g =>
-                            g.GroupRole.Guid.Equals( new Guid( Rock.SystemGuid.GroupRole.GROUPROLE_KNOWN_RELATIONSHIPS_OWNER ) ) &&
-                            familyMemberIds.Contains( g.PersonId ) )
-                        .Select( g => g.GroupId );
-
-                    // Get anyone in any of those groups that has a role with the canCheckIn attribute set
-                    foreach ( var person in groupMemberService
-                        .Queryable().AsNoTracking()
-                        .Where( g =>
-                            relationshipGroups.Contains( g.GroupId ) &&
-                            roles.Contains( g.GroupRoleId ) )
-                        .Select( g => g.Person )
-                        .ToList() )
+                    var knownRelationshipGroupType = GroupTypeCache.Read( Rock.SystemGuid.GroupType.GROUPTYPE_KNOWN_RELATIONSHIPS.AsGuid() );
+                    if ( knownRelationshipGroupType != null )
                     {
-                        if ( !family.People.Any( p => p.Person.Id == person.Id ) )
+                        var ownerRole = knownRelationshipGroupType.Roles.FirstOrDefault( r => r.Guid == Rock.SystemGuid.GroupRole.GROUPROLE_KNOWN_RELATIONSHIPS_OWNER.AsGuid() );
+                        if ( ownerRole != null )
                         {
-                            if ( !preventInactive || dvInactive == null || person.RecordStatusValueId != dvInactive.Id )
+                            // Get the Known Relationship group id's for each person in the family
+                            var relationshipGroupIds = groupMemberService
+                                .Queryable().AsNoTracking()
+                                .Where( g =>
+                                    g.GroupRoleId == ownerRole.Id &&
+                                    familyMemberIds.Contains( g.PersonId ) )
+                                .Select( g => g.GroupId );
+
+                            // Get anyone in any of those groups that has a role with the canCheckIn attribute set
+                            var personIds = groupMemberService
+                                .Queryable().AsNoTracking()
+                                .Where( g =>
+                                    relationshipGroupIds.Contains( g.GroupId ) &&
+                                    roles.Contains( g.GroupRoleId ) )
+                                .Select( g => g.PersonId )
+                                .ToList();
+
+                            foreach ( var person in new PersonService( rockContext )
+                                .Queryable().AsNoTracking()
+                                .Where( p => personIds.Contains( p.Id ) )
+                                .ToList() )
                             {
-                                var relatedPerson = new CheckInPerson();
-                                relatedPerson.Person = person.Clone( false );
-                                relatedPerson.FamilyMember = false;
-                                family.People.Add( relatedPerson );
+                                if ( !family.People.Any( p => p.Person.Id == person.Id ) )
+                                {
+                                    if ( !preventInactive || dvInactive == null || person.RecordStatusValueId != dvInactive.Id )
+                                    {
+                                        var relatedPerson = new CheckInPerson();
+                                        relatedPerson.Person = person.Clone( false );
+                                        relatedPerson.FamilyMember = false;
+                                        family.People.Add( relatedPerson );
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes.

# Context
_What is the problem you encountered that lead to you creating this pull request?_

After the performance enhancements in #1956, @azturner sent me this change to FindRelationships.  I confirmed the original query execution plan had multiple GroupMember and Person lookups:

![screen shot 2017-01-09 at 2 42 13 pm](https://cloud.githubusercontent.com/assets/1210933/21781291/cd2206f6-d67c-11e6-98f4-d3a349948bdf.png)

Average execution time was ~95ms using a cold cache or OPTION RECOMPILE.

# Goal
_What will this pull request achieve and how will this fix the problem?_

This PR seeks to optimize the `Can Check-in` relationship lookups.

# Strategy
_How have you implemented your solution?_

Instead of joining GroupMember and Person multiple times to find intersecting records, this lookup pulls the GroupMember.PersonId for any `Can Check-in` relationship, then a lookup fires to get the necessary Person information. 

With the new structure/execution plan, SQL Server runs a single index seek:  

![screen shot 2017-01-09 at 2 42 47 pm](https://cloud.githubusercontent.com/assets/1210933/21781427/475dbcd0-d67d-11e6-9835-64036945f5f8.png)

Average execution time is now ~30ms using a cold cache or OPTION RECOMPILE.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

I've confirmed this change returns the same result set for Rock v6.0 running on SQL 2012 and SQL 2016.