### PR TITLE
Added support for getting user by EncryptedKey in GetPerson()

### DIFF
--- a/Rock.Rest/ApiControllerBase.cs
+++ b/Rock.Rest/ApiControllerBase.cs
@@ -58,14 +58,26 @@ namespace Rock.Rest
             var principal = ControllerContext.Request.GetUserPrincipal();
             if ( principal != null && principal.Identity != null )
             {
-                var userLoginService = new Rock.Model.UserLoginService( new RockContext() );
-                var userLogin = userLoginService.GetByUserName( principal.Identity.Name );
-
-                if ( userLogin != null )
+                if ( principal.Identity.Name.StartsWith( "rckipid=" ) )
                 {
-                    var person = userLogin.Person;
-                    Request.Properties.Add( "Person", person );
-                    return userLogin.Person;
+                    var personService = new Model.PersonService( new RockContext() );
+                    var impersonatedPerson = personService.GetByEncryptedKey( principal.Identity.Name.Substring( 8 ) );
+                    if ( impersonatedPerson != null )
+                    {
+                        return impersonatedPerson;
+                    }
+                }
+                else
+                {
+                    var userLoginService = new Rock.Model.UserLoginService( new RockContext() );
+                    var userLogin = userLoginService.GetByUserName( principal.Identity.Name );
+
+                    if ( userLogin != null )
+                    {
+                        var person = userLogin.Person;
+                        Request.Properties.Add( "Person", person );
+                        return userLogin.Person;
+                    }
                 }
             }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

We email a link to our protection application to applicants, which logs them in to fill out a workflow that's assigned to them, and most of these users will not have a username (the application uses a custom form and controller, if that matters). When saving their changes to the history, no user was being tagged as the creator.

# Goal
_What will this pull request achieve and how will this fix the problem?_

When the principal.Identity.Name is "rckipid=[EncryptedKeyHere]" it will be able to return the associated user.

# Strategy
_How have you implemented your solution?_

By talking to @azturner about the issue and passing off the code he graciously provided as my own.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
