### PR TITLE
Update Github Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,16 @@
-### PLEASE READ
+<!--
 
-If the nature of your issue relates to the security of Rock, please do not post it here in the public issues.
+If you have found a security bug in Rock and want to report it to us, DO NOT file an issue. Email secretary@sparkdevnetwork.org and we'll be in touch shortly.
+
+Do you want to ask a question? Are you looking for support? The Ask Rock is the best place for getting support: https://www.rockrms.com/Ask
+
+-->
 
 ### Prerequisites
-
-* [ ] Can you reproduce the problem on a fresh install or the [demo site](http://rock.rocksolidchurchdemo.com/)?
-* [ ] Did you include your Rock version number and [client culture](https://github.com/SparkDevNetwork/Rock/wiki/Environment-and-Diagnostics-Information) setting?
-* [ ] Did you [perform a cursory search](https://github.com/issues?q=is%3Aissue+user%3ASparkDevNetwork+-repo%3ASparkDevNetwork%2FSlack) to see if your bug or enhancement is already reported?
+* [ ] Put an X between the brackets on this line if you have done all of the following:
+    * Can you reproduce the problem on a fresh install or the [demo site](http://rock.rocksolidchurchdemo.com/)?
+    * Did you include your Rock version number and [client culture](https://github.com/SparkDevNetwork/Rock/wiki/Environment-and-Diagnostics-Information) setting?
+    * Did you [perform a cursory search](https://github.com/issues?q=is%3Aissue+user%3ASparkDevNetwork+-repo%3ASparkDevNetwork%2FSlack) to see if your bug or enhancement is already reported?
 
 ### Description
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
Most people are struggling with the prerequisite checkbox system, and a general understanding of what GitHub issues is for, this also helps to move non-developers to appropriate support channels. Inspired heavily by the current iteration of [Atom's Issue Template](https://github.com/atom/atom/issues/new) 

# Goal
- Remove noise from GitHub Issues
- Let developers know where to submit security bugs
- Direct new Rock users to appropriate support channels.

# Strategy
- Big commented out block of directions for security, and support.
- Fewer checkboxes, and including directions on how to use

# Possible Implications
None, but confirming that secretary at sparkdevnetwork.org is a appropriate location for security bugs

# Screenshots
See https://github.com/atom/atom/issues to see a similar template in use

# Documentation
N/A
