### PR TITLE
- Removed port from analytics link (Fixes #2068)

### DIFF
--- a/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx.cs
@@ -503,7 +503,7 @@ function(item) {
             }
 
             Uri uri = new Uri( Request.Url.ToString() );
-            hfFilterUrl.Value = uri.Scheme + "://" + uri.GetComponents( UriComponents.HostAndPort, UriFormat.UriEscaped ) + pageReference.BuildUrl();
+            hfFilterUrl.Value = uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped ) + pageReference.BuildUrl();
             btnCopyToClipboard.Disabled = false;
         }
 

--- a/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceAnalytics.ascx.cs
@@ -503,7 +503,7 @@ function(item) {
             }
 
             Uri uri = new Uri( Request.Url.ToString() );
-            hfFilterUrl.Value = uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped ) + pageReference.BuildUrl();
+            hfFilterUrl.Value = uri.GetLeftPart(UriPartial.Authority) + pageReference.BuildUrl();
             btnCopyToClipboard.Disabled = false;
         }
 

--- a/RockWeb/Blocks/Finance/GivingAnalytics.ascx.cs
+++ b/RockWeb/Blocks/Finance/GivingAnalytics.ascx.cs
@@ -635,7 +635,7 @@ function(item) {
             }
 
             Uri uri = new Uri( Request.Url.ToString() );
-            hfFilterUrl.Value = uri.Scheme + "://" + uri.GetComponents( UriComponents.HostAndPort, UriFormat.UriEscaped ) + pageReference.BuildUrl();
+            hfFilterUrl.Value = uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped ) + pageReference.BuildUrl();
             btnCopyToClipboard.Disabled = false;
         }
 

--- a/RockWeb/Blocks/Finance/GivingAnalytics.ascx.cs
+++ b/RockWeb/Blocks/Finance/GivingAnalytics.ascx.cs
@@ -635,7 +635,7 @@ function(item) {
             }
 
             Uri uri = new Uri( Request.Url.ToString() );
-            hfFilterUrl.Value = uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped ) + pageReference.BuildUrl();
+            hfFilterUrl.Value = uri.GetLeftPart(UriPartial.Authority) + pageReference.BuildUrl();
             btnCopyToClipboard.Disabled = false;
         }
 


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
Unnecessary port included in link from giving analytics and attendance analytics. 

# Goal
Remove the port

# Strategy
Dropping the port from the copy link

# Tests
N/A

# Possible Implications
Links created during development will need to append the port to link URLs.

# Screenshots
N/A

# Documentation
N/A
