### PR TITLE
SYS-3184 Fixing checkboxes not updating from a disabled state

### DIFF
--- a/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
+++ b/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
@@ -151,6 +151,18 @@ namespace RockWeb.Blocks.Crm
         selectIcon.toggleClass('fa-check-circle-o', enabled);
         selectIcon.toggleClass('fa-circle-o', !enabled);
 
+        // Checkboxes needs special handling
+        var checkboxes = formGroup.find('.checkboxlist-group');
+        if ( checkboxes.length ) {{
+            $( checkboxes[0].children ).each(function() {{
+                if ( this.children[0].nodeName === 'INPUT' ) {{
+                    $( this.children[0] ).toggleClass('aspNetDisabled', !enabled);
+                    $( this.children[0] ).prop('disabled', !enabled);
+                    $( this.children[0] ).closest('.form-group').toggleClass('bulk-item-selected', enabled);
+                }}
+            }});
+        }}
+
         // Enable/Disable the controls
         formGroup.find('.form-control').each( function() {{
 


### PR DESCRIPTION
# Context
When in the bulk update screen, selecting an input with checkboxes did not remove the disabled state.

# Goal
This pull request removes the disabled states from checkboxes in the formGroup, if they exist.

# Strategy
I've added to the JS onClick event to check if the formGroup contains checkboxes.  If it does, it removes the disabled state.

# Video Example of Issue
https://drive.google.com/file/d/0Bw8uldfEkvqrN25oZ1owMzZqdVE/view