### PR TITLE
Workflow action to test if person is in a dataview

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1686,6 +1686,7 @@
     <Compile Include="Workflow\Action\People\PersonAddressUpdate.cs" />
     <Compile Include="Workflow\Action\People\PersonGetHeadOfHousehold.cs" />
     <Compile Include="Workflow\Action\People\PersonGetSpouse.cs" />
+    <Compile Include="Workflow\Action\People\PersonInDataView.cs" />
     <Compile Include="Workflow\Action\People\PersonNoteAdd.cs" />
     <Compile Include="Workflow\Action\People\PersonPhoneUpdate.cs" />
     <Compile Include="Workflow\Action\People\PersonPropertyUpdate.cs" />

--- a/Rock/Workflow/Action/People/PersonInDataView.cs
+++ b/Rock/Workflow/Action/People/PersonInDataView.cs
@@ -1,0 +1,146 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Data.Entity;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Sets boolean based on if person is in dataview.
+    /// </summary>
+    [ActionCategory( "People" )]
+    [Description( "Sets an attribute True or False depending on if the person is in selected dataview." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Person In DataView" )]
+
+    [WorkflowAttribute( "Person", "Workflow attribute that contains the person to add the note to.", true, "", "", 0, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
+    [DataViewField( "DataView", "DataView to check.", true, "", "Rock.Model.Person", order: 1 )]
+    [IntegerField( "Timeout", "Number of seconds to wait before timing out.", false, 30, order: 2 )]
+    [WorkflowAttribute( "Boolean", "Workflow attribute to set True or False.", true, "", "", 3, null, new string[] { "Rock.Field.Types.BooleanFieldType" } )]
+
+    public class PersonInDataView : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            var person = GetPersonAliasFromActionAttribute( "Person", rockContext, action, errorMessages );
+            if ( person != null )
+            {
+                Guid booleanGuid = GetAttributeValue( action, "Boolean" ).AsGuid();
+                if ( !booleanGuid.IsEmpty() )
+                {
+                    var attribute = AttributeCache.Read( booleanGuid, rockContext );
+                    if ( attribute != null )
+                    {
+                        var dataViewAttributeGuid = GetAttributeValue( action, "DataView" ).AsGuid();
+                        if ( dataViewAttributeGuid != Guid.Empty )
+                        {
+                            var dataViewService = new DataViewService( rockContext );
+                            var dataView = dataViewService.Get( dataViewAttributeGuid );
+                            if ( dataView != null )
+                            {
+                                var timeout = GetAttributeValue( action, "Timeout" ).AsIntegerOrNull();
+                                var qry = dataView.GetQuery( null, timeout, out errorMessages );
+                                if ( qry != null && qry.Where( e => e.Id == person.Id ).Any() )
+                                {
+                                    SetWorkflowAttributeValue( action, booleanGuid, "True" );
+                                }
+                                else
+                                {
+                                    SetWorkflowAttributeValue( action, booleanGuid, "False" );
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        errorMessages.Add( "DataView could not be found." );
+                    }
+                }
+            }
+            else
+            {
+                errorMessages.Add( "No person was provided for DataView." );
+            }
+
+            errorMessages.ForEach( m => action.AddLogEntry( m, true ) );
+
+            return true;
+        }
+
+        private Person GetPersonAliasFromActionAttribute( string key, RockContext rockContext, WorkflowAction action, List<string> errorMessages )
+        {
+            string value = GetAttributeValue( action, key );
+            Guid guidPersonAttribute = value.AsGuid();
+            if ( !guidPersonAttribute.IsEmpty() )
+            {
+                var attributePerson = AttributeCache.Read( guidPersonAttribute, rockContext );
+                if ( attributePerson != null )
+                {
+                    string attributePersonValue = action.GetWorklowAttributeValue( guidPersonAttribute );
+                    if ( !string.IsNullOrWhiteSpace( attributePersonValue ) )
+                    {
+                        if ( attributePerson.FieldType.Class == "Rock.Field.Types.PersonFieldType" )
+                        {
+                            Guid personAliasGuid = attributePersonValue.AsGuid();
+                            if ( !personAliasGuid.IsEmpty() )
+                            {
+                                PersonAliasService personAliasService = new PersonAliasService( rockContext );
+                                return personAliasService.Queryable().AsNoTracking()
+                                    .Where( a => a.Guid.Equals( personAliasGuid ) )
+                                    .Select( a => a.Person )
+                                    .FirstOrDefault();
+                            }
+                            else
+                            {
+                                errorMessages.Add( string.Format( "Person could not be found for selected value ('{0}')!", guidPersonAttribute.ToString() ) );
+                                return null;
+                            }
+                        }
+                        else
+                        {
+                            errorMessages.Add( string.Format( "The attribute used for {0} to provide the person was not of type 'Person'.", key ) );
+                            return null;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
We have a dataview which is our standard for who can work with children. When someone makes a requests in a connection, we would like to send an email to everyone who not completed the process so they can begin the application to serve. We could use a SQL action, but we would like to have one source for truth. 

# Goal
This action would allow people to use a dataview to set a boolean attribute in their workflow based on if a person is in that dataview. 

# Strategy
I created a workflow action that checks to see if the person is in a particular dataview and sets a workflow attribute "True" or "False" accordingly. That attribute can then be used as a filter to start or end actions and activities. 

# Possible Implications
None

# Documentation
Person: The person who will be tested against the dataview.
DataView: The dataview to test the person against. 
Timeout: This is a safeguard against your dataview taking too long to run. Default is 30 seconds.
Boolean: Boolean attribute to set based on if the person is found in the dataview. Note: when filtering against a boolean attribute, test to see if the value equals "True" or "False"