### PR TITLE
- Fix AsDoubleOrNull allowing strings that don't represent numbers

### DIFF
--- a/Rock.Tests/Rock.Tests.csproj
+++ b/Rock.Tests/Rock.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Rock\Model\PageRouteTests.cs" />
     <Compile Include="Rock\Model\PageTests.cs" />
     <Compile Include="Rock\Model\PersonTests.cs" />
+    <Compile Include="Rock\Utility\ExtensionMethods\StringExtensionsTests.cs" />
     <Compile Include="Rock\Workflow\Action\BackgroundCheckRequestTests.cs" />
     <Compile Include="SqlServerTypes\Loader.cs" />
   </ItemGroup>

--- a/Rock.Tests/Rock/Utility/ExtensionMethods/StringExtensionsTests.cs
+++ b/Rock.Tests/Rock/Utility/ExtensionMethods/StringExtensionsTests.cs
@@ -1,0 +1,81 @@
+﻿using Xunit;
+
+namespace Rock.Tests.Utility.ExtensionMethods
+{
+    public class StringExtensionsTest
+    {
+        #region AsDoubleOrNull
+
+        /// <summary>
+        /// Should not cast the true boolean to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_InvalidBoolean()
+        {
+            var output = @"True".AsDoubleOrNull();
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// Should cast the integer to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidInteger()
+        {
+            var output = @"3".AsDoubleOrNull();
+            Assert.Equal( output, 3.0d );
+        }
+
+        /// <summary>
+        /// Should cast the double to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidDouble()
+        {
+            var output = @"3.141592".AsDoubleOrNull();
+            Assert.Equal( output, (double)3.141592d );
+        }
+
+        /// <summary>
+        /// Should cast the string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_ValidString()
+        {
+            var output = @"$3.14".AsDoubleOrNull();
+            Assert.Equal( output, (double)3.14d );
+        }
+
+        /// <summary>
+        /// Should not cast the string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_InvalidString()
+        {
+            var output = @"a".AsDoubleOrNull();
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// Should not cast the string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_EmptyString()
+        {
+            var output = @"".AsDoubleOrNull();
+            Assert.Null( output );
+        }
+
+        /// <summary>
+        /// Should not cast the decimal string to a double.
+        /// </summary>
+        [Fact]
+        public void AsDouble_InvalidDecimalString()
+        {
+            var output = @"T3.V3".AsDoubleOrNull();
+            Assert.Null( output );
+        }
+
+        #endregion
+    }
+}

--- a/Rock/Utility/ExtensionMethods/StringExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/StringExtensions.cs
@@ -63,7 +63,7 @@ namespace Rock
         /// </summary>
         /// <param name="str">The string.</param>
         /// <returns></returns>
-        public static bool IsNullOrWhiteSpace(this string str )
+        public static bool IsNullOrWhiteSpace( this string str )
         {
             return string.IsNullOrWhiteSpace( str );
         }
@@ -106,7 +106,7 @@ namespace Rock
                 Int64 hashCodeEnd = BitConverter.ToInt64( hashText, 24 );
                 hashCode = hashCodeStart ^ hashCodeMedium ^ hashCodeEnd;
             }
-            return (hashCode);
+            return ( hashCode );
         }
 
         /// <summary>
@@ -352,13 +352,13 @@ namespace Rock
         /// Attempts to convert string to an dictionary using the |/comma and ^ delimiter Key/Value syntax.  Returns an empty dictionary if unsuccessful.
         /// </summary>
         /// <param name="str">The string.</param>
-        /// <returns></returns>                     
+        /// <returns></returns>
         public static System.Collections.Generic.Dictionary<string, string> AsDictionary( this string str )
         {
             var dictionary = new System.Collections.Generic.Dictionary<string, string>();
             string[] nameValues = str.Split( new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries );
             // If we haven't found any pipes, check for commas
-            if ( nameValues.Count() == 1 && nameValues[0] == str)
+            if ( nameValues.Count() == 1 && nameValues[0] == str )
             {
                 nameValues = str.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries );
             }
@@ -388,7 +388,6 @@ namespace Rock
             }
             return null;
         }
-
 
         /// <summary>
         /// Attempts to convert string to integer.  Returns 0 if unsuccessful.
@@ -513,8 +512,8 @@ namespace Rock
         {
             if ( !string.IsNullOrWhiteSpace( str ) )
             {
-                // strip off non numeric and characters (for example, currency symbols)
-                str = Regex.Replace( str, @"[^0-9\.-]", "" );
+                // strip off non numeric and characters at the beginning of the line (currency symbols)
+                str = Regex.Replace( str, @"^[^0-9\.-]", "" );
             }
 
             double value;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

☑️

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Fixes #1747.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Fixes the issue and adds unit tests to make sure it doesn't break again.

# Strategy
_How have you implemented your solution?_

This removes multiple non-decimal characters at the front of a string.  If non-decimal characters are in the middle of a string, it's no longer valid.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

☑️

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

N/A, fixed buggy behavior.