### PR TITLE
Fixed a bug that caused groups not to show up if sorting by distance while Map is enabled and Show Distance is disabled (Fixes #2007)

### DIFF
--- a/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
@@ -1019,7 +1019,7 @@ namespace RockWeb.Blocks.Groups
                 }
 
                 // if not sorting by ColumnClick and SortByDistance, then sort the groups by distance
-                if ( gGroups.SortProperty == null && GetAttributeValue( "SortByDistance" ).AsBoolean() )
+                if ( gGroups.SortProperty == null && showProximity && GetAttributeValue( "SortByDistance" ).AsBoolean() )
                 {
                     // only show groups with a known location, and sort those by distance
                     groups = groups.Where( a => distances.Select( b => b.Key ).Contains( a.Id ) ).ToList();


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When the Group Finder was configured to display the Map and Sort by Distance but not Show Distance, no groups were displayed

# Goal
_What will this pull request achieve and how will this fix the problem?_

Display the groups and ignore the Sort By Distance setting when Show Distance is false.

# Strategy
_How have you implemented your solution?_

Added a check for the Show Distance property where the groups are limited by distance, since without that property set to true, no distances have been calculated.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
