### PR TITLE
Prevented merge picker from overflowing on SMS Communication (Fixes #1316)

### DIFF
--- a/RockWeb/Styles/rock-components/pickers.less
+++ b/RockWeb/Styles/rock-components/pickers.less
@@ -157,6 +157,7 @@
 
   &.picker-mergefield {
     width: 370px;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
Fixes #1316

# Goal
Prevent overflow to improve accessibility on mobile devices

# Strategy
max-width: 100%;

# Tests
N/A

# Possible Implications
N/A

# Screenshots
N/A

# Documentation
N/A
