### PR TITLE
Fix Public Profile Edit saving wrong Record Status (Fixes #2096)

### DIFF
--- a/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
+++ b/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
@@ -357,7 +357,7 @@ namespace RockWeb.Blocks.Cms
                             if ( headOfHousehold != null )
                             {
                                 DefinedValueCache dvcConnectionStatus = DefinedValueCache.Read( headOfHousehold.ConnectionStatusValueId ?? 0 );
-                                DefinedValueCache dvcRecordStatus = DefinedValueCache.Read( headOfHousehold.ConnectionStatusValueId ?? 0 );
+                                DefinedValueCache dvcRecordStatus = DefinedValueCache.Read( headOfHousehold.RecordStatusValueId ?? 0 );
                                 if ( dvcConnectionStatus != null )
                                 {
                                     groupMember.Person.ConnectionStatusValueId = dvcConnectionStatus.Id;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_
From the issue, The person's ConnectionStatusValueId was being used for their RecordStatusValueId.

# Goal
_What will this pull request achieve and how will this fix the problem?_
Fixes it to properly use the RecordStatusValueId.

# Strategy
_How have you implemented your solution?_

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
None

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._
N/A

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
N/A