### PR TITLE
SelectFromListFieldType.FormatValue no longer breaks when value is null

### DIFF
--- a/Rock/Field/SelectFromListFieldType.cs
+++ b/Rock/Field/SelectFromListFieldType.cs
@@ -45,6 +45,10 @@ namespace Rock.Field.Types
         /// <returns></returns>
         public override string FormatValue( System.Web.UI.Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed )
         {
+            if (value == null)
+            {
+                return string.Empty;
+            }
             var valueGuidList = value.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries ).AsGuidList();
             return this.ListSource.Where( a => valueGuidList.Contains( a.Key.AsGuid() ) ).Select( s => s.Value ).ToList().AsDelimited( "," );
         }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Testing some other logic, accidentally created an attribute with a null value. FormatValue broke when trying to load that attribute.

# Goal
_What will this pull request achieve and how will this fix the problem?_

To avoid throwing an exception when an attribute's value is null

# Strategy
_How have you implemented your solution?_

Return string.Empty when value is null.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_