### PR TITLE
Fixed Connection Opportunity "all" capitalization for consistency

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionOpportunityDetail.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionOpportunityDetail.ascx.cs
@@ -1790,7 +1790,7 @@ namespace RockWeb.Blocks.Connection
                 }
                 else
                 {
-                    CampusName = "all";
+                    CampusName = "All";
                 }
             }
         }


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
Capitalization error mentioned by Chris Rea on Slack where all changes to lowercase on save for Connector Groups.

# Goal
Uppercase "All"

# Strategy
N/A

# Tests
N/A

# Possible Implications
None

# Screenshots
Before Provided by Chris Rea:
![connection opportunity detail _ rock rms - google chrome 2017-03-15 16 40 47](https://cloud.githubusercontent.com/assets/374209/24019166/268c0cfe-0a54-11e7-9cbe-0f6f9adb6805.png)

# Documentation
N/A
