### PR TITLE
- Registration Entry no longer inserts nicknames into Registration Text Attribute form fields ( Fixes #2040).

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -1425,8 +1425,9 @@ namespace RockWeb.Blocks.Event
                         foreach( var field in RegistrationTemplate.Forms
                             .SelectMany( f => f.Fields )
                             .Where( f => 
-                                f.PersonFieldType == RegistrationPersonFieldType.FirstName ||
-                                f.PersonFieldType == RegistrationPersonFieldType.LastName ) )
+                                ( f.PersonFieldType == RegistrationPersonFieldType.FirstName ||
+                                f.PersonFieldType == RegistrationPersonFieldType.LastName ) 
+                                && f.Attribute == null ) )
                         {
                             registrant.FieldValues.AddOrReplace( field.Id, 
                                 new FieldValueObject( field, field.PersonFieldType == RegistrationPersonFieldType.FirstName ? CurrentPerson.NickName : CurrentPerson.LastName ) );
@@ -4736,8 +4737,9 @@ namespace RockWeb.Blocks.Event
                             object dbValue = null;
 
                             if ( field.ShowCurrentValue ||
-                                field.PersonFieldType == RegistrationPersonFieldType.FirstName ||
-                                field.PersonFieldType == RegistrationPersonFieldType.LastName )
+                                ( ( field.PersonFieldType == RegistrationPersonFieldType.FirstName || 
+                                field.PersonFieldType == RegistrationPersonFieldType.LastName ) && 
+                                field.Attribute == null ) )
                             {
                                 dbValue = registrant.GetRegistrantValue( null, person, family, field, rockContext );
                             }

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -1426,8 +1426,8 @@ namespace RockWeb.Blocks.Event
                             .SelectMany( f => f.Fields )
                             .Where( f => 
                                 ( f.PersonFieldType == RegistrationPersonFieldType.FirstName ||
-                                f.PersonFieldType == RegistrationPersonFieldType.LastName ) 
-                                && f.Attribute == null ) )
+                                f.PersonFieldType == RegistrationPersonFieldType.LastName ) &&
+                                f.FieldSource == RegistrationFieldSource.PersonField ) )
                         {
                             registrant.FieldValues.AddOrReplace( field.Id, 
                                 new FieldValueObject( field, field.PersonFieldType == RegistrationPersonFieldType.FirstName ? CurrentPerson.NickName : CurrentPerson.LastName ) );
@@ -4738,8 +4738,8 @@ namespace RockWeb.Blocks.Event
 
                             if ( field.ShowCurrentValue ||
                                 ( ( field.PersonFieldType == RegistrationPersonFieldType.FirstName || 
-                                field.PersonFieldType == RegistrationPersonFieldType.LastName ) && 
-                                field.Attribute == null ) )
+                                field.PersonFieldType == RegistrationPersonFieldType.LastName ) &&
+                                field.FieldSource == RegistrationFieldSource.PersonField ) )
                             {
                                 dbValue = registrant.GetRegistrantValue( null, person, family, field, rockContext );
                             }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_
Registration Text Attributes were being populated with the current person's nickname ( see [Jim Michael's issue](https://github.com/SparkDevNetwork/Rock/issues/2040) for more details).

# Goal
_What will this pull request achieve and how will this fix the problem?_
The issue is that even when RegistrationTemplateFormFields are not tied to a person field, they are still saved with a PersonFieldType enum value corresponding to FirstName, '0' (see below), so when the RegistrationEntry block crawls for fields of type FirstName or LastName, it picks up those fields as well. This pull request now makes the code check whether the field is actually tied to a PersonField or not.
![image](https://cloud.githubusercontent.com/assets/5482014/23869172/4e352afa-07df-11e7-9dff-8226dd96dc70.png)


# Strategy
_How have you implemented your solution?_
There are now additional checks in the places that RegistrationEntry crawls for the FirstName and LastName field types, where the code verifies that the field is a PersonField
