### PR TITLE
Updated WorkflowDetail and WorkflowList blocks to honor the ViewList security

### DIFF
--- a/RockWeb/Blocks/WorkFlow/WorkflowDetail.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowDetail.ascx.cs
@@ -45,6 +45,7 @@ namespace RockWeb.Blocks.WorkFlow
         #region Fields
 
         private bool _canEdit = false;
+        private bool _canView = false;
         private PersonAliasService _personAliasService = null;
         private GroupService _groupService = null;
 
@@ -108,6 +109,7 @@ namespace RockWeb.Blocks.WorkFlow
             }
 
             _canEdit = UserCanEdit || Workflow.IsAuthorized( Rock.Security.Authorization.EDIT, CurrentPerson );
+            _canView = _canEdit || ( Workflow.IsAuthorized( Authorization.VIEW, CurrentPerson ) && Workflow.IsAuthorized( "ViewList", CurrentPerson ) );
         }
 
         /// <summary>
@@ -673,6 +675,7 @@ namespace RockWeb.Blocks.WorkFlow
             pdAuditDetails.SetEntity( Workflow, ResolveRockUrl( "~" ) );
 
             _canEdit = UserCanEdit || Workflow.IsAuthorized( Rock.Security.Authorization.EDIT, CurrentPerson );
+            _canView = _canEdit || ( Workflow.IsAuthorized( Authorization.VIEW, CurrentPerson ) && Workflow.IsAuthorized( "ViewList", CurrentPerson ) );
 
             Workflow.LoadAttributes( rockContext );
             foreach ( var activity in Workflow.Activities )
@@ -702,9 +705,11 @@ namespace RockWeb.Blocks.WorkFlow
         {
             hfMode.Value = "View";
 
+            HideSecondaryBlocks( false );
+
             if ( Workflow != null )
             {
-                if ( _canEdit || Workflow.IsAuthorized( Authorization.VIEW, CurrentPerson ) )
+                if ( _canView )
                 {
                     if ( Workflow.WorkflowType != null )
                     {
@@ -765,10 +770,9 @@ namespace RockWeb.Blocks.WorkFlow
                 {
                     nbNotAuthorized.Visible = true;
                     pnlContent.Visible = false;
+                    HideSecondaryBlocks( true );
                 }
             }
-
-            HideSecondaryBlocks( false );
         }
 
         private void ShowEditDetails()

--- a/RockWeb/Blocks/WorkFlow/WorkflowList.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowList.ascx.cs
@@ -90,7 +90,7 @@ namespace RockWeb.Blocks.WorkFlow
             if ( _workflowType != null )
             {
                 _canEdit = UserCanEdit || _workflowType.IsAuthorized( Authorization.EDIT, CurrentPerson );
-                _canView = _canEdit || _workflowType.IsAuthorized( Authorization.VIEW, CurrentPerson );
+                _canView = _canEdit || ( _workflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ) && _workflowType.IsAuthorized( "ViewList", CurrentPerson ) );
 
                 gfWorkflows.ApplyFilterClick += gfWorkflows_ApplyFilterClick;
                 gfWorkflows.DisplayFilterValue += gfWorkflows_DisplayFilterValue;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Fixes #2098. WorkflowDetail and WorkflowList blocks did not honor the ViewList security setting of the respective Workflow Type being viewed. Specific use case is the Background Check workflow. Users should be able to run it, but not necessarily see the internal data (such as SSN, Result PDF, etc.).

# Goal
_What will this pull request achieve and how will this fix the problem?_

Update blocks to honor that security. This allows admins to give users permission to "View" (i.e. run) a workflow but not view the details of attribute values and such inside the workflow. 

# Strategy
_How have you implemented your solution?_

Mentioned blocks now check to make sure the CurrentPerson can either Edit the workflow or can both `View` _and_ `ViewList` the workflow.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Generally speaking, should not be any. The default access for `ViewList` security is to allow All Users so there should not be any impact to existing installs unless they have modified that security role.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a