### PR TITLE
Fix 'Notified' text to not vanish on Group Member Detail block

### DIFF
--- a/RockWeb/Blocks/Groups/GroupMemberDetail.ascx
+++ b/RockWeb/Blocks/Groups/GroupMemberDetail.ascx
@@ -49,7 +49,7 @@
                             <Rock:PersonPicker runat="server" ID="ppGroupMemberPerson" Label="Person" CssClass="js-authorizedperson" Required="true" OnSelectPerson="ppGroupMemberPerson_SelectPerson" />
                         </div>
                         <div class="col-md-6">
-                            <Rock:RockCheckBox runat="server" ID="cbIsNotified" Label="Notified" />
+                            <Rock:RockCheckBox runat="server" ID="cbIsNotified" Label="Notified" Help="If this box is unchecked and a <a href='http://www.rockrms.com/Rock/BookContent/7/#servicejobsrelatingtogroups'>group leader notification job</a> is enabled then a notification will be sent to the group's leaders when this group member is saved." />
                         </div>
                     </div>
 

--- a/RockWeb/Blocks/Groups/GroupMemberDetail.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupMemberDetail.ascx.cs
@@ -518,7 +518,6 @@ namespace RockWeb.Blocks.Groups
             {
                 cbIsNotified.Checked = groupMember.IsNotified;
                 cbIsNotified.Visible = true;
-                cbIsNotified.Help = "If this box is unchecked and a <a href=\"http://www.rockrms.com/Rock/BookContent/7/#servicejobsrelatingtogroups\">group leader notification job</a> is enabled then a notification will be sent to the group's leaders when this group member is saved.";
             }
             else
             {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Issue #1996 - During postback the help text for the 'Notified' checkbox vanishes.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Ensure the Help text does not vanish.

# Strategy
_How have you implemented your solution?_

Move the Help text from C# code into the .ascx file.

For some reason the HelpBlock control does not save/restore the Text value on postback. I'm not sure if this is a failure of the HelpBlock control or the controls that use it. Therefore if C# code does something like `cbIsNotified.Help = "some text";` it will show up on initial page load, but if that same code does not execute during Postback then the Help text is lost by the underlying HelpBlock.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a