### PR TITLE
Partial fix for scrolling problems on devices supporting touch and mouse

### DIFF
--- a/RockWeb/Scripts/jquery.tinyscrollbar.js
+++ b/RockWeb/Scripts/jquery.tinyscrollbar.js
@@ -18,6 +18,7 @@
         + function wheel( event ) now only adjust the content when the scrollbar is vertical (axis == 'y')
         + touch events now only get attached when the content when the scrollbar is vertical (axis == 'y')
         + if a scroll position is specified, it now will only scroll if there is a scrollbar visible
+        + always enable mouse based scrolling, even on touch devices (some devices support both)
  */
 ;( function( $ ) 
 {
@@ -117,12 +118,10 @@
 
         function setEvents()
         {
-			if( ! touchEvents )
-            {
-                oThumb.obj.bind( 'mousedown', start );
-                oTrack.obj.bind( 'mouseup', drag );
-            }
-            else
+            oThumb.obj.bind( 'mousedown', start );
+            oTrack.obj.bind( 'mouseup', drag );
+
+            if ( touchEvents )
             {
                 oViewport.obj[0].ontouchstart = function( event )
                 {   
@@ -162,13 +161,11 @@
             iMouse.start    = sAxis ? event.pageX : event.pageY;
             iPosition.start = oThumbDir == 'auto' ? 0 : oThumbDir;
             
-            if( ! touchEvents )
-            {
-                $( document ).bind( 'mousemove', drag );
-                $( document ).bind( 'mouseup', end );
-                oThumb.obj.bind( 'mouseup', end );
-            }
-            else
+            $( document ).bind( 'mousemove', drag );
+            $( document ).bind( 'mouseup', end );
+            oThumb.obj.bind( 'mouseup', end );
+
+            if (touchEvents)
             {
                 if (options.axis == 'x') {
                     // don't hook to document.ontouchmove when in X mode


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Partial fix for issue #1731.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Resolve the issue of not being able to use the mouse to scroll on mixed-input devices.

# Strategy
_How have you implemented your solution?_

Enabled mouse-tracking events on touch input devices.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Mixed-input devices MAY double scroll. I cannot test this as I do not have a mixed input device. But as much testing as I can to detect those cases via JavaScript logging showed that they are not happening on iPad (pseudo mixed input device). This is only a partial fix as the tinyscrollbar package has other issues, and iOS 10 has added new issues as well.

Before being submitted this patch should be tested on the original device to ensure that it works as expected in both mouse and touch interactions.

Also should be tested on an Android touch device to ensure that it works as expected.

iOS 10 has broken tinyscrollbar. When doing a vertical scroll the entire screen AND the screen element both scroll, which causes the screen element to barely scroll (since the coordinates are no longer valid).

Also the horizontal scrolling on touch devices is disabled due to an unknown issue in the past (meaning we are not exactly sure why it was disabled to be able to re-test it). If you can manage to grab the thumb bar scrolling should still work.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a