### PR TITLE
Enhance GroupDetailLava block to provide new limiting options

### DIFF
--- a/RockWeb/Blocks/Groups/GroupDetailLava.ascx
+++ b/RockWeb/Blocks/Groups/GroupDetailLava.ascx
@@ -21,6 +21,7 @@
                 </div>
                 <div class="col-md-6">
                     <Rock:RockCheckBox ID="cbIsActive" runat="server" Text="Active" />
+                    <Rock:RockCheckBox ID="cbIsPublic" runat="server" Text="Public" />
                 </div>
             </div>
 
@@ -98,12 +99,12 @@
             </div>
 
             <div class="row">
-                <div class="col-md-6">
+                <asp:Panel ID="pnlGroupMemberRole" runat="server" CssClass="col-md-6">
                     <Rock:RockDropDownList runat="server" ID="ddlGroupRole" DataTextField="Name" DataValueField="Id" Label="Role" Required="true" />
-                </div>
-                <div class="col-md-6">
+                </asp:Panel>
+                <asp:Panel ID="pnlGroupMemberAttributes" runat="server" CssClass="col-md-6">
                     <asp:PlaceHolder ID="phGroupMemberAttributes" runat="server" EnableViewState="false"></asp:PlaceHolder>
-                </div>
+                </asp:Panel>
             </div>
 
             <div class="actions">

--- a/RockWeb/Blocks/Groups/GroupDetailLava.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupDetailLava.ascx.cs
@@ -45,15 +45,17 @@ namespace RockWeb.Blocks.Groups
     [LinkedPage( "Attendance Page", "The page to link to to manage the group's attendance.", true, "", "", 3 )]
     [LinkedPage( "Communication Page", "The communication page to use for sending emails to the group members.", true, "", "", 4 )]
     [BooleanField( "Hide the 'Active' Group checkbox", "Set this to true to hide the checkbox for 'Active' for the group.", false, key: "HideActiveGroupCheckbox", order: 5 )]
-    [BooleanField( "Hide Inactive Group Member Status", "Set this to true to hide the radiobox for the 'Inactive' group member status.", false, order: 6 )]
-    [BooleanField( "Hide Group Description Edit", "Set this to true to hide the edit box for group 'Description'.", false, key: "HideGroupDescriptionEdit", order: 7 )]
-    [CodeEditorField( "Lava Template", "The lava template to use to format the group details.", CodeEditorMode.Lava, CodeEditorTheme.Rock, 400, true, "{% include '~~/Assets/Lava/GroupDetail.lava' %}", "", 8 )]
-    [BooleanField( "Enable Location Edit", "Enables changing locations when editing a group.", false, "", 9 )]
-    [BooleanField( "Enable Debug", "Shows the fields available to merge in lava.", false, "", 10 )]
-    [CodeEditorField( "Edit Group Pre-HTML", "HTML to display before the edit group panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 11 )]
-    [CodeEditorField( "Edit Group Post-HTML", "HTML to display after the edit group panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 12 )]
-    [CodeEditorField( "Edit Group Member Pre-HTML", "HTML to display before the edit group member panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 13 )]
-    [CodeEditorField( "Edit Group Member Post-HTML", "HTML to display after the edit group member panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 14 )]
+    [BooleanField( "Hide the 'Public' Group checkbox", "Set this to true to hide the checkbox for 'Public' for the group.", true, key: "HidePublicGroupCheckbox", order: 6 )]
+    [BooleanField( "Hide Inactive Group Member Status", "Set this to true to hide the radiobox for the 'Inactive' group member status.", false, order: 7 )]
+    [BooleanField( "Hide Group Member Role", "Set this to true to hide the drop down list for the 'Role' when editing a group member. If set to 'true' then the default group role will be used when adding a new member.", false, order: 8 )]
+    [BooleanField( "Hide Group Description Edit", "Set this to true to hide the edit box for group 'Description'.", false, key: "HideGroupDescriptionEdit", order: 9 )]
+    [CodeEditorField( "Lava Template", "The lava template to use to format the group details.", CodeEditorMode.Lava, CodeEditorTheme.Rock, 400, true, "{% include '~~/Assets/Lava/GroupDetail.lava' %}", "", 10 )]
+    [BooleanField( "Enable Location Edit", "Enables changing locations when editing a group.", false, "", 11 )]
+    [BooleanField( "Enable Debug", "Shows the fields available to merge in lava.", false, "", 12 )]
+    [CodeEditorField( "Edit Group Pre-HTML", "HTML to display before the edit group panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 13 )]
+    [CodeEditorField( "Edit Group Post-HTML", "HTML to display after the edit group panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 14 )]
+    [CodeEditorField( "Edit Group Member Pre-HTML", "HTML to display before the edit group member panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 15 )]
+    [CodeEditorField( "Edit Group Member Post-HTML", "HTML to display after the edit group member panel.", CodeEditorMode.Html, CodeEditorTheme.Rock, 200, false, "", "HTML Wrappers", 16 )]
     public partial class GroupDetailLava : Rock.Web.UI.RockBlock
     {
         #region Fields
@@ -281,6 +283,7 @@ namespace RockWeb.Blocks.Groups
                 group.Name = tbName.Text;
                 group.Description = tbDescription.Text;
                 group.IsActive = cbIsActive.Checked;
+                group.IsPublic = cbIsPublic.Checked;
 
                 if ( pnlSchedule.Visible )
                 {
@@ -593,6 +596,12 @@ namespace RockWeb.Blocks.Groups
                 cbIsActive.Visible = false;
             }
 
+            bool hidePublicGroupCheckbox = this.GetAttributeValue( "HidePublicGroupCheckbox" ).AsBooleanOrNull() ?? true;
+            if ( hidePublicGroupCheckbox )
+            {
+                cbIsPublic.Visible = false;
+            }
+
             bool hideDescriptionEdit = this.GetAttributeValue( "HideGroupDescriptionEdit" ).AsBooleanOrNull() ?? false;
             if ( hideDescriptionEdit )
             {
@@ -704,6 +713,7 @@ namespace RockWeb.Blocks.Groups
                     tbName.Text = group.Name;
                     tbDescription.Text = group.Description;
                     cbIsActive.Checked = group.IsActive;
+                    cbIsPublic.Checked = group.IsPublic;
 
                     if ( ( group.GroupType.AllowedScheduleTypes & ScheduleType.Weekly ) == ScheduleType.Weekly )
                     {
@@ -981,6 +991,17 @@ namespace RockWeb.Blocks.Groups
                 {
                     rblStatus.Items.Remove( inactiveItem );
                 }
+            }
+            bool hideGroupMemberRole = this.GetAttributeValue( "HideGroupMemberRole" ).AsBooleanOrNull() ?? false;
+            if ( hideGroupMemberRole )
+            {
+                pnlGroupMemberRole.Visible = false;
+                pnlGroupMemberAttributes.AddCssClass( "col-md-12" ).RemoveCssClass( "col-md-6" );
+            }
+            else
+            {
+                pnlGroupMemberRole.Visible = true;
+                pnlGroupMemberAttributes.AddCssClass( "col-md-6" ).RemoveCssClass( "col-md-12" );
             }
 
             // set attributes


### PR DESCRIPTION
Enhanced the GroupDetailLava block of the Group Leader Toolbox to support:

- Block setting to hide the `Role` while editing or adding a Group Member.
- Block setting to hide the `Public` flag while editing the Group.

# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Our Small Group team wanted to prevent leaders from changing the role of an existing group member (for example, prevent the leader from making another member a leader without them having been vetted by our team).

Additionally they needed the Leader's to be able to mark their group as Public or Not Public themselves to be able to hide the group from the group locator.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Add block settings and support code to add the needed functionality.

# Strategy
_How have you implemented your solution?_

Two new block settings to turn on the new functionality.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Backwards compatibility is maintained by the default values keeping the UI looking like it did before this commit.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![sample1](https://cloud.githubusercontent.com/assets/1119863/22660979/57e24616-ec58-11e6-8e32-4034871c162a.png)

![sample2](https://cloud.githubusercontent.com/assets/1119863/22660982/5c32789e-ec58-11e6-9c91-9b1b21cc65f1.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a