### PR TITLE
+ Event registrations will no longer occasionally create a duplicate address on a family. (Fixes #1680)

### DIFF
--- a/Rock/Model/GroupService.Partial.cs
+++ b/Rock/Model/GroupService.Partial.cs
@@ -762,13 +762,13 @@ namespace Rock.Model
         public static void AddNewGroupAddress( RockContext rockContext, Group group, string locationTypeGuid,
             string street1, string street2, string city, string state, string postalCode, string country, bool moveExistingToPrevious = false )
         {
-            if ( !String.IsNullOrWhiteSpace( street1 ) ||
-                 !String.IsNullOrWhiteSpace( street2 ) ||
-                 !String.IsNullOrWhiteSpace( city ) ||
-                 !String.IsNullOrWhiteSpace( postalCode ) ||
+            if ( !string.IsNullOrWhiteSpace( street1 ) ||
+                 !string.IsNullOrWhiteSpace( street2 ) ||
+                 !string.IsNullOrWhiteSpace( city ) ||
+                 !string.IsNullOrWhiteSpace( postalCode ) ||
                  !string.IsNullOrWhiteSpace( country ) )
             {
-                var location = new LocationService( rockContext ).Get( street1, street2, city, state, postalCode, country );
+                var location = new LocationService( rockContext ).Get( street1, street2, city, state, postalCode, country, true, group );
                 AddNewGroupAddress( rockContext, group, locationTypeGuid, location, moveExistingToPrevious );
             }
         }

--- a/Rock/Model/GroupService.Partial.cs
+++ b/Rock/Model/GroupService.Partial.cs
@@ -768,7 +768,7 @@ namespace Rock.Model
                  !string.IsNullOrWhiteSpace( postalCode ) ||
                  !string.IsNullOrWhiteSpace( country ) )
             {
-                var location = new LocationService( rockContext ).Get( street1, street2, city, state, postalCode, country, true, group );
+                var location = new LocationService( rockContext ).Get( street1, street2, city, state, postalCode, country, group, true );
                 AddNewGroupAddress( rockContext, group, locationTypeGuid, location, moveExistingToPrevious );
             }
         }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When we have an event registration that asks for a person's address, occasionally if they entered the same address we already have on file for them, Rock would move the existing address record to Previous and create a new, identical Home record for them. I found that this was due to the fact that Rock assumes there will only be one Location record in the database for each address, but due to multiple data imports, many addresses had been duplicated in the Location table. When Rock tries to find the existing Location record, it would often find a different one than the one attached to the family, and attach it as well, which resulted in having a duplicate Home and Previous address.

# Goal
_What will this pull request achieve and how will this fix the problem?_

To prevent unnecessary address duplicates from occurring.

# Strategy
_How have you implemented your solution?_

Before searching for the first found Location record that has a matching address, the Location Get method now accepts a group, which it will check for a match first. If it finds a match there, it will use that address. If not, then it will search the database for a match.  This not only prevents the duplicate problem, but should perform faster when there is a match since it does not have to query the entire Location table to find it.

Incidentally, I have also removed the initial search that happened before standardizing the address. My logic is that any address that can be standardized should already be standardized, and it is unlikely that most manually entered addresses would be in the correct standard form. So this eliminates a generally unnecessary database query each time an address is added.  If there is some reason why this logic needs to stay in, by all means put it back, its removal is not a necessary part of this pull request.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
