### PR TITLE
Fixed bug where clicking the group type label selects all groups

### DIFF
--- a/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx
+++ b/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx
@@ -339,7 +339,7 @@
                 // toggle all group checkboxes
                 $('.js-checkbox-selector, .js-groups-container .rock-check-box-list .control-label').on('click', function (e) {
 
-                    var container = $(this).closest('.js-groups-container');
+                    var container = $(this).parent().parent();
 
                     var isChecked = true;
                     container.find('input:checkbox').each(function (a) {


### PR DESCRIPTION
# Contributor Agreement
YES

# Context
One of our admins noticed that clicking the group type label in attendance analytics selects all checkboxes instead of only those for that grouptype

# Goal
It will restore intended functionality.

# Strategy
I changed the javascript to only go so high in the tree before looking for checkboxes to check/uncheck

# Possible Implications
None
