### PR TITLE
Update SignatureDocumentTemplateService.Partial.cs

### DIFF
--- a/Rock/Model/SignatureDocumentTemplateService.Partial.cs
+++ b/Rock/Model/SignatureDocumentTemplateService.Partial.cs
@@ -150,13 +150,16 @@ namespace Rock.Model
 
                         if ( document == null )
                         {
-                            document = new SignatureDocument();
-                            document.SignatureDocumentTemplate = signatureDocumentTemplate;
-                            document.SignatureDocumentTemplateId = signatureDocumentTemplate.Id;
-                            document.Name = documentName;
-                            document.AppliesToPersonAliasId = appliesToPerson.PrimaryAliasId;
-                            document.AssignedToPersonAliasId = assignedToPerson.PrimaryAliasId;
-                            documentService.Add( document );
+                             //Recreate SignatureDocumentTemplate as the object passed in the parameter is used in a different context.
+                            SignatureDocumentTemplate thisSignatureDocumentTemplate = new SignatureDocumentTemplate();
+                            thisSignatureDocumentTemplate.Name = signatureDocumentTemplate.Name;
+                            thisSignatureDocumentTemplate.Description = signatureDocumentTemplate.Description;
+                            thisSignatureDocumentTemplate.ProviderEntityTypeId = signatureDocumentTemplate.ProviderEntityTypeId;
+                            thisSignatureDocumentTemplate.ProviderTemplateKey = signatureDocumentTemplate.ProviderTemplateKey;
+                            thisSignatureDocumentTemplate.BinaryFileTypeId = signatureDocumentTemplate.BinaryFileTypeId;
+                            thisSignatureDocumentTemplate.InviteSystemEmailId = signatureDocumentTemplate.InviteSystemEmailId;
+                            int? appliestoPersonId = appliesToPerson.PrimaryAliasId;
+                            int? assignedToPersonId = assignedToPerson.PrimaryAliasId;
                         }
 
                         if ( !sendErrors.Any() )


### PR DESCRIPTION
The objects used to set the Signature Document properties that is being saved are currently used in two different contexts this causes the code execution to throw an exception.

By creating new objects based on the values of the objects being passed as a parameter into the function resolves the issue.

# Context
_What is the problem you encountered that lead to you creating this pull request?_
Clicking the "Send Signature Request" button raised Invalid Operation Exceptions because an object was being used in two different contexts.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

"Send Signature Request" button on Registration Detail block.
![image](https://cloud.githubusercontent.com/assets/18447151/23522700/9cbb814a-ff49-11e6-9ed9-8120a0ae5753.png)
