### PR TITLE
SaveAttributeValues() now loads and saves once

### DIFF
--- a/Rock/Attribute/Helper.cs
+++ b/Rock/Attribute/Helper.cs
@@ -802,7 +802,14 @@ namespace Rock.Attribute
             {
                 rockContext = rockContext ?? new RockContext();
                 var attributeValueService = new Model.AttributeValueService( rockContext );
-                var attributeValues = attributeValueService.GetByEntityId( model.Id ).ToDictionary(x => x.AttributeKey);
+                var attributeService = new Model.AttributeService( rockContext );
+                var entityType = EntityTypeCache.Read( model.GetType() );
+
+                var valueQuery = ( from a in attributeService.GetByEntityTypeId( entityType.Id )
+                                   join v in attributeValueService.GetByEntityId( model.Id ) on a.Id equals v.AttributeId
+                                   select v );
+
+                var attributeValues = valueQuery.ToDictionary(x => x.AttributeKey);
                 foreach (var attribute in model.Attributes.Values)
                 {
                     if ( model.AttributeValues.ContainsKey( attribute.Key ) )

--- a/Rock/Attribute/Helper.cs
+++ b/Rock/Attribute/Helper.cs
@@ -798,19 +798,17 @@ namespace Rock.Attribute
         /// </remarks>
         public static void SaveAttributeValues( IHasAttributes model, RockContext rockContext = null )
         {
-            if ( model != null && model.Attributes != null && model.AttributeValues != null )
+            if ( model != null && model.Attributes != null && model.AttributeValues != null && model.Attributes.Any() && model.AttributeValues.Any() )
             {
                 rockContext = rockContext ?? new RockContext();
                 var attributeValueService = new Model.AttributeValueService( rockContext );
                 var attributeService = new Model.AttributeService( rockContext );
-                var entityType = EntityTypeCache.Read( model.GetType() );
 
-                var valueQuery = ( from a in attributeService.GetByEntityTypeId( entityType.Id )
-                                   join v in attributeValueService.GetByEntityId( model.Id ) on a.Id equals v.AttributeId
-                                   select v );
+                var attributeIds = model.Attributes.Select( y => y.Value.Id ).ToList();
+                var valueQuery = attributeValueService.Queryable().Where( x => attributeIds.Contains( x.AttributeId ) && x.EntityId == model.Id );
 
-                var attributeValues = valueQuery.ToDictionary(x => x.AttributeKey);
-                foreach (var attribute in model.Attributes.Values)
+                var attributeValues = valueQuery.ToDictionary( x => x.AttributeKey );
+                foreach ( var attribute in model.Attributes.Values )
                 {
                     if ( model.AttributeValues.ContainsKey( attribute.Key ) )
                     {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

We have about 200 person attributes. Calling SaveAttributeValues() takes a few seconds to run because it loops through all the attributes and loads their values one at a time, then saves each modified attribute one at a time.

# Goal
_What will this pull request achieve and how will this fix the problem?_

To optimize the process of saving all attributes.

# Strategy
_How have you implemented your solution?_

Instead of calling SaveAttributeValue() for each attribute, instead load all the entity's attributes all at once, update all that need updating, then save once at the end.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_