### PR TITLE
- Fixed date comparisons in unit tests making Appveyor fail every single PR

### DIFF
--- a/Rock.Tests/Rock.Tests.csproj
+++ b/Rock.Tests/Rock.Tests.csproj
@@ -37,6 +37,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DDay.iCal, Version=1.0.2.575, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DDay.iCal.1.0.2.575\lib\DDay.iCal.dll</HintPath>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>

--- a/Rock.Tests/Rock/Lava/RockFiltersTests.cs
+++ b/Rock.Tests/Rock/Lava/RockFiltersTests.cs
@@ -1,46 +1,59 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using System;
-
-using Rock;
+using DDay.iCal;
+using DDay.iCal.Serialization.iCalendar;
 using Rock.Lava;
-using Rock.Model;
 using Xunit;
-
 
 namespace Rock.Tests.Rock.Lava
 {
     public class RockFiltersTest
     {
-        static readonly Dictionary<string, object> mergeObjects = new Dictionary<string, object>();
-        static readonly string iCalStringSaturday430 = @"BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//ddaysoftware.com//NONSGML DDay.iCal 1.0//EN
-BEGIN:VEVENT
-DTEND:20130501T173000
-DTSTAMP:20170303T203737Z
-DTSTART:20130501T163000
-RRULE:FREQ=WEEKLY;BYDAY=SA
-SEQUENCE:0
-UID:d74561ac-c0f9-4dce-a610-c39ca14b0d6e
-END:VEVENT
-END:VCALENDAR";
+        private static readonly Dictionary<string, object> mergeObjects = new Dictionary<string, object>();
+        private static iCalendarSerializer serializer = new iCalendarSerializer();
+        private static RecurrencePattern weeklyRecurrence = new RecurrencePattern( "RRULE:FREQ=WEEKLY;BYDAY=SA" );
+        private static RecurrencePattern monthlyRecurrence = new RecurrencePattern( "RRULE:FREQ=MONTHLY;BYDAY=1SA" );
 
-        // First Saturday of month until 2018; ends on 12/7/2019 - 8:00 AM to 10:00 AM
-        static readonly string iCalStringFirstSaturdayOfMonthTil2020 = @"BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//ddaysoftware.com//NONSGML DDay.iCal 1.0//EN
-BEGIN:VEVENT
-DTEND:20170101T100000
-DTSTAMP:20170303T215639Z
-DTSTART:20170101T080000
-RRULE:FREQ=MONTHLY;UNTIL=20200101T000000;BYDAY=1SA
-SEQUENCE:0
-UID:517d77dd-6fe8-493b-925f-f266aa2d852c
-END:VEVENT
-END:VCALENDAR";
+        private static readonly DateTime today = RockDateTime.Today;
+
+        private static readonly iCalendar weeklySaturday430 = new iCalendar()
+        {
+            Events =
+            {
+                new Event
+                    {
+                        DTStart = new iCalDateTime( today.Year, today.Month, today.Day + DayOfWeek.Saturday - today.DayOfWeek, 16, 30, 0 ),
+                        DTEnd = new iCalDateTime( today.Year, today.Month, today.Day + DayOfWeek.Saturday - today.DayOfWeek, 17, 30, 0 ),
+                        DTStamp = new iCalDateTime( today.Year, today.Month, today.Day ),
+                        RecurrenceRules = new List<IRecurrencePattern> { weeklyRecurrence },
+                        Sequence = 0,
+                        UID = @"d74561ac-c0f9-4dce-a610-c39ca14b0d6e"
+                    }
+                }
+        };
+
+        private static readonly iCalendar monthlyFirstSaturday = new iCalendar()
+        {
+            Events =
+            {
+                new Event
+                    {
+                        DTStart = new iCalDateTime( today.Year, today.Month, today.Day, 8, 0, 0 ),
+                        DTEnd = new iCalDateTime( today.Year, today.Month, today.Day, 10, 0, 0 ),
+                        DTStamp = new iCalDateTime( today.Year, today.Month, today.Day ),
+                        RecurrenceRules = new List<IRecurrencePattern> { monthlyRecurrence },
+                        Sequence = 0,
+                        UID = @"517d77dd-6fe8-493b-925f-f266aa2d852c"
+                    }
+                }
+        };
+
+        private static readonly string iCalStringSaturday430 = serializer.SerializeToString( weeklySaturday430 );
+        private static readonly string iCalStringFirstSaturdayOfMonth = serializer.SerializeToString( monthlyFirstSaturday );
 
         #region Minus
+
         /// <summary>
         /// For use in Lava -- should subtract two integers and return an integer.
         /// </summary>
@@ -95,9 +108,11 @@ END:VCALENDAR";
             var output = RockFilters.Minus( 3, "2.0" );
             Assert.Equal( 1.0M, output );
         }
+
         #endregion
 
         #region Plus
+
         /// <summary>
         /// For use in Lava -- should add two integers and return an integer.
         /// </summary>
@@ -161,6 +176,7 @@ END:VCALENDAR";
         #endregion
 
         #region Times
+
         /// <summary>
         /// For use in Lava -- should multiply two integers and return an integer.
         /// </summary>
@@ -387,7 +403,7 @@ END:VCALENDAR";
         public void AsDecimal_ValidString()
         {
             var output = RockFilters.AsDecimal( "3.14" );
-            Assert.Equal( output, ( decimal )3.14d );
+            Assert.Equal( output, ( decimal ) 3.14d );
         }
 
         /// <summary>
@@ -652,8 +668,8 @@ END:VCALENDAR";
             DateTime today = RockDateTime.Today;
             int daysUntilSaturday = ( ( int ) DayOfWeek.Saturday - ( int ) today.DayOfWeek + 7 ) % 7;
             DateTime nextSaturday = today.AddDays( daysUntilSaturday );
-            DateTime nextYearSaturday = nextSaturday.AddDays( 7 * 51 );
-            
+            DateTime nextYearSaturday = nextSaturday.AddDays( 7 * 52 );
+
             DateTime expected = DateTime.Parse( nextYearSaturday.ToShortDateString() + " 4:30:00 PM" );
 
             var output = RockFilters.DatesFromICal( iCalStringSaturday430, 53 ).LastOrDefault();
@@ -679,18 +695,18 @@ END:VCALENDAR";
         /// <summary>
         /// For use in Lava -- should find the end datetime (10 AM) occurrence for the fictitious, first Saturday of the month event for Saturday a year from today.
         /// </summary>
-        [Fact( Skip = "Needs a rewrite.  This slides back and fourth one day after Saturday occurs." )]
+        [Fact]
         public void DatesFromICal_NextYearsEndOccurrenceSaturday()
         {
             // Next year's Saturday (from right now)
             DateTime today = RockDateTime.Today;
             int daysUntilSaturday = ( ( int ) DayOfWeek.Saturday - ( int ) today.DayOfWeek + 7 ) % 7;
-            DateTime nextSaturday = today.AddDays( daysUntilSaturday );
-            DateTime nextYearSaturday = nextSaturday.AddDays( 7 * 51 );
+            DateTime firstSaturdayThisMonth = today.AddDays( daysUntilSaturday - ( ( today.Day / 7 ) * 7 ) );
+            DateTime nextYearSaturday = firstSaturdayThisMonth.AddDays( 7 * 52 );
 
             DateTime expected = DateTime.Parse( nextYearSaturday.ToShortDateString() + " 10:00:00 AM" );
 
-            var output = RockFilters.DatesFromICal( iCalStringFirstSaturdayOfMonthTil2020, 13, "enddatetime" ).LastOrDefault();
+            var output = RockFilters.DatesFromICal( iCalStringFirstSaturdayOfMonth, 13, "enddatetime" ).LastOrDefault();
             Assert.Equal( expected, output );
         }
     }

--- a/Rock.Tests/packages.config
+++ b/Rock.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DDay.iCal" version="1.0.2.575" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

☑️

# Context
_What is the problem you encountered that lead to you creating this pull request?_

![](https://media.giphy.com/media/13d2jHlSlxklVe/giphy.gif)

Fix unit tests that were dependent on a mix of hard-coded event times but would always compare against RockDateTime.Today.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the dang thing to always use RockDateTime.Today.  Also I never want to see an iCal event ever again.


# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

☑️
