### PR TITLE
Adding a illegal characters filter to FileUploader.

### DIFF
--- a/RockWeb/App_Code/FileUploader.ashx.cs
+++ b/RockWeb/App_Code/FileUploader.ashx.cs
@@ -211,6 +211,13 @@ namespace RockWeb
                 }
             }
 
+            char[] illegalCharacters = new char[] { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
+
+            if ( uploadedFile.FileName.IndexOfAny( illegalCharacters ) >= 0 )
+            {
+                throw new Rock.Web.FileUploadException( "Invalid Filename.  Please remove any special characters (" + string.Join(" ", illegalCharacters) + ").", System.Net.HttpStatusCode.UnsupportedMediaType );
+            }
+
             // always create a new BinaryFile record of IsTemporary when a file is uploaded
             var binaryFileService = new BinaryFileService( rockContext );
             var binaryFile = new BinaryFile();


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
When uploading a file with a | character in the filename (allowed from MacOS) the file uploader throws an error (see issue #2004)

# Goal
This checks for a list of special characters that might exist from other operating systems that don't work with Windows.

# Strategy
Just check the filename and throw an error if we get something we don't like.

# Possible Implications
None.

# Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/1248118/22571948/0bc1feba-e970-11e6-8f6b-0a1a80a3bcd9.png)
After:
![image](https://cloud.githubusercontent.com/assets/1248118/22572043/4f4040b6-e970-11e6-8955-a7b7e725e2e6.png)


# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
Shouldn't need to update anything.