### PR TITLE
+ History will be properly created when adding a new person from the Edit Family screen. (Fixes #1726)

### DIFF
--- a/Rock/Model/PersonService.Partial.cs
+++ b/Rock/Model/PersonService.Partial.cs
@@ -1646,7 +1646,7 @@ namespace Rock.Model
                 rockContext,
                 typeof( Person ),
                 Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(),
-                groupMember.Id,
+                groupMember.Person.Id,
                 demographicChanges );
 
             if ( isFamilyGroup )
@@ -1655,7 +1655,7 @@ namespace Rock.Model
                     rockContext,
                     typeof( Person ),
                     Rock.SystemGuid.Category.HISTORY_PERSON_FAMILY_CHANGES.AsGuid(),
-                    groupMember.Id,
+                    groupMember.Person.Id,
                     memberChanges,
                     group.Name,
                     typeof( Group ),

--- a/Rock/Model/PersonService.Partial.cs
+++ b/Rock/Model/PersonService.Partial.cs
@@ -1593,6 +1593,7 @@ namespace Rock.Model
                 person.LastName = person.LastName.FixCase();
 
                 // new person that hasn't be saved to database yet
+                demographicChanges.Add( "Created" );
                 History.EvaluateChange( demographicChanges, "Title", string.Empty, DefinedValueCache.GetName( person.TitleValueId ) );
                 History.EvaluateChange( demographicChanges, "First Name", string.Empty, person.FirstName );
                 History.EvaluateChange( demographicChanges, "Last Name", string.Empty, person.LastName );

--- a/RockWeb/Blocks/Crm/PersonDetail/EditGroup.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/EditGroup.ascx.cs
@@ -1067,6 +1067,9 @@ namespace RockWeb.Blocks.Crm.PersonDetail
 
                     foreach ( var groupMemberInfo in GroupMembers )
                     {
+                        var memberChanges = new List<string>();
+                        var demographicChanges = new List<string>();
+
                         var role = _groupType.Roles.Where( r => r.Guid.Equals( groupMemberInfo.RoleGuid ) ).FirstOrDefault();
                         if ( role == null )
                         {
@@ -1126,14 +1129,26 @@ namespace RockWeb.Blocks.Crm.PersonDetail
                                 return;
                             }
 
+                            if ( _isFamilyGroupType )
+                            {
+                                if ( person.RecordStatusValueId != recordStatusValueID )
+                                {
+                                    History.EvaluateChange( demographicChanges, "Record Status", DefinedValueCache.GetName( person.RecordStatusValueId ), DefinedValueCache.GetName( recordStatusValueID ) );
+                                    person.RecordStatusValueId = recordStatusValueID;
+                                }
+
+                                if ( person.RecordStatusReasonValueId != reasonValueId )
+                                {
+                                    History.EvaluateChange( demographicChanges, "Record Status Reason", DefinedValueCache.GetName( person.RecordStatusReasonValueId ), DefinedValueCache.GetName( reasonValueId ) );
+                                    person.RecordStatusReasonValueId = reasonValueId;
+                                }
+                            }
+
                             PersonService.AddPersonToGroup( person, person.Id == 0, _group.Id, role.Id, rockContext );
                             groupMemberInfo.Id = person.Id;
                         }
                         else
                         {
-                            var memberChanges = new List<string>();
-                            var demographicChanges = new List<string>();
-
                             // existing group members
                             var groupMember = groupMemberService.Queryable( "Person", true ).Where( m =>
                                 m.PersonId == groupMemberInfo.Id &&
@@ -1229,19 +1244,19 @@ namespace RockWeb.Blocks.Crm.PersonDetail
                                     }
                                 }
                             }
-
-                            HistoryService.SaveChanges( rockContext, typeof( Person ), Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(), groupMemberInfo.Id, demographicChanges );
-
-                            if ( _isFamilyGroupType )
-                            {
-                                HistoryService.SaveChanges( rockContext, typeof( Person ), Rock.SystemGuid.Category.HISTORY_PERSON_FAMILY_CHANGES.AsGuid(), groupMemberInfo.Id, memberChanges, _group.Name, typeof( Group ), _group.Id );
-                            }
                         }
 
                         // Remove anyone that was moved from another family
                         if ( groupMemberInfo.RemoveFromOtherGroups )
                         {
                             PersonService.RemovePersonFromOtherFamilies( _group.Id, groupMemberInfo.Id, rockContext );
+                        }
+
+                        HistoryService.SaveChanges( rockContext, typeof( Person ), Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(), groupMemberInfo.Id, demographicChanges );
+
+                        if ( _isFamilyGroupType )
+                        {
+                            HistoryService.SaveChanges( rockContext, typeof( Person ), Rock.SystemGuid.Category.HISTORY_PERSON_FAMILY_CHANGES.AsGuid(), groupMemberInfo.Id, memberChanges, _group.Name, typeof( Group ), _group.Id );
                         }
                     }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Investigating the creation of Person records, we would often find records that had no information in the History screen about when they were created, by whom, or what their values were at creation. We found that this was happening when people were added from the Edit Family screen.

# Goal
_What will this pull request achieve and how will this fix the problem?_

To create History records when a person is added from the Edit Family screen.

# Strategy
_How have you implemented your solution?_

The ID used to save the history was the GroupMember ID rather than the Person's ID. Fixed that. 

Also removed extraneous history that was being saved to a -1 ID. 

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
