### PR TITLE
Fix bug when updating a BinaryFile to use a different storage provider

### DIFF
--- a/Rock/Model/BinaryFile.cs
+++ b/Rock/Model/BinaryFile.cs
@@ -377,12 +377,16 @@ namespace Rock.Model
                                 StorageEntityTypeId.Value != BinaryFileType.StorageEntityTypeId.Value ||
                                 StorageEntitySettings != settingsJson ) )
                             {
+                                // Save the file contents before deleting
+                                var contentStream = ContentStream;
+
                                 // Delete the current provider's storage
                                 StorageProvider.DeleteContent( this );
 
                                 // Set the new storage provider with its settings
                                 StorageEntityTypeId = BinaryFileType.StorageEntityTypeId;
                                 StorageEntitySettings = settingsJson;
+                                ContentStream = contentStream;
                             }
                         }
                     }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

While coding a process to create bulk contribution statement files from a Word merge template, I wanted to save the files on the disk rather than in the database. I found that though I was able to update the BinaryFileType of the file after the merge template CreateDocument() function saved it as the default binary file type, it did not save the file to the disk as expected.

# Goal
_What will this pull request achieve and how will this fix the problem?_

To allow an update of the BinaryFileType to correctly save the file even if the storage method differs from that of the original BinaryFileType.

# Strategy
_How have you implemented your solution?_

By saving the BinaryFile's ContentStream to a variable before deleting the existing file, then setting it again from this variable once the StorageProvider is changed. This corrects the problem of the ContentStream being null and the dirty flag being false.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
