### PR TITLE
Fixed delete note button.

### DIFF
--- a/Rock/Web/UI/Controls/NoteControl.cs
+++ b/Rock/Web/UI/Controls/NoteControl.cs
@@ -919,7 +919,7 @@ namespace Rock.Web.UI.Controls
                 if ( NoteId.HasValue )
                 {
                     note = service.Get( NoteId.Value );
-                    if ( note != null && note.NoteType.UserSelectable && note.IsAuthorized( Authorization.EDIT, currentPerson ) )
+                    if ( note != null && note.IsAuthorized( Authorization.EDIT, currentPerson ) )
                     {
                         service.Delete( note );
                         rockContext.SaveChanges();


### PR DESCRIPTION
User should be able to delete notes having edit rights.

# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_
Fix issue #2123 

# Goal
_What will this pull request achieve and how will this fix the problem?_
User cann't delete note even with Edit rights as the delete function only works when the note type is "User Selctable".

# Strategy
_How have you implemented your solution?_
Removed the "User Selectable" note type check from the delete function.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None that I'm aware of.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a