### PR TITLE
Fix Add button not showing in MetricValueList block.

### DIFF
--- a/RockWeb/Blocks/Reporting/MetricValueList.ascx.cs
+++ b/RockWeb/Blocks/Reporting/MetricValueList.ascx.cs
@@ -94,6 +94,7 @@ namespace RockWeb.Blocks.Reporting
 
             CreateDynamicControls( hfMetricId.Value.AsIntegerOrNull() );
             CreateEntityValueLookups( hfMetricId.Value.AsIntegerOrNull() );
+            SetGridSecurity();
 
             if ( !Page.IsPostBack )
             {
@@ -566,13 +567,20 @@ namespace RockWeb.Blocks.Reporting
 
             hfMetricId.Value = metricId.ToString();
             hfMetricCategoryId.Value = metricCategoryId.ToString();
+        }
 
+        /// <summary>
+        /// Set the appropriate security access to the gMetricValues grid buttons.
+        /// </summary>
+        private void SetGridSecurity()
+        {
+            int metricId = hfMetricId.ValueAsInt();
             gMetricValues.Actions.ShowAdd = false;
             gMetricValues.IsDeleteEnabled = false;
 
-            if ( metricId.HasValue && metricId.Value > 0 )
+            if ( metricId > 0 )
             {
-                var metric = new MetricService( new RockContext() ).Get( metricId.Value );
+                var metric = new MetricService( new RockContext() ).Get( metricId );
                 if ( UserCanEdit || ( metric != null && metric.IsAuthorized( Authorization.EDIT, CurrentPerson ) ) )
                 {
                     // Block Security and special attributes (RockPage takes care of View)


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When viewing the list of values in a Metric, the Add button vanishes after a Postback event occurs. Fixes #2119.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Set the property enabled/disabled state of the button on every page load rather than just initial non-postback page load.

# Strategy
_How have you implemented your solution?_

Move the code for enabling/disabling the Add button into it's own function that is called on each page load.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a