### PR TITLE
Added a ToString override to fix export problems

### DIFF
--- a/Rock/Reporting/DataSelect/Group/MemberListSelect.cs
+++ b/Rock/Reporting/DataSelect/Group/MemberListSelect.cs
@@ -106,6 +106,11 @@ namespace Rock.Reporting.DataSelect.Group
             public int PersonId { get; set; }
 
             public int GroupMemberId { get; set; }
+
+            public override string ToString()
+            {
+                return NickName + " " + LastName;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Contributor Agreement
Yes.

# Context
When exporting a group report with group members listed in it. It shows the class name instead of the members' names.

# Goal & Strategy
I added a ToString override to the MemberInfo class to print the same in an export as it does in the grid.

**Before**
![before](https://cloud.githubusercontent.com/assets/495787/24673150/3d5819dc-1945-11e7-8e38-79827c7513ba.JPG)

**After**
![after](https://cloud.githubusercontent.com/assets/495787/24673156/440ae84a-1945-11e7-8df3-af762aff8910.JPG)