### PR TITLE
 Missing Open tag < on line 108 - before onclick

### DIFF
--- a/RockWeb/Themes/Flat/Assets/Lava/CalendarItem.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/CalendarItem.lava
@@ -105,7 +105,7 @@
       <li>
         <a href="http://www.facebook.com/share.php?u="
           <url>
-            " onclick="return fbs_click()" target="_blank" class="socialicon socialicon-facebook" title="" data-original-title="Share via Facebook">
+            <onclick="return fbs_click()" target="_blank" class="socialicon socialicon-facebook" title="" data-original-title="Share via Facebook">
             <i class="fa fa-fw fa-facebook"></i>
           </a>
       </li>


### PR DESCRIPTION
There was a missing open tag on line 108 before the onclick event.

# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

# Context
_What is the problem you encountered that lead to you creating this pull request?_

# Goal
_What will this pull request achieve and how will this fix the problem?_

# Strategy
_How have you implemented your solution?_

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
