### PR TITLE
Fixed Grid Command Column header text to be vertically aligned

### DIFF
--- a/RockWeb/Styles/_grid.less
+++ b/RockWeb/Styles/_grid.less
@@ -361,6 +361,10 @@ td.grid-col-actions {
   }
 }
 
+.grid .table > thead > tr > th.grid-columncommand {
+  padding: 12px;
+}
+
 .table .color-field {
   width: 4px;
   padding: 0;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Vertical alignment for the `Register` column header in the Group Finder block was incorrect. Text was aligned too low and did not match other column headers. Found this was an issue with the core CSS Grid control in general for any command column header.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Adjust the CSS to use correct padding.

# Strategy
_How have you implemented your solution?_

The current CSS overrides the padding (and other styles) for both `thead` and `tbody` elements to make the buttons of a command column vertically aligned with the text. However, this makes the `thead` elements now have incorrect alignment with text in other column headers. CSS now overrides the `thead` padding style back to 12px to match other columns and leaves the `tbody` as it is currently.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Any grids that use text in command columns (I could not find any) that expect the text to be aligned that way will no longer look as intended.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![baseline](https://cloud.githubusercontent.com/assets/1119863/22576359/d740f858-e96f-11e6-8f63-a21deeb9b331.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a
