### PR TITLE
Declutter the Lava variable space

### DIFF
--- a/Rock/Lava/Blocks/RockLavaBlockBase.cs
+++ b/Rock/Lava/Blocks/RockLavaBlockBase.cs
@@ -39,19 +39,13 @@ namespace Rock.Lava.Blocks
         /// <returns></returns>
         protected bool IsAuthorized( Context context )
         {
-            if ( context.Scopes != null )
+            if ( context.Registers.ContainsKey( "EnabledCommands" ) )
             {
-                foreach ( var scopeHash in context.Scopes )
-                {
-                    if ( scopeHash.ContainsKey( "EnabledCommands" ) )
-                    {
-                        var enabledCommands = scopeHash["EnabledCommands"].ToString().Split( ',' ).ToList();
+                var enabledCommands = context.Registers["EnabledCommands"].ToString().Split( ',' ).ToList();
 
-                        if ( enabledCommands.Contains( "All" ) || enabledCommands.Contains( this.GetType().Name ) )
-                        {
-                            return true;
-                        }
-                    }
+                if ( enabledCommands.Contains( "All" ) || enabledCommands.Contains( this.GetType().Name ) )
+                {
+                    return true;
                 }
             }
 

--- a/Rock/Utility/ExtensionMethods/LavaExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/LavaExtensions.cs
@@ -475,7 +475,7 @@ namespace Rock
                 }
 
                 Template template = Template.Parse( content );
-                template.InstanceAssigns.Add( "EnabledCommands", enabledLavaCommands );
+                template.Registers.Add( "EnabledCommands", enabledLavaCommands );
                 template.InstanceAssigns.Add( "CurrentPerson", currentPersonOverride );
                 return template.Render( Hash.FromDictionary( mergeObjects ) );
             }
@@ -546,7 +546,7 @@ namespace Rock
                 }
 
                 Template template = Template.Parse( content );
-                template.InstanceAssigns.Add( "EnabledCommands", enabledLavaCommands );
+                template.Registers.Add( "EnabledCommands", enabledLavaCommands );
 
                 if ( encodeStrings )
                 {

--- a/RockWeb/Blocks/Cms/ContentChannelView.ascx.cs
+++ b/RockWeb/Blocks/Cms/ContentChannelView.ascx.cs
@@ -574,13 +574,13 @@ $(document).ready(function() {
 
             var template = GetTemplate();
 
-            if ( template.InstanceAssigns.ContainsKey( "EnabledCommands" ) )
+            if ( template.Registers.ContainsKey( "EnabledCommands" ) )
             {
-                template.InstanceAssigns["EnabledCommands"] = GetAttributeValue( "EnabledLavaCommands" );
+                template.Registers["EnabledCommands"] = GetAttributeValue( "EnabledLavaCommands" );
             }
             else // this should never happen
             {
-                template.InstanceAssigns.Add( "EnabledCommands", GetAttributeValue( "EnabledLavaCommands" ) );
+                template.Registers.Add( "EnabledCommands", GetAttributeValue( "EnabledLavaCommands" ) );
             }
             
             phContent.Controls.Add( new LiteralControl( template.Render( Hash.FromDictionary( mergeFields ) ) ) );


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Lava variable space should be kept as clean and lean as possible in order to not cause confusion to the user when working with Lava.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Declutter the Lava variable space a bit.

# Strategy
_How have you implemented your solution?_

Move some of the Lava commands tracking around so it doesn't get in the user's way anymore.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a