### PR TITLE
Changed UI to support inactivating check-in groups

### DIFF
--- a/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinAreaRow.cs
+++ b/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinAreaRow.cs
@@ -38,7 +38,6 @@ namespace Rock.Web.UI.Controls
 
         private LinkButton _lbAddArea;
         private LinkButton _lbAddGroup;
-        private LinkButton _lblDeleteArea;
 
         /// <summary>
         /// Gets the group type unique identifier.
@@ -199,6 +198,7 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
             _lbAddArea.CssClass = "btn btn-xs btn-default checkin-area-add-area";
             _lbAddArea.Click += lbAddArea_Click;
             _lbAddArea.CausesValidation = false;
+            _lbAddArea.ToolTip = "Add New Area";
             _lbAddArea.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-folder-open'></i>" } );
 
             _lbAddGroup = new LinkButton();
@@ -206,22 +206,14 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
             _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-area-add-group";
             _lbAddGroup.Click += lbAddGroup_Click;
             _lbAddGroup.CausesValidation = false;
+            _lbAddGroup.ToolTip = "Add New Group";
             _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
-
-            _lblDeleteArea = new LinkButton();
-            _lblDeleteArea.CausesValidation = false;
-            _lblDeleteArea.ID = this.ID + "_lblDeleteArea";
-            _lblDeleteArea.CssClass = "btn btn-xs btn-danger";
-            _lblDeleteArea.Click += lblDeleteArea_Click;
-            _lblDeleteArea.Controls.Add( new LiteralControl { Text = "<i class='fa fa-times'></i>" } );
-            _lblDeleteArea.Attributes["onclick"] = string.Format( "javascript: return Rock.dialogs.confirmDelete(event, '{0}', '{1}');", "check-in area", "Once saved, you will lose all attendance data." );
 
             Controls.Add( _hfGroupTypeGuid );
             Controls.Add( _lblAreaRowName );
 
             Controls.Add( _lbAddArea );
             Controls.Add( _lbAddGroup );
-            Controls.Add( _lblDeleteArea );
         }
 
         /// <summary>
@@ -251,8 +243,6 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
             _lbAddArea.RenderControl( writer );
             writer.Write( " " );
             _lbAddGroup.RenderControl( writer );
-            writer.Write( " " );
-            _lblDeleteArea.RenderControl( writer );
 
             writer.RenderEndTag();  // Div
             writer.RenderEndTag();  // Section

--- a/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinGroup.cs
+++ b/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinGroup.cs
@@ -38,6 +38,7 @@ namespace Rock.Web.UI.Controls
         private Literal _lblGroupName;
 
         private DataTextBox _tbGroupName;
+        private RockCheckBox _cbIsActive;
         private PlaceHolder _phGroupAttributes;
         private Grid _gLocations;
 
@@ -216,7 +217,7 @@ namespace Rock.Web.UI.Controls
         public void GetGroupValues( Group group )
         {
             group.Name = _tbGroupName.Text;
-
+            group.IsActive = _cbIsActive.Checked;
             Rock.Attribute.Helper.GetEditValues( _phGroupAttributes, group );
         }
 
@@ -239,6 +240,7 @@ namespace Rock.Web.UI.Controls
                 _hfGroupId.Value = value.Id.ToString();
                 _hfGroupTypeId.Value = value.GroupTypeId.ToString();
                 _tbGroupName.Text = value.Name;
+                _cbIsActive.Checked = value.IsActive;
 
                 CreateGroupAttributeControls( value, rockContext );
             }
@@ -267,6 +269,10 @@ namespace Rock.Web.UI.Controls
             _tbGroupName.ID = this.ID + "_tbGroupName";
             _tbGroupName.Label = "Check-in Group Name";
 
+            _cbIsActive = new RockCheckBox();
+            _cbIsActive.ID = this.ID + "_cbIsActive";
+            _cbIsActive.Text = "Active";
+
             // set label when they exit the edit field
             _tbGroupName.Attributes["onblur"] = string.Format( "javascript: $('#{0}').text($(this).val());", _lblGroupName.ID );
             _tbGroupName.SourceTypeName = "Rock.Model.Group, Rock";
@@ -280,6 +286,7 @@ namespace Rock.Web.UI.Controls
             Controls.Add( _hfGroupTypeId );
             Controls.Add( _lblGroupName );
             Controls.Add( _tbGroupName );
+            Controls.Add( _cbIsActive );
             Controls.Add( _phGroupAttributes );
 
             // Locations Grid
@@ -339,6 +346,7 @@ namespace Rock.Web.UI.Controls
                 writer.RenderEndTag();
 
                 _tbGroupName.RenderControl( writer );
+                _cbIsActive.RenderBaseControl( writer );
                 _phGroupAttributes.RenderControl( writer );
 
                 writer.WriteLine( "<h3>Locations</h3>" );

--- a/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinGroupRow.cs
+++ b/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinGroupRow.cs
@@ -38,8 +38,6 @@ namespace Rock.Web.UI.Controls
         private Label _lblGroupRowName;
 
         private LinkButton _lbAddGroup;
-        private LinkButton _lbReactivateGroup;
-        private LinkButton _lblDeleteGroup;
 
         /// <summary>
         /// Gets the group type unique identifier.
@@ -180,44 +178,15 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
             _lblGroupRowName.ID = this.ID + "_lblGroupRowName";
             Controls.Add( _lblGroupRowName );
 
-            if ( _group != null && _group.IsActive )
-            {
-                _lbAddGroup = new LinkButton();
-                _lbAddGroup.ID = this.ID + "_lbAddGroup";
-                _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-group-add-group";
-                _lbAddGroup.Click += lbAddGroup_Click;
-                _lbAddGroup.CausesValidation = false;
-                _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
-                Controls.Add( _lbAddGroup );
 
-                _lblDeleteGroup = new LinkButton();
-                _lblDeleteGroup.CausesValidation = false;
-                _lblDeleteGroup.ID = this.ID + "_lblDeleteGroup";
-                _lblDeleteGroup.CssClass = "btn btn-xs btn-danger";
-                _lblDeleteGroup.Click += lblDeleteGroup_Click;
-                _lblDeleteGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-times'></i>" } );
-                _lblDeleteGroup.Attributes["onclick"] = string.Format( "javascript: return Rock.dialogs.confirmPreventOnCancel(event, '{0}');", "Are you sure you wish to remove this group? Note: if the group has attendance records, it will be deactivated instead of deleted." );
-                Controls.Add( _lblDeleteGroup );
-            }
-            else
-            {
-                _lbReactivateGroup = new LinkButton();
-                _lbReactivateGroup.ID = this.ID + "_lbReactivateGroup";
-                _lbReactivateGroup.CssClass = "btn btn-xs btn-default checkin-reactivate-group";
-                _lbReactivateGroup.Click += lbReactivateGroup_Click;
-                _lbReactivateGroup.CausesValidation = false;
-                _lbReactivateGroup.Controls.Add( new LiteralControl { Text = "Reactivate" } );
-                Controls.Add( _lbReactivateGroup );
-
-                _lblDeleteGroup = new LinkButton();
-                _lblDeleteGroup.CausesValidation = false;
-                _lblDeleteGroup.ID = this.ID + "_lblDeleteGroup";
-                _lblDeleteGroup.CssClass = "btn btn-xs btn-danger";
-                _lblDeleteGroup.Click += lblDeleteGroup_Click;
-                _lblDeleteGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-times'></i>" } );
-                _lblDeleteGroup.Attributes["onclick"] = string.Format( "javascript: return Rock.dialogs.confirmDelete(event, '{0}', '{1}');", "check-in group", "Once completed, you will lose all attendance data." );
-                Controls.Add( _lblDeleteGroup );
-            }
+            _lbAddGroup = new LinkButton();
+            _lbAddGroup.ID = this.ID + "_lbAddGroup";
+            _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-group-add-group";
+            _lbAddGroup.Click += lbAddGroup_Click;
+            _lbAddGroup.CausesValidation = false;
+            _lbAddGroup.ToolTip = "Add New Group";
+            _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
+            Controls.Add( _lbAddGroup );
         }
 
         /// <summary>
@@ -248,16 +217,6 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
             {
                 _lbAddGroup.RenderControl( writer );
                 writer.Write( " " );
-            }
-
-            if ( _lbReactivateGroup != null )
-            {
-                _lbReactivateGroup.RenderControl( writer );
-            }
-
-            if ( _lblDeleteGroup != null )
-            {
-                _lblDeleteGroup.RenderControl( writer );
             }
 
             writer.RenderEndTag();  // Div
@@ -300,19 +259,6 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
         }
 
         /// <summary>
-        /// Handles the Click event of the lbAddGroup control.
-        /// </summary>
-        /// <param name="sender">The source of the event.</param>
-        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        protected void lbReactivateGroup_Click( object sender, EventArgs e )
-        {
-            if ( ReactivateGroupClick != null )
-            {
-                ReactivateGroupClick( this, e );
-            }
-        }
-
-        /// <summary>
         /// Handles the Click event of the lblDeleteGroup control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
@@ -329,11 +275,6 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
         /// Occurs when [add group click].
         /// </summary>
         public event EventHandler AddGroupClick;
-
-        /// <summary>
-        /// Occurs when [undelete group click].
-        /// </summary>
-        public event EventHandler ReactivateGroupClick;
 
         /// <summary>
         /// Occurs when [delete group click].

--- a/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx
+++ b/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx
@@ -74,6 +74,7 @@
                             <Rock:NotificationBox ID="nbGroupsWarning" runat="server" NotificationBoxType="Warning" Text="Please select at least one group." Visible="false"/>
                             
                             <div class="grouplist-actions rollover-container" id="divGroupListActions" runat="server">
+                                <Rock:Toggle runat="server" ID="cbShowInactive" CssClass="pull-right" ButtonSizeCssClass="btn-xs" OnCssClass="btn-primary" OffCssClass="btn-primary" OnText="All Groups" OffText="Active Groups" AutoPostBack="true" OnCheckedChanged="cbShowInactive_CheckedChanged" />
                                 <span class="h4 js-checkbox-selector cursor-pointer">Groups</span>
                                 <span class="rollover-item" id="pnlRolloverConfig" runat="server">
                                     <i class="fa fa-gear clickable js-show-config" onclick="$(this).closest('.js-groups-container').find('.js-groups-config-panel').slideToggle()"></i>

--- a/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx.cs
@@ -73,6 +73,8 @@ namespace RockWeb.Blocks.CheckIn
         {
             base.OnInit( e );
 
+            cbShowInactive.Checked = GetUserPreference( BlockCache.Guid.ToString() + "_showInactive" ).AsBoolean();
+
             // Setup for being able to copy text to clipboard
             RockPage.AddScriptLink( this.Page, "~/Scripts/ZeroClipboard/ZeroClipboard.js" );
             string script = string.Format( @"
@@ -281,7 +283,9 @@ namespace RockWeb.Blocks.CheckIn
                 if ( ddlAttendanceType.SelectedGroupTypeId.HasValue )
                 {
                     return new GroupTypeService( _rockContext )
-                        .GetAllAssociatedDescendentsOrdered( ddlAttendanceType.SelectedGroupTypeId.Value )
+                        .GetChildGroupTypes( ddlAttendanceType.SelectedGroupTypeId.Value )
+                        .OrderBy( a => a.Order )
+                        .ThenBy( a => a.Name )
                         .ToList();
                 }
             }
@@ -351,7 +355,7 @@ namespace RockWeb.Blocks.CheckIn
                             {
                                 lcAttendance.Options.xaxis.tickSize = null;
                             }
-                            
+
                             lcAttendance.TooltipFormatter = @"
 function(item) {
     var itemDate = new Date(item.series.chartData[item.dataIndex].DateTimeStamp);
@@ -529,7 +533,6 @@ function(item) {
             string keyPrefix = string.Format( "attendance-reporting-{0}-", this.BlockId );
 
             ddlAttendanceType.SelectedGroupTypeId = GetSetting( keyPrefix, "TemplateGroupTypeId" ).AsIntegerOrNull();
-            cbIncludeGroupsWithoutSchedule.Checked = this.GetBlockUserPreference( "IncludeGroupsWithoutSchedule" ).AsBooleanOrNull() ?? true;
             BuildGroupTypesUI();
 
             string slidingDateRangeSettings = GetSetting( keyPrefix, "SlidingDateRange" );
@@ -716,10 +719,18 @@ function(item) {
             gChartAttendance.Columns[1].Visible = graphBy != AttendanceGraphBy.Total;
             switch ( graphBy )
             {
-                case AttendanceGraphBy.Group: gChartAttendance.Columns[1].HeaderText = "Group"; break;
-                case AttendanceGraphBy.Campus: gChartAttendance.Columns[1].HeaderText = "Campus"; break;
-                case AttendanceGraphBy.Location: gChartAttendance.Columns[1].HeaderText = "Location"; break;
-                case AttendanceGraphBy.Schedule: gChartAttendance.Columns[1].HeaderText = "Schedule"; break;
+                case AttendanceGraphBy.Group:
+                    gChartAttendance.Columns[1].HeaderText = "Group";
+                    break;
+                case AttendanceGraphBy.Campus:
+                    gChartAttendance.Columns[1].HeaderText = "Campus";
+                    break;
+                case AttendanceGraphBy.Location:
+                    gChartAttendance.Columns[1].HeaderText = "Location";
+                    break;
+                case AttendanceGraphBy.Schedule:
+                    gChartAttendance.Columns[1].HeaderText = "Schedule";
+                    break;
             }
 
             SortProperty sortProperty = gChartAttendance.SortProperty;
@@ -750,11 +761,11 @@ function(item) {
 
             // Adjust the start/end times to reflect the attendance dates who's SundayDate value would fall between the date range selected
             DateTime start = dateRange.Start.HasValue ?
-                dateRange.Start.Value.Date.AddDays( 0 - ( dateRange.Start.Value.DayOfWeek == DayOfWeek.Sunday ? 6 : (int)dateRange.Start.Value.DayOfWeek - 1 ) ) :
+                dateRange.Start.Value.Date.AddDays( 0 - ( dateRange.Start.Value.DayOfWeek == DayOfWeek.Sunday ? 6 : ( int ) dateRange.Start.Value.DayOfWeek - 1 ) ) :
                 new DateTime( 1900, 1, 1 );
 
             DateTime end = dateRange.End.HasValue ?
-                dateRange.End.Value.AddDays( 0 - (int)dateRange.End.Value.DayOfWeek ) :
+                dateRange.End.Value.AddDays( 0 - ( int ) dateRange.End.Value.DayOfWeek ) :
                 new DateTime( 2100, 1, 1, 23, 59, 59 );
 
             if ( end < start )
@@ -893,7 +904,7 @@ function(item) {
 
                     foreach ( DataRow row in dtAttendeeDates.Rows )
                     {
-                        int personId = (int)row["PersonId"];
+                        int personId = ( int ) row["PersonId"];
                         allAttendeeVisits.AddOrIgnore( personId, new AttendeeVisits() );
                         var result = allAttendeeVisits[personId];
                         result.PersonId = personId;
@@ -901,9 +912,15 @@ function(item) {
                         DateTime summaryDate = DateTime.MinValue;
                         switch ( groupBy )
                         {
-                            case ChartGroupBy.Week: summaryDate = (DateTime)row["SundayDate"]; break;
-                            case ChartGroupBy.Month: summaryDate = (DateTime)row["MonthDate"]; break;
-                            case ChartGroupBy.Year: summaryDate = (DateTime)row["YearDate"]; break;
+                            case ChartGroupBy.Week:
+                                summaryDate = ( DateTime ) row["SundayDate"];
+                                break;
+                            case ChartGroupBy.Month:
+                                summaryDate = ( DateTime ) row["MonthDate"];
+                                break;
+                            case ChartGroupBy.Year:
+                                summaryDate = ( DateTime ) row["YearDate"];
+                                break;
                         }
                         if ( !result.AttendanceSummary.Contains( summaryDate ) )
                         {
@@ -942,7 +959,7 @@ function(item) {
                         var missedResults = new Dictionary<int, AttendeeResult>();
                         foreach ( DataRow row in dtAttendeeDatesMissed.Rows )
                         {
-                            int personId = (int)row["PersonId"];
+                            int personId = ( int ) row["PersonId"];
                             missedResults.AddOrIgnore( personId, new AttendeeResult() );
                             var missedResult = missedResults[personId];
                             missedResult.PersonId = personId;
@@ -950,9 +967,15 @@ function(item) {
                             DateTime summaryDate = DateTime.MinValue;
                             switch ( groupBy )
                             {
-                                case ChartGroupBy.Week: summaryDate = (DateTime)row["SundayDate"]; break;
-                                case ChartGroupBy.Month: summaryDate = (DateTime)row["MonthDate"]; break;
-                                case ChartGroupBy.Year: summaryDate = (DateTime)row["YearDate"]; break;
+                                case ChartGroupBy.Week:
+                                    summaryDate = ( DateTime ) row["SundayDate"];
+                                    break;
+                                case ChartGroupBy.Month:
+                                    summaryDate = ( DateTime ) row["MonthDate"];
+                                    break;
+                                case ChartGroupBy.Year:
+                                    summaryDate = ( DateTime ) row["YearDate"];
+                                    break;
                             }
 
                             if ( !missedResult.AttendanceSummary.Contains( summaryDate ) )
@@ -991,7 +1014,7 @@ function(item) {
 
                     foreach ( DataRow row in dtNonAttenders.Rows )
                     {
-                        int personId = (int)row["Id"];
+                        int personId = ( int ) row["Id"];
 
                         var result = new AttendeeResult();
                         result.PersonId = personId;
@@ -1008,7 +1031,7 @@ function(item) {
 
                         if ( includeParents )
                         {
-                            result.ParentId = (int)row["ParentId"];
+                            result.ParentId = ( int ) row["ParentId"];
                             var parent = new PersonInfo();
                             parent.NickName = row["ParentNickName"].ToString();
                             parent.LastName = row["ParentLastName"].ToString();
@@ -1021,7 +1044,7 @@ function(item) {
                         if ( includeChildren )
                         {
                             var child = new PersonInfo();
-                            result.ChildId = (int)row["ChildId"];
+                            result.ChildId = ( int ) row["ChildId"];
                             child.NickName = row["ChildNickName"].ToString();
                             child.LastName = row["ChildLastName"].ToString();
                             child.Email = row["ChildEmail"].ToString();
@@ -1092,10 +1115,10 @@ function(item) {
                 // Add the First Visit information
                 foreach ( DataRow row in dtAttendeeFirstDates.Rows )
                 {
-                    int personId = (int)row["PersonId"];
+                    int personId = ( int ) row["PersonId"];
                     if ( allAttendeeVisits.ContainsKey( personId ) )
                     {
-                        allAttendeeVisits[personId].FirstVisits.Add( (DateTime)row["StartDate"] );
+                        allAttendeeVisits[personId].FirstVisits.Add( ( DateTime ) row["StartDate"] );
                     }
                 }
 
@@ -1113,7 +1136,7 @@ function(item) {
                 {
                     foreach ( DataRow row in dtAttendeeLastAttendance.Rows )
                     {
-                        int personId = (int)row["PersonId"];
+                        int personId = ( int ) row["PersonId"];
                         if ( allAttendeeVisits.ContainsKey( personId ) )
                         {
                             var result = allAttendeeVisits[personId];
@@ -1126,7 +1149,7 @@ function(item) {
                                 lastAttendance.RoleName = row["RoleName"].ToString();
                                 lastAttendance.InGroup = !string.IsNullOrWhiteSpace( lastAttendance.RoleName );
                                 lastAttendance.ScheduleId = row["ScheduleId"] as int?;
-                                lastAttendance.StartDateTime = (DateTime)row["StartDateTime"];
+                                lastAttendance.StartDateTime = ( DateTime ) row["StartDateTime"];
                                 lastAttendance.LocationId = row["LocationId"] as int?;
                                 lastAttendance.LocationName = row["LocationName"].ToString();
                                 result.LastVisit = lastAttendance;
@@ -1142,7 +1165,7 @@ function(item) {
 
                     foreach ( DataRow row in dtAttendees.Rows )
                     {
-                        int personId = (int)row["Id"];
+                        int personId = ( int ) row["Id"];
                         if ( allAttendeeVisits.ContainsKey( personId ) )
                         {
                             var result = new AttendeeResult( allAttendeeVisits[personId] );
@@ -1158,7 +1181,7 @@ function(item) {
 
                             if ( includeParents )
                             {
-                                result.ParentId = (int)row["ParentId"];
+                                result.ParentId = ( int ) row["ParentId"];
                                 var parent = new PersonInfo();
                                 parent.NickName = row["ParentNickName"].ToString();
                                 parent.LastName = row["ParentLastName"].ToString();
@@ -1171,7 +1194,7 @@ function(item) {
                             if ( includeChildren )
                             {
                                 var child = new PersonInfo();
-                                result.ChildId = (int)row["ChildId"];
+                                result.ChildId = ( int ) row["ChildId"];
                                 child.NickName = row["ChildNickName"].ToString();
                                 child.LastName = row["ChildLastName"].ToString();
                                 child.Email = row["ChildEmail"].ToString();
@@ -1198,10 +1221,10 @@ function(item) {
                 // Add the first visit dates for people
                 foreach ( DataRow row in dtAttendeeFirstDates.Rows )
                 {
-                    int personId = (int)row["PersonId"];
+                    int personId = ( int ) row["PersonId"];
                     foreach ( var result in allResults.Where( r => r.PersonId == personId ) )
                     {
-                        result.FirstVisits.Add( (DateTime)row["StartDate"] );
+                        result.FirstVisits.Add( ( DateTime ) row["StartDate"] );
                     }
                 }
 
@@ -1210,7 +1233,7 @@ function(item) {
                 {
                     foreach ( DataRow row in dtAttendeeLastAttendance.Rows )
                     {
-                        int personId = (int)row["PersonId"];
+                        int personId = ( int ) row["PersonId"];
                         foreach ( var result in allResults.Where( r => r.PersonId == personId ) )
                         {
                             if ( result.LastVisit == null )
@@ -1222,7 +1245,7 @@ function(item) {
                                 lastAttendance.RoleName = row["RoleName"].ToString();
                                 lastAttendance.InGroup = !string.IsNullOrWhiteSpace( lastAttendance.RoleName );
                                 lastAttendance.ScheduleId = row["ScheduleId"] as int?;
-                                lastAttendance.StartDateTime = (DateTime)row["StartDateTime"];
+                                lastAttendance.StartDateTime = ( DateTime ) row["StartDateTime"];
                                 lastAttendance.LocationId = row["LocationId"] as int?;
                                 lastAttendance.LocationName = row["LocationName"].ToString();
                                 result.LastVisit = lastAttendance;
@@ -1235,7 +1258,7 @@ function(item) {
             // Begin formatting the columns
             var qryResult = allResults.AsQueryable();
 
-            var personUrlFormatString = ( (RockPage)this.Page ).ResolveRockUrl( "~/Person/{0}" );
+            var personUrlFormatString = ( ( RockPage ) this.Page ).ResolveRockUrl( "~/Person/{0}" );
 
             var personHyperLinkField = gAttendeesAttendance.Columns.OfType<HyperLinkField>().FirstOrDefault( a => a.HeaderText == "Name" );
             if ( personHyperLinkField != null )
@@ -1702,7 +1725,7 @@ function(item) {
                 bool isExporting = _currentlyExporting;
                 if ( !isExporting && e is RockGridViewRowEventArgs )
                 {
-                    isExporting = ( (RockGridViewRowEventArgs)e ).IsExporting;
+                    isExporting = ( ( RockGridViewRowEventArgs ) e ).IsExporting;
                 }
 
                 if ( _personPhoneNumbers != null && _personPhoneNumbers.ContainsKey( currentPersonId ) )
@@ -1749,11 +1772,11 @@ function(item) {
                 int attendanceSummaryCount = personDates.AttendanceSummary.Count();
                 lAttendanceCount.Text = attendanceSummaryCount.ToString();
 
-                int? attendencePossibleCount = _possibleAttendances != null ? _possibleAttendances.Count() : (int?)null;
+                int? attendencePossibleCount = _possibleAttendances != null ? _possibleAttendances.Count() : ( int? ) null;
 
                 if ( attendencePossibleCount.HasValue && attendencePossibleCount > 0 )
                 {
-                    var attendancePerPossibleCount = (decimal)attendanceSummaryCount / attendencePossibleCount.Value;
+                    var attendancePerPossibleCount = ( decimal ) attendanceSummaryCount / attendencePossibleCount.Value;
                     if ( attendancePerPossibleCount > 1 )
                     {
                         attendancePerPossibleCount = 1;
@@ -1799,49 +1822,48 @@ function(item) {
             {
                 _addedGroupTypeIds.Add( groupType.Id );
 
-                var groups = groupType.Groups
-                    .Where( g => 
-                        g.IsActive &&
-                        ( !g.ParentGroupId.HasValue || ( g.ParentGroup.GroupTypeId != groupType.Id ) ) )
-                    .OrderBy( a => a.Order )
-                    .ThenBy( a => a.Name )
-                    .ToList();
+                bool showInactive = GetUserPreference( BlockCache.Guid.ToString() + "_showInactive" ).AsBoolean();
 
-                var childGroupTypes = groupType.ChildGroupTypes.OrderBy( a => a.Order ).ThenBy( a => a.Name ).ToList();
-
-                if ( groups.Any() )
+                if ( ( groupType.Groups.Any() && showInactive ) || groupType.Groups.Where( g => g.IsActive ).Any() )
                 {
                     bool showGroupAncestry = GetAttributeValue( "ShowGroupAncestry" ).AsBoolean( true );
 
                     var groupService = new GroupService( _rockContext );
 
-                    var cblGroupTypeGroups = new RockCheckBoxList { ID = "cblGroupTypeGroups" + groupType.Id, FormGroupCssClass= "js-groups-container" };
+                    var cblGroupTypeGroups = new RockCheckBoxList { ID = "cblGroupTypeGroups" + groupType.Id };
 
                     cblGroupTypeGroups.Label = groupType.Name;
                     cblGroupTypeGroups.Items.Clear();
 
                     // limit to Groups that don't have a Parent, or the ParentGroup is a different grouptype so we don't end up with infinite recursion
-                    foreach ( var group in groups )
+                    foreach ( var group in groupType.Groups
+                        .Where( g => !g.ParentGroupId.HasValue || ( g.ParentGroup.GroupTypeId != groupType.Id ) )
+                        .OrderBy( a => a.Order )
+                        .ThenBy( a => a.Name )
+                        .ToList() )
                     {
-                        AddGroupControls( group, cblGroupTypeGroups, groupService, showGroupAncestry );
+                        if ( group.IsActive || showInactive )
+                        {
+                            AddGroupControls( group, cblGroupTypeGroups, groupService, showGroupAncestry );
+                        }
                     }
 
                     liGroupTypeItem.Controls.Add( cblGroupTypeGroups );
                 }
                 else
                 {
-                    if ( childGroupTypes.Any() )
+                    if ( groupType.ChildGroupTypes.Any() )
                     {
                         liGroupTypeItem.Controls.Add( new Label { Text = groupType.Name, ID = "lbl" + groupType.Name } );
                     }
                 }
 
-                if ( childGroupTypes.Any() )
+                if ( groupType.ChildGroupTypes.Any() )
                 {
                     var ulGroupTypeList = new HtmlGenericContainer( "ul", "list-unstyled" );
 
                     liGroupTypeItem.Controls.Add( ulGroupTypeList );
-                    foreach ( var childGroupType in childGroupTypes )
+                    foreach ( var childGroupType in groupType.ChildGroupTypes.OrderBy( a => a.Order ).ThenBy( a => a.Name ) )
                     {
                         var liChildGroupTypeItem = new HtmlGenericContainer( "li" );
                         liChildGroupTypeItem.ID = "liGroupTypeItem" + childGroupType.Id;
@@ -1861,13 +1883,13 @@ function(item) {
         /// <param name="showGroupAncestry">if set to <c>true</c> [show group ancestry].</param>
         private void AddGroupControls( Group group, RockCheckBoxList checkBoxList, GroupService service, bool showGroupAncestry )
         {
-            // Only show groups that actually have a schedule, unless they choose IncludeGroupsWithoutSchedule
+            // Only show groups that actually have a schedule
             if ( group != null )
             {
                 if ( !_addedGroupIds.Contains( group.Id ) )
                 {
                     _addedGroupIds.Add( group.Id );
-                    if ( cbIncludeGroupsWithoutSchedule.Checked || group.ScheduleId.HasValue || group.GroupLocations.Any( l => l.Schedules.Any() ) )
+                    if ( group.ScheduleId.HasValue || group.GroupLocations.Any( l => l.Schedules.Any() ) )
                     {
                         string displayName = showGroupAncestry ? service.GroupAncestorPathName( group.Id ) : group.Name;
                         checkBoxList.Items.Add( new ListItem( displayName, group.Id.ToString() ) );
@@ -2140,6 +2162,12 @@ function(item) {
             public int? LocationId { get; set; }
 
             public string LocationName { get; set; }
+        }
+
+        protected void cbShowInactive_CheckedChanged( object sender, EventArgs e )
+        {
+            SetUserPreference( BlockCache.Guid.ToString() + "_showInactive", cbShowInactive.Checked.ToString() );
+            BuildGroupTypesUI();
         }
 
         /// <summary>

--- a/RockWeb/Blocks/CheckIn/CheckinGroupList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/CheckinGroupList.ascx.cs
@@ -259,6 +259,8 @@ namespace RockWeb.Blocks.Checkin
                             {
                                 _addedGroupIds.Add( group.Id );
 
+                                var groupName = group.IsActive ? group.Name : group.Name + " (Inactive)";
+
                                 if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "GroupDetailPage" ) ) )
                                 {
                                     var groupPageParams = new Dictionary<string, string>();
@@ -267,11 +269,11 @@ namespace RockWeb.Blocks.Checkin
                                         groupPageParams.Add( "GroupTypeIds", Request["GroupTypeIds"] );
                                     }
                                     groupPageParams.Add( "GroupId", group.Id.ToString() );
-                                    groupContent.Append( string.Format( "<li><a href='{0}'>{1}</a></li>", LinkedPageUrl( "GroupDetailPage", groupPageParams ), group.Name ) );
+                                    groupContent.Append( string.Format( "<li><a href='{0}'>{1}</a></li>", LinkedPageUrl( "GroupDetailPage", groupPageParams ), groupName ) );
                                 }
                                 else
                                 {
-                                    groupContent.Append( string.Format( "<li>{0}</li>", group.Name ) );
+                                    groupContent.Append( string.Format( "<li>{0}</li>", groupName ) );
                                 }
                             }
                         }

--- a/RockWeb/Blocks/CheckIn/CheckinScheduleBuilder.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/CheckinScheduleBuilder.ascx.cs
@@ -278,7 +278,7 @@ namespace RockWeb.Blocks.CheckIn
             var groupService = new GroupService( rockContext );
 
             var groupPaths = new List<GroupTypePath>();
-            var groupLocationQry = groupLocationService.Queryable();
+            var groupLocationQry = groupLocationService.Queryable().Where(gl => gl.Group.IsActive);
             int groupTypeId;
 
             // if this page has a PageParam for groupTypeId use that to limit which groupTypeId to see. Otherwise, use the groupTypeId specified in the filter

--- a/RockWeb/Blocks/CheckIn/Config/CheckinAreas.ascx
+++ b/RockWeb/Blocks/CheckIn/Config/CheckinAreas.ascx
@@ -17,20 +17,26 @@
         list-style-type: none;
         padding-left: 40px;
     }
+
     .checkin-list-first {
         padding-left: 0;
     }
+
     .checkin-item .fa-bars {
         opacity: .5;
         margin-right: 6px;
     }
-    
+
     .checkin-group {
         border-top-color: #afd074;
     }
-    
+
     .checkin-area {
         border-top-color: #5593a4;
+    }
+
+    .checkin-reactivate-group{
+        margin-right:4px;
     }
 </style>
 
@@ -38,9 +44,14 @@
     <ContentTemplate>
         <asp:HiddenField runat="server" ID="hfAreaGroupClicked" />
         <asp:Panel ID="pnlDetails" runat="server" CssClass="panel panel-block js-panel-details">
-            <div class="panel-heading"><h3 class="panel-title"><i class="fa fa-list"></i> Areas and Groups</h3></div>
+            <div class="panel-heading">
+                <h3 class="panel-title"><i class="fa fa-list"></i>Areas and Groups</h3>
+                <div class="pull-right">
+                    <asp:CheckBox Text="Show Inactive Groups" ID="cbShowInactive" AutoPostBack="true" OnCheckedChanged="cbShowInactive_CheckedChanged" runat="server" />
+                </div>
+            </div>
             <div class="panel-body">
-    
+
                 <Rock:NotificationBox ID="nbDeleteWarning" runat="server" NotificationBoxType="Warning" />
 
                 <div class="row">
@@ -48,7 +59,9 @@
                         <ul class="checkin-list checkin-list-first js-checkin-area-list">
                             <asp:PlaceHolder ID="phRows" runat="server" />
                         </ul>
-                        <div class="pull-right checkin-item-actions"><asp:LinkButton ID="lbAddArea" runat="server" CssClass="btn btn-xs btn-default" OnClick="lbAddArea_Click"><i class="fa fa-plus"></i> <i class="fa fa-folder-open"></i></asp:LinkButton></div>
+                        <div class="pull-right checkin-item-actions">
+                            <asp:LinkButton ID="lbAddArea" runat="server" CssClass="btn btn-xs btn-default" OnClick="lbAddArea_Click"><i class="fa fa-plus"></i> <i class="fa fa-folder-open"></i></asp:LinkButton>
+                        </div>
                     </div>
                     <div class="col-md-6 js-area-group-details">
 
@@ -67,11 +80,11 @@
 
                     </div>
                 </div>
-    
+
             </div>
         </asp:Panel>
 
-        <Rock:ModalDialog ID="mdAddCheckinLabel" runat="server" ScrollbarEnabled="false" ValidationGroup="vgAddCheckinLabel" SaveButtonText="Add" OnSaveClick="mdAddCheckinLabel_SaveClick"  Title="Select Check-in Label">
+        <Rock:ModalDialog ID="mdAddCheckinLabel" runat="server" ScrollbarEnabled="false" ValidationGroup="vgAddCheckinLabel" SaveButtonText="Add" OnSaveClick="mdAddCheckinLabel_SaveClick" Title="Select Check-in Label">
             <Content>
                 <Rock:RockDropDownList ID="ddlCheckinLabel" runat="server" Label="Select Check-in Label" ValidationGroup="vgAddCheckinLabel" />
             </Content>
@@ -100,7 +113,7 @@
 
                     $('html, body').animate({
                         scrollTop: $(scrollToPanel).offset().top + 'px'
-                        }, 400
+                    }, 400
                     );
                 }
             }

--- a/RockWeb/Blocks/CheckIn/Config/CheckinAreas.ascx
+++ b/RockWeb/Blocks/CheckIn/Config/CheckinAreas.ascx
@@ -34,10 +34,6 @@
     .checkin-area {
         border-top-color: #5593a4;
     }
-
-    .checkin-reactivate-group{
-        margin-right:4px;
-    }
 </style>
 
 <asp:UpdatePanel ID="upDetail" runat="server">
@@ -60,7 +56,7 @@
                             <asp:PlaceHolder ID="phRows" runat="server" />
                         </ul>
                         <div class="pull-right checkin-item-actions">
-                            <asp:LinkButton ID="lbAddArea" runat="server" CssClass="btn btn-xs btn-default" OnClick="lbAddArea_Click"><i class="fa fa-plus"></i> <i class="fa fa-folder-open"></i></asp:LinkButton>
+                            <asp:LinkButton ID="lbAddArea" runat="server" ToolTip="Add New Area" CssClass="btn btn-xs btn-default" OnClick="lbAddArea_Click"><i class="fa fa-plus"></i> <i class="fa fa-folder-open"></i></asp:LinkButton>
                         </div>
                     </div>
                     <div class="col-md-6 js-area-group-details">
@@ -76,6 +72,8 @@
 
                         <div class="actions margin-t-md">
                             <asp:LinkButton ID="btnSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="btnSave_Click" Visible="false" />
+                            <asp:LinkButton ID="btnDelete" runat="server" Text="Delete" CssClass="btn btn-link" OnClick="btnDelete_Click" Visible="false" />
+                            
                         </div>
 
                     </div>

--- a/RockWeb/Scripts/Rock/dialogs.js
+++ b/RockWeb/Scripts/Rock/dialogs.js
@@ -42,20 +42,14 @@
                     });
                 },
 
-                // Presents a bootstrap style alert box with a 'Are you sure you want to delete this ...' message 
-                // Returns true if the user selects OK
-                confirmDelete: function (e, nameText, additionalMsg) {
+                // Presents a bootstrap style alert box which prevents on "Cancel" and continues on "Ok"
+                confirmPreventOnCancel: function (e, msg) {
                     // make sure the element that triggered this event isn't disabled
                     if (e.currentTarget && e.currentTarget.disabled) {
                         return false;
                     }
 
                     e.preventDefault();
-                    var msg = 'Are you sure you want to delete this ' + nameText + '?';
-                    if (additionalMsg) {
-                        msg += ' ' + additionalMsg;
-                    }
-
                     bootbox.dialog({
                         message: msg,
                         buttons: {
@@ -73,6 +67,18 @@
                             }
                         }
                     });
+                },
+                
+                // Presents a bootstrap style alert box with a 'Are you sure you want to delete this ...' message 
+                // Returns true if the user selects OK
+                confirmDelete: function (e, nameText, additionalMsg)
+                {
+                    var msg = 'Are you sure you want to delete this ' + nameText + '?';
+                    if (additionalMsg)
+                    {
+                        msg += ' ' + additionalMsg;
+                    }
+                    this.confirmPreventOnCancel(e, msg);
                 },
 
                 // Updates the modal so that scrolling works


### PR DESCRIPTION
# Contributor Agreement
- [x] _Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

# Context
Occasionally we need to retire check-in groups and to reduce clutter we would like to inactivate them and have them not clutter up the check-in interface. If we choose to delete a group all the attendance records are essentially lost.

# Goal
My goal is to make is easy to inactivate and reactivate check-in groups.

# Strategy
I modified the configuration controls and blocks to check to see if the group has attendance records before deleting. If the group does not have attendance records it is simply deleted. However, if it does have attendance records it inactivates the group instead of deleting it outright. Inactive groups are hidden by default, but can be shown by selecting a check box. Once a group has been inactivated, it can be deleted or reactivated.

Additionally I added an option to attendance analytics to view or not view inactive groups. This means you can still run reports on check-in groups you are no longer using.

# Tests
We've been running a version of these changes at Southeast for a while.

# Possible Implications
If a custom check-in workflow piece doesn't check to see if the group is active before adding it to the check-in state it could cause problems for that plug-in.

# Screenshots
![inactivate1](https://cloud.githubusercontent.com/assets/495787/23909837/3236276c-08ae-11e7-9f7d-47391ef9b7e1.png)

![inactivate2](https://cloud.githubusercontent.com/assets/495787/23909853/3e55ee60-08ae-11e7-84f0-861c52cdb56c.png)

![inactivate3](https://cloud.githubusercontent.com/assets/495787/23909858/40e359e2-08ae-11e7-95ff-e854dbbddded.png)


# Documentation
https://www.rockrms.com/Rock/BookContent/10/102 may need to be updated with in attendance analytics descriptive image with an explanation of the toggle (all groups/active groups). The screenshots of the checkin configuration block and attendance analytics may need to be updated as well.