### PR TITLE
Add the option to restrict Group Context by Campus Context

### DIFF
--- a/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
+++ b/RockWeb/Blocks/Core/GroupContextSetter.ascx.cs
@@ -41,6 +41,7 @@ namespace RockWeb.Blocks.Core
     [TextField( "Clear Selection Text", "The text displayed when a group can be unselected. This will not display when the text is empty.", true, "", order: 3 )]
     [BooleanField( "Display Query Strings", "Select to always display query strings. Default behavior will only display the query string when it's passed to the page.", false, "", order: 4 )]
     [BooleanField( "Include GroupType Children", "Include all children of the grouptype selected", false, "", order: 5 )]
+    [BooleanField( "Respect Campus Context", "Filter groups by the Campus Context block if it exists", true, "", order: 6 )]
     public partial class GroupContextSetter : RockBlock
     {
         #region Base Control Methods
@@ -139,6 +140,16 @@ namespace RockWeb.Blocks.Core
                 else
                 {
                     qryGroups = groupService.Queryable().Where( a => a.GroupType.Guid == groupTypeGuid.Value );
+                }
+            }
+
+            if ( GetAttributeValue( "RespectCampusContext" ).AsBoolean() )
+            {
+                var campusContext = RockPage.GetCurrentContext( EntityTypeCache.Read( typeof( Campus ) ) );
+
+                if ( campusContext != null )
+                {
+                    qryGroups = qryGroups.Where( g => g.CampusId == campusContext.Id );
                 }
             }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes.

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When setting up dashboards to display data by user-selected contexts, the Group Context was pulling every group for a particular grouptype.  Since we have 16 campuses, the list of groups would get fairly large.

# Goal
_What will this pull request achieve and how will this fix the problem?_

This PR seeks to limit the list of Groups by Campus when a Campus Context is set.

# Strategy
_How have you implemented your solution?_

I've added a Block Attribute for Admins to enable the Campus filter, assuming a Campus Context is set.  If a Campus Context is not set, the Group Context setter behaves as normal.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

N/A.