### PR TITLE
switch to newer async twilio client

### DIFF
--- a/Rock/Communication/Transport/Twilio.cs
+++ b/Rock/Communication/Transport/Twilio.cs
@@ -30,6 +30,8 @@ using Rock.Model;
 using Rock.Web.Cache;
 
 using Twilio;
+using TwilioTypes = Twilio.Types;
+using Twilio.Rest.Api.V2010.Account;
 
 namespace Rock.Communication.Transport
 {
@@ -48,7 +50,7 @@ namespace Rock.Communication.Transport
         /// </summary>
         /// <param name="communication">The communication.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public override void Send( Rock.Model.Communication communication )
+        public override async void Send( Rock.Model.Communication communication )
         {
             var rockContext = new RockContext();
 
@@ -72,7 +74,7 @@ namespace Rock.Communication.Transport
                 {
                     string accountSid = GetAttributeValue( "SID" );
                     string authToken = GetAttributeValue( "Token" );
-                    var twilio = new TwilioRestClient( accountSid, authToken );
+                    TwilioClient.Init( accountSid, authToken );
 
                     var historyService = new HistoryService( rockContext );
                     var recipientService = new CommunicationRecipientService( rockContext );
@@ -114,7 +116,12 @@ namespace Rock.Communication.Transport
                                     var globalAttributes = Rock.Web.Cache.GlobalAttributesCache.Read();
                                     string callbackUrl = globalAttributes.GetValue( "PublicApplicationRoot" ) + "Webhooks/Twilio.ashx";
 
-                                    var response = twilio.SendMessage( fromPhone, twilioNumber, message, callbackUrl );
+                                    var response = await MessageResource.CreateAsync(
+                                        from: new TwilioTypes.PhoneNumber(fromPhone),
+                                        to: new TwilioTypes.PhoneNumber(twilioNumber),
+                                        body: message,
+                                        statusCallback: new System.Uri(callbackUrl)
+                                    );
 
                                     recipient.Status = CommunicationRecipientStatus.Delivered;
                                     recipient.TransportEntityTypeName = this.GetType().FullName;
@@ -184,7 +191,7 @@ namespace Rock.Communication.Transport
         /// <param name="appRoot">The application root.</param>
         /// <param name="themeRoot">The theme root.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public override void Send(Dictionary<string, string> mediumData, List<string> recipients, string appRoot, string themeRoot)
+        public override async void Send(Dictionary<string, string> mediumData, List<string> recipients, string appRoot, string themeRoot)
         {
             try
             {
@@ -200,7 +207,7 @@ namespace Rock.Communication.Transport
                     {
                         string accountSid = GetAttributeValue( "SID" );
                         string authToken = GetAttributeValue( "Token" );
-                        var twilio = new TwilioRestClient( accountSid, authToken );
+                        TwilioClient.Init( accountSid, authToken );
 
                         string message = string.Empty;
                         mediumData.TryGetValue( "Message", out message );
@@ -219,7 +226,11 @@ namespace Rock.Communication.Transport
 
                         foreach (var recipient in recipients)
                         {
-                            var response = twilio.SendMessage( fromPhone, recipient, message );
+                            var response = await MessageResource.CreateAsync(
+                                from: new TwilioTypes.PhoneNumber(fromPhone),
+                                to: new TwilioTypes.PhoneNumber(recipient),
+                                body: message
+                            );
                         }
                     }
                 }
@@ -241,7 +252,7 @@ namespace Rock.Communication.Transport
         /// <param name="appRoot">The application root.</param>
         /// <param name="themeRoot">The theme root.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public override void Send( List<string> recipients, string from, string subject, string body, string appRoot = null, string themeRoot = null )
+        public override async void Send( List<string> recipients, string from, string subject, string body, string appRoot = null, string themeRoot = null )
         {
             try
             {
@@ -252,7 +263,7 @@ namespace Rock.Communication.Transport
                 {
                     string accountSid = GetAttributeValue( "SID" );
                     string authToken = GetAttributeValue( "Token" );
-                    var twilio = new TwilioRestClient( accountSid, authToken );
+                    TwilioClient.Init( accountSid, authToken );
 
                     string message = body;
                     if ( !string.IsNullOrWhiteSpace( themeRoot ) )
@@ -269,7 +280,11 @@ namespace Rock.Communication.Transport
 
                     foreach ( var recipient in recipients )
                     {
-                        var response = twilio.SendMessage( fromPhone, recipient, message );
+                        var response = await MessageResource.CreateAsync(
+                            from: new TwilioTypes.PhoneNumber(fromPhone),
+                            to: new TwilioTypes.PhoneNumber(recipient),
+                            body: message
+                        );
                     }
                 }
             }
@@ -291,7 +306,7 @@ namespace Rock.Communication.Transport
         /// <param name="themeRoot">The theme root.</param>
         /// <param name="attachments">Attachments.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public override void Send(List<string> recipients, string from, string subject, string body, string appRoot = null, string themeRoot = null, List<Attachment> attachments = null)
+        public override async void Send(List<string> recipients, string from, string subject, string body, string appRoot = null, string themeRoot = null, List<Attachment> attachments = null)
         {
             throw new NotImplementedException();
         }
@@ -308,7 +323,7 @@ namespace Rock.Communication.Transport
         /// <param name="themeRoot">The theme root.</param>
         /// <param name="attachments">The attachments.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public override void Send( List<string> recipients, string from, string fromName, string subject, string body, string appRoot = null, string themeRoot = null, List<Attachment> attachments = null )
+        public override async void Send( List<string> recipients, string from, string fromName, string subject, string body, string appRoot = null, string themeRoot = null, List<Attachment> attachments = null )
         {
             throw new NotImplementedException();
         }

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -114,6 +114,14 @@
       <HintPath>..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.2.0\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.2\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.1.2\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -184,6 +192,10 @@
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.2\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Packaging, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenXMLSDK-MOT.2.6.0.0\lib\System.IO.Packaging.dll</HintPath>
       <Private>True</Private>
@@ -224,8 +236,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Twilio.Api, Version=3.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Twilio.4.7.2\lib\3.5\Twilio.Api.dll</HintPath>
+    <Reference Include="Twilio, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Twilio.5.0.2\lib\net451\Twilio.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="UAParser, Version=2.1.0.0, Culture=neutral, PublicKeyToken=f7377bf021646069, processorArchitecture=MSIL">

--- a/Rock/packages.config
+++ b/Rock/packages.config
@@ -24,6 +24,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Logging" version="1.1.2" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.1.2" targetFramework="net452" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net452" />
@@ -38,9 +40,10 @@
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="RestSharp" version="105.2.3" targetFramework="net452" />
   <package id="StackExchange.Redis" version="1.1.603" targetFramework="net452" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.2" targetFramework="net452" />
   <package id="System.Linq.Dynamic" version="1.0.6" targetFramework="net452" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net452" />
-  <package id="Twilio" version="4.7.2" targetFramework="net452" />
+  <package id="Twilio" version="5.0.2" targetFramework="net452" />
   <package id="UAParser" version="2.1.0.0" targetFramework="net452" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
# Context
During a sunday service, we did a big push for a campaign backed by text to workflow. We had over 6000 text in which at peak, locked up our rock instance and dropped communication from over half. The waiting on twilio response caused our instance to spike with CPU and timeout on all requests
 
# Goal
This makes the waiting for the POST to twilio async to not block the main thread.

# Strategy
After updating the twilio client, we are able to use the `CreateAsyncMessage`. This changes the `Send` method to be an async method.

# Possible Implications
There shouldn't be any
