### PR TITLE
- Small improvement to the new family member input display.

### DIFF
--- a/Rock/Web/UI/Controls/NewFamily/Members.cs
+++ b/Rock/Web/UI/Controls/NewFamily/Members.cs
@@ -156,7 +156,7 @@ namespace Rock.Web.UI.Controls
             Controls.Add( _lbAddGroupMember );
             _lbAddGroupMember.ID = this.ID + "_btnAddGroupMember";
             _lbAddGroupMember.Click += lbAddGroupMember_Click;
-            _lbAddGroupMember.AddCssClass( "add btn btn-xs btn-action" );
+            _lbAddGroupMember.AddCssClass( "add btn btn-xs btn-action pull-right" );
             _lbAddGroupMember.CausesValidation = false;
 
             var iAddFilter = new HtmlGenericControl( "i" );
@@ -273,10 +273,7 @@ namespace Rock.Web.UI.Controls
                 writer.RenderBeginTag( HtmlTextWriterTag.Tfoot );
                 writer.RenderBeginTag( HtmlTextWriterTag.Tr );
 
-                writer.AddAttribute( HtmlTextWriterAttribute.Colspan, "8" );
-                writer.RenderBeginTag( HtmlTextWriterTag.Td );
-                writer.RenderEndTag();
-
+                writer.AddAttribute( HtmlTextWriterAttribute.Colspan, "9" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Td );
                 _lbAddGroupMember.RenderControl( writer );
                 writer.RenderEndTag();

--- a/Rock/Web/UI/Controls/NewFamily/MembersRow.cs
+++ b/Rock/Web/UI/Controls/NewFamily/MembersRow.cs
@@ -474,7 +474,7 @@ namespace Rock.Web.UI.Controls
             _lbDelete.Controls.Add( iDelete );
             iDelete.AddCssClass( "fa fa-times" );
 
-            _lbDelete.CssClass = "btn btn-sm btn-danger";
+            _lbDelete.CssClass = "btn btn-sm btn-danger pull-right";
             _lbDelete.Click += lbDelete_Click;
             _lbDelete.CausesValidation = false;
         }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

The rightmost column of the new family screen is very wide considering it only holds an X button. This is due to the Add Person button being stored in this same column.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Make better use of the screen real estate.

# Strategy
_How have you implemented your solution?_

Have the Add Person row span all the columns and align the button to the right. Also aligned the delete button to the right.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

Before:

![image](https://cloud.githubusercontent.com/assets/18447084/25022252/d14af904-205a-11e7-9380-f83fd91a3cad.png)

After: 

![image](https://cloud.githubusercontent.com/assets/18447084/25022257/d551bf92-205a-11e7-9cd9-fc3f8219eaf7.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
