### PR TITLE
New Lava Filters to cast variables into explicit data types

### DIFF
--- a/Rock.Tests/Rock/Lava/RockFiltersTests.cs
+++ b/Rock.Tests/Rock/Lava/RockFiltersTests.cs
@@ -224,6 +224,408 @@ END:VCALENDAR";
 
         #endregion
 
+        #region AsInteger
+
+        /// <summary>
+        /// For use in Lava -- should not cast the null to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_Null()
+        {
+            var output = RockFilters.AsInteger( null );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the true boolean to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_InvalidBoolean()
+        {
+            var output = RockFilters.AsInteger( true );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the integer to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_ValidInteger()
+        {
+            var output = RockFilters.AsInteger( 3 );
+            Assert.Equal( output, 3 );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the decimal to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_ValidDecimal()
+        {
+            var output = RockFilters.AsInteger( ( decimal ) 3.0d );
+            Assert.Equal( output, 3 );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the decimal to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_InvalidDecimal()
+        {
+            var output = RockFilters.AsInteger( ( decimal ) 3.2d );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the double to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_ValidDouble()
+        {
+            var output = RockFilters.AsInteger( 3.0d );
+            Assert.Equal( output, 3 );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the double to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_InvalidDouble()
+        {
+            var output = RockFilters.AsInteger( 3.2d );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the string to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_ValidString()
+        {
+            var output = RockFilters.AsInteger( "3" );
+            Assert.Equal( output, 3 );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the string to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_InvalidString()
+        {
+            var output = RockFilters.AsInteger( "a" );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the decimal string to an integer.
+        /// </summary>
+        [Fact]
+        public void AsInteger_InvalidDecimalString()
+        {
+            var output = RockFilters.AsInteger( "3.0" );
+            Assert.Null( output );
+        }
+
+        #endregion
+
+        #region AsDecimal
+
+        /// <summary>
+        /// For use in Lava -- should not cast the null to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_Null()
+        {
+            var output = RockFilters.AsDecimal( null );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the true boolean to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_InvalidBoolean()
+        {
+            var output = RockFilters.AsDecimal( true );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the integer to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_ValidInteger()
+        {
+            var output = RockFilters.AsDecimal( 3 );
+            Assert.Equal( output, ( decimal ) 3.0d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the decimal to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_ValidDecimal()
+        {
+            var output = RockFilters.AsDecimal( ( decimal ) 3.2d );
+            Assert.Equal( output, ( decimal ) 3.2d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the double to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_ValidDouble()
+        {
+            var output = RockFilters.AsDecimal( 3.141592d );
+            Assert.Equal( output, ( decimal ) 3.141592d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the string to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_ValidString()
+        {
+            var output = RockFilters.AsDecimal( "3.14" );
+            Assert.Equal( output, ( decimal )3.14d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the string to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_InvalidString()
+        {
+            var output = RockFilters.AsDecimal( "a" );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the decimal string to a decimal.
+        /// </summary>
+        [Fact]
+        public void AsDecimal_InvalidDecimalString()
+        {
+            var output = RockFilters.AsInteger( "3.0.2" );
+            Assert.Null( output );
+        }
+
+        #endregion
+
+        #region AsDouble
+
+        /// <summary>
+        /// For use in Lava -- should not cast the null to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_Null()
+        {
+            var output = RockFilters.AsDouble( null );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the true boolean to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_InvalidBoolean()
+        {
+            var output = RockFilters.AsDouble( true );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the integer to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidInteger()
+        {
+            var output = RockFilters.AsDouble( 3 );
+            Assert.Equal( output, 3.0d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the decimal to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidDecimal()
+        {
+            var output = RockFilters.AsDouble( ( decimal ) 3.2d );
+            Assert.Equal( output, ( double ) 3.2d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the double to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidDouble()
+        {
+            var output = RockFilters.AsDouble( 3.141592d );
+            Assert.Equal( output, ( double ) 3.141592d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidString()
+        {
+            var output = RockFilters.AsDouble( "3.14" );
+            Assert.Equal( output, ( double ) 3.14d );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_InvalidString()
+        {
+            var output = RockFilters.AsDouble( "a" );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the decimal string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_InvalidDecimalString()
+        {
+            var output = RockFilters.AsDouble( "3.0.2" );
+            Assert.Null( output );
+        }
+
+        #endregion
+
+        #region AsString
+
+        /// <summary>
+        /// For use in Lava -- should not cast the null to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_Null()
+        {
+            var output = RockFilters.AsString( null );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the false boolean to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidFalseBoolean()
+        {
+            var output = RockFilters.AsString( false );
+            Assert.Equal( output, "False" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the true boolean to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidTrueBoolean()
+        {
+            var output = RockFilters.AsString( true );
+            Assert.Equal( output, "True" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the integer to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidInteger()
+        {
+            var output = RockFilters.AsString( 3 );
+            Assert.Equal( output, "3" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the decimal to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidDecimal()
+        {
+            var output = RockFilters.AsString( ( decimal ) 3.2d );
+            Assert.Equal( output, "3.2" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the double to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidDouble()
+        {
+            var output = RockFilters.AsString( 3.141592d );
+            Assert.Equal( output, "3.141592" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the string to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidDoubleString()
+        {
+            var output = RockFilters.AsString( "3.14" );
+            Assert.Equal( output, "3.14" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the string to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_ValidString()
+        {
+            var output = RockFilters.AsString( "abc" );
+            Assert.Equal( output, "abc" );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the datetime to a string.
+        /// </summary>
+        [Fact]
+        public void AsString_DateTime()
+        {
+            DateTime dt = new DateTime( 2017, 3, 7, 15, 4, 33 );
+            var output = RockFilters.AsString( dt );
+            Assert.Equal( output, dt.ToString() );
+        }
+
+        #endregion
+
+        #region AsDateTime
+
+        /// <summary>
+        /// For use in Lava -- should not cast the null to an datetime.
+        /// </summary>
+        [Fact]
+        public void AsDateTime_Null()
+        {
+            var output = RockFilters.AsDateTime( null );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not cast the string to an datetime.
+        /// </summary>
+        [Fact]
+        public void AsDateTime_InvalidString()
+        {
+            var output = RockFilters.AsDateTime( "1/1/1 50:00" );
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should cast the string to an datetime.
+        /// </summary>
+        [Fact]
+        public void AsDateTime_ValidString()
+        {
+            DateTime dt = new DateTime( 2017, 3, 7, 15, 4, 33 );
+            var output = RockFilters.AsDateTime( dt.ToString() );
+            Assert.Equal( output, dt );
+        }
+
+        #endregion
+
         /// <summary>
         /// For use in Lava -- should return next occurrence for Rock's standard Saturday 4:30PM service datetime.
         /// </summary>

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -3148,7 +3148,7 @@ namespace Rock.Lava
                 return null;
             }
 
-            return input.ToString().AsIntegerOrNull();
+            return input.ToString().AsDecimalOrNull();
         }
 
         /// <summary>

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -3106,6 +3106,96 @@ namespace Rock.Lava
             return result;
         }
 
+        /// <summary>
+        /// Casts the input as a boolean value.
+        /// </summary>
+        /// <param name="input">The input value to be parsed into boolean form.</param>
+        /// <returns>A boolean value or null if the cast could not be performed.</returns>
+        public static bool? AsBoolean( object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            return input.ToString().AsBooleanOrNull();
+        }
+
+        /// <summary>
+        /// Casts the input as an integer value.
+        /// </summary>
+        /// <param name="input">The input value to be parsed into integer form.</param>
+        /// <returns>An integer value or null if the cast could not be performed.</returns>
+        public static int? AsInteger( object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            return input.ToString().AsIntegerOrNull();
+        }
+
+        /// <summary>
+        /// Casts the input as a decimal value.
+        /// </summary>
+        /// <param name="input">The input value to be parsed into decimal form.</param>
+        /// <returns>A decimal value or null if the cast could not be performed.</returns>
+        public static decimal? AsDecimal( object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            return input.ToString().AsIntegerOrNull();
+        }
+
+        /// <summary>
+        /// Casts the input as a double value.
+        /// </summary>
+        /// <param name="input">The input value to be parsed into double form.</param>
+        /// <returns>A double value or null if the cast could not be performed.</returns>
+        public static double? AsDouble( object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            return input.ToString().AsDoubleOrNull();
+        }
+
+        /// <summary>
+        /// Casts the input as a string value.
+        /// </summary>
+        /// <param name="input">The input value to be parsed into string form.</param>
+        /// <returns>A string value or null if the cast could not be performed.</returns>
+        public static string AsString( object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            return input.ToString();
+        }
+
+        /// <summary>
+        /// Casts the input as a DateTime value.
+        /// </summary>
+        /// <param name="input">The input value to be parsed into DateTime form.</param>
+        /// <returns>A DateTime value or null if the cast could not be performed.</returns>
+        public static DateTime? AsDateTime( object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            return input.ToString().AsDateTime();
+        }
+
         #endregion
 
         #region Array Filters


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Sometimes there is a need to put a value in a very specific date type but often we get these values as strings. A few examples are building custom JSON when we want the value to be a true integer, or when passing values to other filters.

One example filter is DateAdd, which requires a true integer value. The following does not work:
```
{% assign interval = '1' %}
{% assign tomorrow = 'Now' | DateAdd:interval,'d' %}
```

# Goal
_What will this pull request achieve and how will this fix the problem?_

Supply new Lava Filters to cast values to specific data types. For example, the above failing example could be rewritten as:
```
{% assign interval = '1' | AsInteger %}
{% assign tomorrow = 'Now' | DateAdd:interval,'d' %}
```

# Strategy
_How have you implemented your solution?_

Added the following new Lava filters to the standard filter list using the corresponding C# functions:
* AsBoolean
* AsInteger
* AsDecimal
* AsDouble
* AsString
* AsDateTime

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

Unit tests included.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

The Lava filters documentation at https://www.rockrms.com/page/565 will need to be updated to include reference information on the new filters available.