### PR TITLE
Fixed mispelled 'amount' in NumberBox validation message.

### DIFF
--- a/Rock/Web/UI/Controls/NumberBox.cs
+++ b/Rock/Web/UI/Controls/NumberBox.cs
@@ -143,7 +143,7 @@ namespace Rock.Web.UI.Controls
             switch( _rangeValidator.Type )
             {
                 case ValidationDataType.Integer: rangeMessageFormat = "{0} must be an integer"; break;
-                case ValidationDataType.Double: rangeMessageFormat = "{0} must be a decimal amout"; break;
+                case ValidationDataType.Double: rangeMessageFormat = "{0} must be a decimal amount"; break;
                 case ValidationDataType.Currency: rangeMessageFormat = "{0} must be a currency amount"; break;
                 case ValidationDataType.Date: rangeMessageFormat = "{0} must be a date"; break;
                 case ValidationDataType.String: rangeMessageFormat = "{0} must be a string"; break;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Invalid spelling.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Fix spelling of "amount".

# Strategy
_How have you implemented your solution?_

Located my text input cursor at the proper location of the file and pressed the "n" key once.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

It is possible that people will become confused and start entering the "amount" instead of the "amout" as they originally did.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

If I hadn't already spent 10x as long writing the pull request as fixing the spelling I would have totally put together a few screenshots too. :)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a