### PR TITLE
Added LavaInclude attribute to many virtual model properties.

### DIFF
--- a/Rock/Model/AttributeQualifier.cs
+++ b/Rock/Model/AttributeQualifier.cs
@@ -87,6 +87,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Attribute"/> that uses this AttributeQualifier.
         /// </value>
+        [LavaInclude]
         public virtual Attribute Attribute { get; set; }
 
         #endregion

--- a/Rock/Model/Audit.cs
+++ b/Rock/Model/Audit.cs
@@ -120,6 +120,7 @@ namespace Rock.Model
         /// <value>
         /// The person alias.
         /// </value>
+        [LavaInclude]
         public virtual Rock.Model.PersonAlias PersonAlias { get; set; }
 
         /// <summary>

--- a/Rock/Model/AuditDetail.cs
+++ b/Rock/Model/AuditDetail.cs
@@ -86,6 +86,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Audit"/>
         /// </value>
+        [LavaInclude]
         public virtual Model.Audit Audit { get; set; }
 
         #endregion

--- a/Rock/Model/Auth.cs
+++ b/Rock/Model/Auth.cs
@@ -130,14 +130,16 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Group"/> that this Auth entity allows or denies access to. If group based authorization is not used, this value will be null.
         /// </value>
+        [LavaInclude]
         public virtual Model.Group Group { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the <see cref="Rock.Model.PersonAlias"/> that this Auth entity allows or denies access to. This is used for Person based authorization.
         /// </summary>
         /// <value>
         /// The <see cref="Rock.Model.PersonAlias"/> that this Auth entity allows or denies access to. If person based authorization is not used, this value will be null.
         /// </value>
+        [LavaInclude]
         public virtual Model.PersonAlias PersonAlias { get; set; }
 
         /// <summary>
@@ -146,6 +148,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.EntityType"/> of of the entity that is being secured.
         /// </value>
+        [LavaInclude]
         public virtual Model.EntityType EntityType { get; set; }
 
         #endregion

--- a/Rock/Model/BackgroundCheck.cs
+++ b/Rock/Model/BackgroundCheck.cs
@@ -109,6 +109,7 @@ namespace Rock.Model
         /// <value>
         /// The person alias.
         /// </value>
+        [LavaInclude]
         public virtual Model.PersonAlias PersonAlias { get; set; }
 
         /// <summary>
@@ -117,6 +118,7 @@ namespace Rock.Model
         /// <value>
         /// The workflow.
         /// </value>
+        [LavaInclude]
         public virtual Model.Workflow Workflow { get; set; }
 
         /// <summary>
@@ -125,6 +127,7 @@ namespace Rock.Model
         /// <value>
         /// The response document.
         /// </value>
+        [LavaInclude]
         public virtual Model.BinaryFile ResponseDocument { get; set; }
 
         #endregion

--- a/Rock/Model/BenevolenceRequestDocument.cs
+++ b/Rock/Model/BenevolenceRequestDocument.cs
@@ -74,6 +74,7 @@ namespace Rock.Model
         /// <value>
         /// The package.
         /// </value>
+        [LavaInclude]
         public virtual BenevolenceRequest BenevolenceRequest { get; set; }
 
         /// <summary>

--- a/Rock/Model/BinaryFile.cs
+++ b/Rock/Model/BinaryFile.cs
@@ -191,6 +191,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.BinaryFileData"/> that contains the content of the file. 
         /// </value>
+        [LavaInclude]
         public virtual BinaryFileData DatabaseData { get; set; }
 
         /// <summary>
@@ -200,6 +201,7 @@ namespace Rock.Model
         /// The storage provider.
         /// </value>
         [NotMapped]
+        [LavaInclude]
         public virtual Storage.ProviderComponent StorageProvider { get; private set; }
 
         /// <summary>

--- a/Rock/Model/Block.cs
+++ b/Rock/Model/Block.cs
@@ -195,6 +195,7 @@ namespace Rock.Model
         /// The <see cref="Rock.Model.Page"/> entity that this Block is being implemented on. This value will 
         /// be null if the Block is implemented as part of a <see cref="Rock.Model.Layout"/>.
         /// </value>
+        [LavaInclude]
         public virtual Page Page { get; set; }
 
         /// <summary>
@@ -205,6 +206,7 @@ namespace Rock.Model
         /// The <see cref="Rock.Model.Layout"/> entity that this Block is being implemented on. This value will 
         /// be null if the Block is implemented as part of a <see cref="Rock.Model.Page"/>.
         /// </value>
+        [LavaInclude]
         public virtual Layout Layout { get; set; }
         
         /// <summary>

--- a/Rock/Model/Category.cs
+++ b/Rock/Model/Category.cs
@@ -146,6 +146,7 @@ namespace Rock.Model
         /// <value>
         /// The parent category
         /// </value>
+        [LavaInclude]
         public virtual Category ParentCategory { get; set; }
 
         /// <summary>

--- a/Rock/Model/CommunicationRecipient.cs
+++ b/Rock/Model/CommunicationRecipient.cs
@@ -178,6 +178,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Communication"/>
         /// </value>
+        [LavaInclude]
         public virtual Communication Communication { get; set; }
 
 

--- a/Rock/Model/ConnectionActivityType.cs
+++ b/Rock/Model/ConnectionActivityType.cs
@@ -80,6 +80,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the connection.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionType ConnectionType { get; set; }
 
         #endregion

--- a/Rock/Model/ConnectionOpportunity.cs
+++ b/Rock/Model/ConnectionOpportunity.cs
@@ -131,6 +131,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the connection.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionType ConnectionType { get; set; }
 
         /// <summary>
@@ -156,6 +157,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.BinaryFile"/> that contains the Opportunity's photo.
         /// </value>
+        [LavaInclude]
         public virtual BinaryFile Photo { get; set; }
 
         /// <summary>

--- a/Rock/Model/ConnectionOpportunityCampus.cs
+++ b/Rock/Model/ConnectionOpportunityCampus.cs
@@ -75,6 +75,7 @@ namespace Rock.Model
         /// <value>
         /// The connection opportunity.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionOpportunity ConnectionOpportunity { get; set; }
 
         /// <summary>
@@ -83,6 +84,7 @@ namespace Rock.Model
         /// <value>
         /// The campus.
         /// </value>
+        [LavaInclude]
         public virtual Campus Campus { get; set; }
 
         /// <summary>
@@ -91,6 +93,7 @@ namespace Rock.Model
         /// <value>
         /// The default connector person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias DefaultConnectorPersonAlias { get; set; }
 
         #endregion

--- a/Rock/Model/ConnectionOpportunityConnectorGroup.cs
+++ b/Rock/Model/ConnectionOpportunityConnectorGroup.cs
@@ -75,6 +75,7 @@ namespace Rock.Model
         /// <value>
         /// The connection opportunity.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionOpportunity ConnectionOpportunity { get; set; }
 
         /// <summary>

--- a/Rock/Model/ConnectionOpportunityGroup.cs
+++ b/Rock/Model/ConnectionOpportunityGroup.cs
@@ -66,6 +66,7 @@ namespace Rock.Model
         /// <value>
         /// The connection opportunity.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionOpportunity ConnectionOpportunity { get; set; }
 
         /// <summary>

--- a/Rock/Model/ConnectionOpportunityGroupConfig.cs
+++ b/Rock/Model/ConnectionOpportunityGroupConfig.cs
@@ -96,6 +96,7 @@ namespace Rock.Model
         /// <value>
         /// The connection opportunity.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionOpportunity ConnectionOpportunity { get; set; }
 
         /// <summary>
@@ -104,6 +105,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the group.
         /// </value>
+        [LavaInclude]
         public virtual GroupType GroupType { get; set; }
 
         /// <summary>
@@ -112,6 +114,7 @@ namespace Rock.Model
         /// <value>
         /// The group member role.
         /// </value>
+        [LavaInclude]
         public virtual GroupTypeRole GroupMemberRole { get; set; }
 
         #endregion

--- a/Rock/Model/ConnectionRequestWorkflow.cs
+++ b/Rock/Model/ConnectionRequestWorkflow.cs
@@ -94,6 +94,7 @@ namespace Rock.Model
         /// <value>
         /// The connection request.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionRequest ConnectionRequest { get; set; }
 
         /// <summary>
@@ -102,6 +103,7 @@ namespace Rock.Model
         /// <value>
         /// The connection workflow.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionWorkflow ConnectionWorkflow { get; set; }
 
         /// <summary>
@@ -110,6 +112,7 @@ namespace Rock.Model
         /// <value>
         /// The workflow.
         /// </value>
+        [LavaInclude]
         public virtual Workflow Workflow { get; set; }
 
         #endregion

--- a/Rock/Model/ConnectionStatus.cs
+++ b/Rock/Model/ConnectionStatus.cs
@@ -107,6 +107,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the connection.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionType ConnectionType { get; set; }
 
         #endregion

--- a/Rock/Model/ConnectionType.cs
+++ b/Rock/Model/ConnectionType.cs
@@ -124,6 +124,7 @@ namespace Rock.Model
         /// <value>
         /// The owner person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias OwnerPersonAlias { get; set; }
 
         /// <summary>
@@ -132,6 +133,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.ConnectionStatus">ConnectionStatuses</see> who are associated with the ConnectionType.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<ConnectionStatus> ConnectionStatuses
         {
             get { return _connectionStatuses ?? ( _connectionStatuses = new Collection<ConnectionStatus>() ); }
@@ -146,6 +148,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.ConnectionWorkflow">ConnectionWorkflows</see> who are associated with the ConnectionType.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<ConnectionWorkflow> ConnectionWorkflows
         {
             get { return _connectionWorkflows ?? ( _connectionWorkflows = new Collection<ConnectionWorkflow>() ); }
@@ -160,6 +163,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.ConnectionActivityType">ConnectionActivityTypes</see> who are associated with the ConnectionType.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<ConnectionActivityType> ConnectionActivityTypes
         {
             get { return _connectionActivityTypes ?? ( _connectionActivityTypes = new Collection<ConnectionActivityType>() ); }
@@ -174,6 +178,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.ConnectionOpportunity">ConnectionOpportunities</see> who are associated with the ConnectionType.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<ConnectionOpportunity> ConnectionOpportunities
         {
             get { return _connectionOpportunities ?? ( _connectionOpportunities = new Collection<ConnectionOpportunity>() ); }

--- a/Rock/Model/ConnectionWorkflow.cs
+++ b/Rock/Model/ConnectionWorkflow.cs
@@ -92,6 +92,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the connection.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionType ConnectionType { get; set; }
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace Rock.Model
         /// <value>
         /// The connection opportunity.
         /// </value>
+        [LavaInclude]
         public virtual ConnectionOpportunity ConnectionOpportunity { get; set; }
 
         /// <summary>

--- a/Rock/Model/ContentChannel.cs
+++ b/Rock/Model/ContentChannel.cs
@@ -188,6 +188,7 @@ namespace Rock.Model
         /// <value>
         /// The items.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<ContentChannelItem> Items { get; set; }
 
         /// <summary>

--- a/Rock/Model/ContentChannelItem.cs
+++ b/Rock/Model/ContentChannelItem.cs
@@ -181,6 +181,7 @@ namespace Rock.Model
         /// <value>
         /// The approved by person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias ApprovedByPersonAlias { get; set; }
 
         /// <summary>

--- a/Rock/Model/ContentChannelItemAssociation.cs
+++ b/Rock/Model/ContentChannelItemAssociation.cs
@@ -70,6 +70,7 @@ namespace Rock.Model
         /// <value>
         /// The content channel item.
         /// </value>
+        [LavaInclude]
         public virtual ContentChannelItem ContentChannelItem { get; set; }
 
         /// <summary>

--- a/Rock/Model/ContentChannelType.cs
+++ b/Rock/Model/ContentChannelType.cs
@@ -116,6 +116,7 @@ namespace Rock.Model
         /// <value>
         /// The channels.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<ContentChannel> Channels { get; set; }
 
         /// <summary>

--- a/Rock/Model/DataViewFilter.cs
+++ b/Rock/Model/DataViewFilter.cs
@@ -88,6 +88,7 @@ namespace Rock.Model
         /// <value>
         /// The parent DataViewFilter.
         /// </value>
+        [LavaInclude]
         public virtual DataViewFilter Parent { get; set; }
 
         /// <summary>

--- a/Rock/Model/DefinedValue.cs
+++ b/Rock/Model/DefinedValue.cs
@@ -94,6 +94,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.DefinedType"/> that this DefinedValue belongs to.
         /// </value>
+        [LavaInclude]
         public virtual DefinedType DefinedType { get; set; }
 
         #endregion

--- a/Rock/Model/Device.cs
+++ b/Rock/Model/Device.cs
@@ -131,6 +131,7 @@ namespace Rock.Model
         /// A physical location would signify where the device is at. A situation where a geographic fence could be used would be for mobile check in, 
         /// where if the device is within the fence, a user would be able to check in from their mobile device.
         /// </remarks>
+        [LavaInclude]
         public virtual Location Location { get; set; }
 
         /// <summary>
@@ -139,6 +140,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.Location">Locations</see> that use this device.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<Location> Locations
         {
             get { return _locations ?? ( _locations = new Collection<Location>() ); }
@@ -152,6 +154,7 @@ namespace Rock.Model
         /// <value>
         /// The printer that is associated with the device.
         /// </value>
+        [LavaInclude]
         public virtual Device PrinterDevice { get; set; }
 
         /// <summary>

--- a/Rock/Model/EntitySet.cs
+++ b/Rock/Model/EntitySet.cs
@@ -111,6 +111,7 @@ namespace Rock.Model
         /// <value>
         /// The parent entity set.
         /// </value>
+        [LavaInclude]
         public virtual EntitySet ParentEntitySet { get; set; }
 
         /// <summary>

--- a/Rock/Model/EntitySetItem.cs
+++ b/Rock/Model/EntitySetItem.cs
@@ -106,6 +106,7 @@ namespace Rock.Model
         /// <value>
         /// The metric.
         /// </value>
+        [LavaInclude]
         public virtual EntitySet EntitySet { get; set; }
 
         #endregion

--- a/Rock/Model/EntityType.cs
+++ b/Rock/Model/EntityType.cs
@@ -262,6 +262,7 @@ namespace Rock.Model
         /// <value>
         /// A <see cref="System.Boolean"/> value that is <c>true</c> if this instance is system; otherwise, <c>false</c>.
         /// </value>
+        [LavaInclude]
         public virtual bool IsSystem
         {
             get { return IsSecured || IsEntity; }

--- a/Rock/Model/EventItemOccurrenceChannelItem.cs
+++ b/Rock/Model/EventItemOccurrenceChannelItem.cs
@@ -60,6 +60,7 @@ namespace Rock.Model
         /// <value>
         /// The event item occurrence.
         /// </value>
+        [LavaInclude]
         public virtual EventItemOccurrence EventItemOccurrence { get; set; }
 
         /// <summary>

--- a/Rock/Model/EventItemOccurrenceGroupMap.cs
+++ b/Rock/Model/EventItemOccurrenceGroupMap.cs
@@ -82,7 +82,7 @@ namespace Rock.Model
         [MaxLength( 200 )]
         [DataMember]
         public string UrlSlug { get; set; }
-        
+
         #region Virtual Properties
 
         /// <summary>
@@ -91,6 +91,7 @@ namespace Rock.Model
         /// <value>
         /// The event item occurrence.
         /// </value>
+        [LavaInclude]
         public virtual EventItemOccurrence EventItemOccurrence { get; set; }
 
         /// <summary>

--- a/Rock/Model/ExceptionLog.cs
+++ b/Rock/Model/ExceptionLog.cs
@@ -181,6 +181,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Site"/> that the exception occurred on. If this did not occur on a site, this value will be null.
         /// </value>
+        [LavaInclude]
         public virtual Rock.Model.Site Site { get; set; }
 
         /// <summary>
@@ -190,6 +191,7 @@ namespace Rock.Model
         /// The <see cref="Rock.Model.Page"/> that the exception occurred on. If this exception was not thrown on a <see cref="Rock.Model.Page"/>
         /// this value will be null.
         /// </value>
+        [LavaInclude]
         public virtual Rock.Model.Page Page { get; set; }
 
         #endregion

--- a/Rock/Model/FinancialAccount.cs
+++ b/Rock/Model/FinancialAccount.cs
@@ -234,6 +234,7 @@ namespace Rock.Model
         /// <value>
         /// A <see cref="System.String"/> representing the parent FinancialAccount.
         /// </value>
+        [LavaInclude]
         public virtual FinancialAccount ParentAccount { get; set; }
 
         /// <summary>
@@ -242,6 +243,7 @@ namespace Rock.Model
         /// <value>
         /// the <see cref="Rock.Model.Campus"/> that this FinancialAccount is associated with.
         /// </value>
+        [LavaInclude]
         public virtual Campus Campus { get; set; }
 
         /// <summary>

--- a/Rock/Model/FinancialPersonBankAccount.cs
+++ b/Rock/Model/FinancialPersonBankAccount.cs
@@ -78,6 +78,7 @@ namespace Rock.Model
         /// <value>
         /// The person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias PersonAlias { get; set; }
 
         #endregion

--- a/Rock/Model/FinancialPersonSavedAccount.cs
+++ b/Rock/Model/FinancialPersonSavedAccount.cs
@@ -117,6 +117,7 @@ namespace Rock.Model
         /// <value>
         /// The person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias PersonAlias { get; set; }
 
         /// <summary>
@@ -125,6 +126,7 @@ namespace Rock.Model
         /// <value>
         /// The group.
         /// </value>
+        [LavaInclude]
         public virtual Group Group { get; set; }
 
         /// <summary>

--- a/Rock/Model/FinancialScheduledTransaction.cs
+++ b/Rock/Model/FinancialScheduledTransaction.cs
@@ -215,6 +215,7 @@ namespace Rock.Model
         /// <value>
         /// The authorized person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias AuthorizedPersonAlias { get; set; }
 
         /// <summary>

--- a/Rock/Model/FinancialScheduledTransactionDetail.cs
+++ b/Rock/Model/FinancialScheduledTransactionDetail.cs
@@ -100,6 +100,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.FinancialScheduledTransaction"/> that the transaction detail belongs to.
         /// </value>
+        [LavaInclude]
         public virtual FinancialScheduledTransaction ScheduledTransaction { get; set; }
 
         /// <summary>
@@ -108,6 +109,7 @@ namespace Rock.Model
         /// <value>
         /// Tehe <see cref="Rock.Model.FinancialAccount"/>/account that the <see cref="Amount"/> of this transaction detail will be credited toward.
         /// </value>
+        [LavaInclude]
         public virtual FinancialAccount Account { get; set; }
 
         /// <summary>

--- a/Rock/Model/FinancialTransaction.cs
+++ b/Rock/Model/FinancialTransaction.cs
@@ -299,6 +299,7 @@ namespace Rock.Model
         /// <value>
         /// A <see cref="Rock.Model.FinancialBatch"/> that contains the transaction.
         /// </value>
+        [LavaInclude]
         public virtual FinancialBatch Batch { get; set; }
 
         /// <summary>
@@ -344,6 +345,7 @@ namespace Rock.Model
         /// The <see cref="Rock.Model.FinancialTransactionRefund">refund transaction</see> associated with this transaction. This will be null if the transaction
         /// is not a refund transaction.
         /// </value>
+        [LavaInclude]
         public virtual FinancialTransactionRefund RefundDetails { get; set; }
 
         /// <summary>
@@ -352,6 +354,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.FinancialScheduledTransaction"/> that initiated this transaction.
         /// </value>
+        [LavaInclude]
         public virtual FinancialScheduledTransaction ScheduledTransaction { get; set; }
 
         /// <summary>
@@ -361,6 +364,7 @@ namespace Rock.Model
         /// <value>
         /// The processed by person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias ProcessedByPersonAlias { get; set; }
 
         /// <summary>
@@ -398,6 +402,7 @@ namespace Rock.Model
         /// <value>
         /// The refunds.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<FinancialTransactionRefund> Refunds
         {
             get { return _refunds ?? ( _refunds = new Collection<FinancialTransactionRefund>() ); }

--- a/Rock/Model/FinancialTransactionImage.cs
+++ b/Rock/Model/FinancialTransactionImage.cs
@@ -70,6 +70,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.FinancialTransaction"/> that this image belongs to.
         /// </value>
+        [LavaInclude]
         public virtual FinancialTransaction Transaction { get; set; }
 
         /// <summary>
@@ -78,6 +79,7 @@ namespace Rock.Model
         /// <value>
         /// The image's <see cref="Rock.Model.BinaryFile"/>
         /// </value>
+        [LavaInclude]
         public virtual BinaryFile BinaryFile { get; set; }
 
         #endregion

--- a/Rock/Model/Group.cs
+++ b/Rock/Model/Group.cs
@@ -257,6 +257,7 @@ namespace Rock.Model
         /// <value>
         /// A <see cref="Rock.Model.Group"/> representing the Group's parent group. If this Group does not have a parent, the value will be null.
         /// </value>
+        [LavaInclude]
         public virtual Group ParentGroup { get; set; }
 
         /// <summary>
@@ -384,6 +385,7 @@ namespace Rock.Model
         /// <value>
         /// The group member workflow triggers.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<GroupMemberWorkflowTrigger> GroupMemberWorkflowTriggers
         {
             get { return _triggers ?? ( _triggers = new Collection<GroupMemberWorkflowTrigger>() ); }
@@ -397,6 +399,7 @@ namespace Rock.Model
         /// <value>
         /// The linkages.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<EventItemOccurrenceGroupMap> Linkages
         {
             get { return _linkages ?? ( _linkages = new Collection<EventItemOccurrenceGroupMap>() ); }

--- a/Rock/Model/GroupLocation.cs
+++ b/Rock/Model/GroupLocation.cs
@@ -122,6 +122,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Group"/> that is associated with this GroupLocation.
         /// </value>
+        [LavaInclude]
         public virtual Group Group { get; set; }
 
         /// <summary>

--- a/Rock/Model/GroupMemberRequirement.cs
+++ b/Rock/Model/GroupMemberRequirement.cs
@@ -98,6 +98,7 @@ namespace Rock.Model
         /// <value>
         /// The group member.
         /// </value>
+        [LavaInclude]
         public virtual GroupMember GroupMember { get; set; }
 
         /// <summary>
@@ -106,6 +107,7 @@ namespace Rock.Model
         /// <value>
         /// The group requirement.
         /// </value>
+        [LavaInclude]
         public virtual GroupRequirement GroupRequirement { get; set; }
 
         #endregion

--- a/Rock/Model/GroupMemberWorkflowTrigger.cs
+++ b/Rock/Model/GroupMemberWorkflowTrigger.cs
@@ -133,6 +133,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the group.
         /// </value>
+        [LavaInclude]
         public virtual GroupType GroupType { get; set; }
 
         /// <summary>
@@ -144,6 +145,7 @@ namespace Rock.Model
         /// <remarks>
         /// NOTE: [DataMember] attribute is intentionally ommited to prevent having to serialize all group members (times out on large groups)
         /// </remarks>
+        [LavaInclude]
         public virtual Group Group { get; set; }
 
         /// <summary>

--- a/Rock/Model/GroupRequirement.cs
+++ b/Rock/Model/GroupRequirement.cs
@@ -78,6 +78,7 @@ namespace Rock.Model
         /// <value>
         /// The group.
         /// </value>
+        [LavaInclude]
         public virtual Group Group { get; set; }
 
         /// <summary>
@@ -95,6 +96,7 @@ namespace Rock.Model
         /// <value>
         /// The group type role.
         /// </value>
+        [LavaInclude]
         public virtual GroupTypeRole GroupRole { get; set; }
 
         #endregion

--- a/Rock/Model/GroupRequirementType.cs
+++ b/Rock/Model/GroupRequirementType.cs
@@ -165,6 +165,7 @@ namespace Rock.Model
         /// <value>
         /// The data view.
         /// </value>
+        [LavaInclude]
         public virtual DataView DataView { get; set; }
 
         /// <summary>
@@ -173,6 +174,7 @@ namespace Rock.Model
         /// <value>
         /// The warning data view.
         /// </value>
+        [LavaInclude]
         public virtual DataView WarningDataView { get; set; }
 
         #endregion

--- a/Rock/Model/GroupType.cs
+++ b/Rock/Model/GroupType.cs
@@ -354,6 +354,7 @@ namespace Rock.Model
         /// <value>
         /// A collection containing a collection of the <see cref="Rock.Model.Group">Groups</see> that belong to this GroupType.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<Group> Groups
         {
             get { return _groups ?? ( _groups = new Collection<Group>() ); }
@@ -469,6 +470,7 @@ namespace Rock.Model
         /// <value>
         /// A <see cref="System.Int32"/> representing the number of <see cref="Rock.Model.Group">Groups</see> that belong to this GroupType.
         /// </value>
+        [LavaInclude]
         public virtual int GroupCount
         {
             get
@@ -498,6 +500,7 @@ namespace Rock.Model
         /// This is similar to a parent or a template GroupType.
         /// </summary>
         /// <value>The <see cref="Rock.Model.GroupType"/> that this GroupType is inheriting settings and properties from.</value>
+        [LavaInclude]
         public virtual GroupType InheritedGroupType { get; set; }
 
         #endregion

--- a/Rock/Model/GroupTypeRole.cs
+++ b/Rock/Model/GroupTypeRole.cs
@@ -153,6 +153,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.GroupType"/> that this GroupRole belongs to.
         /// </value>
+        [LavaInclude]
         public virtual GroupType GroupType { get; set; }
 
         #endregion

--- a/Rock/Model/HtmlContent.cs
+++ b/Rock/Model/HtmlContent.cs
@@ -133,6 +133,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Block"/> that this HTML content appears on.
         /// </value>
+        [LavaInclude]
         public virtual Block Block { get; set; }
 
         /// <summary>
@@ -141,6 +142,7 @@ namespace Rock.Model
         /// <value>
         /// The approved by person alias.
         /// </value>
+        [LavaInclude]
         public virtual Model.PersonAlias ApprovedByPersonAlias { get; set; }
 
         #endregion

--- a/Rock/Model/InteractionSession.cs
+++ b/Rock/Model/InteractionSession.cs
@@ -84,6 +84,7 @@ namespace Rock.Model
         /// <value>
         /// The Device type.
         /// </value>
+        [LavaInclude]
         public virtual InteractionDeviceType DeviceType { get; set; }
 
         /// <summary>

--- a/Rock/Model/Layout.cs
+++ b/Rock/Model/Layout.cs
@@ -112,6 +112,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Site" /> that this Layout Block is associated with.
         /// </value>
+        [LavaInclude]
         public virtual Site Site { get; set; }
 
         /// <summary>
@@ -120,6 +121,7 @@ namespace Rock.Model
         /// <value>
         /// Collection of <see cref="Rock.Model.Page">Pages</see> that use this Layout.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<Page> Pages
         {
             get { return _pages ?? ( _pages = new Collection<Page>() ); }

--- a/Rock/Model/Location.cs
+++ b/Rock/Model/Location.cs
@@ -347,6 +347,7 @@ namespace Rock.Model
         /// <value>
         /// A Location object representing the parent location of the current location. If this Location does not have a parent Location, this value will be null.
         /// </value>
+        [LavaInclude]
         public virtual Location ParentLocation { get; set; }
 
         /// <summary>
@@ -395,6 +396,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.GroupLocation"/> entities that reference this Location.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<GroupLocation> GroupLocations
         {
             get { return _groupLocations ?? ( _groupLocations = new Collection<GroupLocation>() ); }

--- a/Rock/Model/MergeTemplate.cs
+++ b/Rock/Model/MergeTemplate.cs
@@ -101,6 +101,7 @@ namespace Rock.Model
         /// <value>
         /// The template binary file.
         /// </value>
+        [LavaInclude]
         public virtual BinaryFile TemplateBinaryFile { get; set; }
 
         /// <summary>
@@ -109,6 +110,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the merge template type entity.
         /// </value>
+        [LavaInclude]
         public virtual EntityType MergeTemplateTypeEntityType { get; set; }
 
         /// <summary>

--- a/Rock/Model/Metric.cs
+++ b/Rock/Model/Metric.cs
@@ -205,6 +205,7 @@ namespace Rock.Model
         /// <value>
         /// The metric values.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<MetricValue> MetricValues { get; set; }
 
         /// <summary>
@@ -222,6 +223,7 @@ namespace Rock.Model
         /// <value>
         /// The data view.
         /// </value>
+        [LavaInclude]
         public virtual DataView DataView { get; set; }
 
         /// <summary>
@@ -230,6 +232,7 @@ namespace Rock.Model
         /// <value>
         /// The metric champion person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias MetricChampionPersonAlias { get; set; }
 
         /// <summary>
@@ -238,6 +241,7 @@ namespace Rock.Model
         /// <value>
         /// The admin person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias AdminPersonAlias { get; set; }
 
         /// <summary>
@@ -246,6 +250,7 @@ namespace Rock.Model
         /// <value>
         /// The schedule.
         /// </value>
+        [LavaInclude]
         public virtual Schedule Schedule { get; set; }
 
         /// <summary>
@@ -265,6 +270,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the numeric data.
         /// </value>
+        [LavaInclude]
         public MetricNumericDataType NumericDataType { get; set; }
 
         #endregion

--- a/Rock/Model/MetricPartition.cs
+++ b/Rock/Model/MetricPartition.cs
@@ -110,6 +110,7 @@ namespace Rock.Model
         /// <value>
         /// The metric.
         /// </value>
+        [LavaInclude]
         public virtual Metric Metric { get; set; }
 
         /// <summary>

--- a/Rock/Model/MetricValue.cs
+++ b/Rock/Model/MetricValue.cs
@@ -108,6 +108,7 @@ namespace Rock.Model
         /// <value>
         /// The metric.
         /// </value>
+        [LavaInclude]
         public virtual Metric Metric { get; set; }
 
         /// <summary>

--- a/Rock/Model/MetricValuePartition.cs
+++ b/Rock/Model/MetricValuePartition.cs
@@ -70,6 +70,7 @@ namespace Rock.Model
         /// <value>
         /// The metric partition.
         /// </value>
+        [LavaInclude]
         public virtual MetricPartition MetricPartition { get; set; }
 
         /// <summary>
@@ -78,6 +79,7 @@ namespace Rock.Model
         /// <value>
         /// The metric value.
         /// </value>
+        [LavaInclude]
         public virtual MetricValue MetricValue { get; set; }
 
         #endregion

--- a/Rock/Model/Page.cs
+++ b/Rock/Model/Page.cs
@@ -355,6 +355,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Page"/> entity for the parent Page
         /// </value>
+        [LavaInclude]
         public virtual Page ParentPage { get; set; }
 
         /// <summary>
@@ -380,6 +381,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Layout"/> entity that the Page is using
         /// </value>
+        [LavaInclude]
         public virtual Layout Layout { get; set; }
 
         /// <summary>

--- a/Rock/Model/PageContext.cs
+++ b/Rock/Model/PageContext.cs
@@ -95,6 +95,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Page"/> that uses this PageContext.
         /// </value>
+        [LavaInclude]
         public virtual Page Page { get; set; }
 
         #endregion

--- a/Rock/Model/PageRoute.cs
+++ b/Rock/Model/PageRoute.cs
@@ -86,6 +86,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Page"/> that is associated with the RoutePath.
         /// </value>
+        [LavaInclude]
         public virtual Page Page { get; set; }
 
         #endregion

--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -787,6 +787,7 @@ namespace Rock.Model
         /// <value>
         /// A collection of <see cref="Rock.Model.GroupMember">GroupMember</see> entities representing the group memberships that are associated with
         /// </value>
+        [LavaInclude]
         public virtual ICollection<GroupMember> Members
         {
             get { return _members; }
@@ -801,6 +802,7 @@ namespace Rock.Model
         /// <value>
         /// The aliases.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<PersonAlias> Aliases
         {
             get { return _aliases; }
@@ -896,6 +898,7 @@ namespace Rock.Model
         /// <value>
         /// The giving group.
         /// </value>
+        [LavaInclude]
         public virtual Group GivingGroup { get; set; }
 
         /// <summary>
@@ -1157,6 +1160,7 @@ namespace Rock.Model
         /// A <see cref="System.Double"/> representing the Person's age (including fraction of year)
         /// </value>
         [NotMapped]
+        [LavaInclude]
         public virtual double? AgePrecise
         {
             get

--- a/Rock/Model/PersonDuplicate.cs
+++ b/Rock/Model/PersonDuplicate.cs
@@ -132,6 +132,7 @@ namespace Rock.Model
         /// <value>
         /// The person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias PersonAlias { get; set; }
 
         /// <summary>
@@ -140,6 +141,7 @@ namespace Rock.Model
         /// <value>
         /// The duplicate person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias DuplicatePersonAlias { get; set; }
 
         #endregion

--- a/Rock/Model/PersonPreviousName.cs
+++ b/Rock/Model/PersonPreviousName.cs
@@ -68,6 +68,7 @@ namespace Rock.Model
         /// <value>
         /// The person alias.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias PersonAlias { get; set; }
 
         /// <summary>

--- a/Rock/Model/PersonViewed.cs
+++ b/Rock/Model/PersonViewed.cs
@@ -94,14 +94,16 @@ namespace Rock.Model
         /// <value>
         /// A <see cref="Rock.Model.Person"/> entity representing the viewer.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias ViewerPersonAlias { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the <see cref="Rock.Model.Person"/> entity of the individual who was viewed.
         /// </summary>
         /// <value>
         /// A <see cref="Rock.Model.Person"/> entity representing the person who was viewed.
         /// </value>
+        [LavaInclude]
         public virtual PersonAlias TargetPersonAlias { get; set; }
 
         #endregion

--- a/Rock/Model/PhoneNumber.cs
+++ b/Rock/Model/PhoneNumber.cs
@@ -162,6 +162,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Person"/> that the phone number belongs to.
         /// </value>
+        [LavaInclude]
         public virtual Person Person { get; set; }
 
         /// <summary>

--- a/Rock/Model/PrayerRequest.cs
+++ b/Rock/Model/PrayerRequest.cs
@@ -245,6 +245,7 @@ namespace Rock.Model
         /// <value>
         /// The request's group.
         /// </value>
+        [LavaInclude]
         public virtual Group Group { get; set; }
 
         /// <summary>

--- a/Rock/Model/RegistrationRegistrant.cs
+++ b/Rock/Model/RegistrationRegistrant.cs
@@ -110,6 +110,7 @@ namespace Rock.Model
         /// <value>
         /// The registration instance.
         /// </value>
+        [LavaInclude]
         public virtual Registration Registration { get; set; }
 
         /// <summary>

--- a/Rock/Model/RegistrationRegistrantFee.cs
+++ b/Rock/Model/RegistrationRegistrantFee.cs
@@ -94,6 +94,7 @@ namespace Rock.Model
         /// <value>
         /// The registration registrant.
         /// </value>
+        [LavaInclude]
         public virtual RegistrationRegistrant RegistrationRegistrant { get; set; }
 
         /// <summary>

--- a/Rock/Model/RegistrationTemplate.cs
+++ b/Rock/Model/RegistrationTemplate.cs
@@ -514,6 +514,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Page" /> entity for the parent Page
         /// </value>
+        [LavaInclude]
         public virtual Category Category { get; set; }
 
         /// <summary>
@@ -522,6 +523,7 @@ namespace Rock.Model
         /// <value>
         /// The type of the group.
         /// </value>
+        [LavaInclude]
         public virtual GroupType GroupType { get; set; }
 
         /// <summary>
@@ -578,13 +580,14 @@ namespace Rock.Model
             set { _fees = value; }
         }
         private ICollection<RegistrationTemplateFee> _fees;
-        
+
         /// <summary>
         /// Gets or sets the collection of the current page's child pages.
         /// </summary>
         /// <value>
         /// Collection of child pages
         /// </value>
+        [LavaInclude]
         public virtual ICollection<RegistrationInstance> Instances
         {
             get { return _registrationInstances ?? ( _registrationInstances = new Collection<RegistrationInstance>() ); }

--- a/Rock/Model/RegistrationTemplateDiscount.cs
+++ b/Rock/Model/RegistrationTemplateDiscount.cs
@@ -141,6 +141,7 @@ namespace Rock.Model
         /// <value>
         /// The registration template.
         /// </value>
+        [LavaInclude]
         public virtual RegistrationTemplate RegistrationTemplate { get; set; }
 
         /// <summary>
@@ -150,6 +151,7 @@ namespace Rock.Model
         /// The discount string.
         /// </value>
         [NotMapped]
+        [LavaInclude]
         public virtual string DiscountString
         {
             get
@@ -173,6 +175,7 @@ namespace Rock.Model
         /// The discount limits string.
         /// </value>
         [NotMapped]
+        [LavaInclude]
         public virtual string DiscountLimitsString
         {
             get

--- a/Rock/Model/RegistrationTemplateFee.cs
+++ b/Rock/Model/RegistrationTemplateFee.cs
@@ -115,6 +115,7 @@ namespace Rock.Model
         /// <value>
         /// The registration template.
         /// </value>
+        [LavaInclude]
         public virtual RegistrationTemplate RegistrationTemplate { get; set; }
 
         #endregion

--- a/Rock/Model/RegistrationTemplateForm.cs
+++ b/Rock/Model/RegistrationTemplateForm.cs
@@ -77,6 +77,7 @@ namespace Rock.Model
         /// <value>
         /// The registration template.
         /// </value>
+        [LavaInclude]
         public virtual RegistrationTemplate RegistrationTemplate { get; set; }
 
         /// <summary>

--- a/Rock/Model/RegistrationTemplateFormField.cs
+++ b/Rock/Model/RegistrationTemplateFormField.cs
@@ -165,6 +165,7 @@ namespace Rock.Model
         /// <value>
         /// The registration template form.
         /// </value>
+        [LavaInclude]
         public virtual RegistrationTemplateForm RegistrationTemplateForm { get; set; }
 
         /// <summary>

--- a/Rock/Model/ReportField.cs
+++ b/Rock/Model/ReportField.cs
@@ -133,6 +133,7 @@ namespace Rock.Model
         /// <value>
         /// The report.
         /// </value>
+        [LavaInclude]
         public virtual Report Report { get; set; }
 
         /// <summary>

--- a/Rock/Model/RestAction.cs
+++ b/Rock/Model/RestAction.cs
@@ -83,6 +83,7 @@ namespace Rock.Model
         /// <value>
         /// The controller.
         /// </value>
+        [LavaInclude]
         public virtual RestController Controller { get; set; }
 
         #endregion

--- a/Rock/Model/ScheduleCategoryExclusion.cs
+++ b/Rock/Model/ScheduleCategoryExclusion.cs
@@ -83,6 +83,7 @@ namespace Rock.Model
         /// <value>
         /// The report.
         /// </value>
+        [LavaInclude]
         public virtual Category Category { get; set; }
 
         #endregion

--- a/Rock/Model/Site.cs
+++ b/Rock/Model/Site.cs
@@ -406,6 +406,7 @@ namespace Rock.Model
         /// <value>
         /// The change password page.
         /// </value>
+        [LavaInclude]
         public virtual Page ChangePasswordPage { get; set; }
 
         /// <summary>

--- a/Rock/Model/SiteDomain.cs
+++ b/Rock/Model/SiteDomain.cs
@@ -81,6 +81,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Site"/> that this SiteDomain is associated with.
         /// </value>
+        [LavaInclude]
         public virtual Site Site { get; set; }
 
         #endregion

--- a/Rock/Model/Tag.cs
+++ b/Rock/Model/Tag.cs
@@ -128,6 +128,7 @@ namespace Rock.Model
         /// <value>
         /// The owner person alias.
         /// </value>
+        [LavaInclude]
         public virtual Model.PersonAlias OwnerPersonAlias { get; set; }
 
         /// <summary>
@@ -145,6 +146,7 @@ namespace Rock.Model
         /// <value>
         /// A collection containing of <see cref="Rock.Model.TaggedItem">TaggedItems</see> representing the entities that use this tag.
         /// </value>
+        [LavaInclude]
         public virtual ICollection<TaggedItem> TaggedItems { get; set; }
         
         #endregion

--- a/Rock/Model/UserLogin.cs
+++ b/Rock/Model/UserLogin.cs
@@ -203,6 +203,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Person"/> that this UserLogin is associated with.
         /// </value>
+        [LavaInclude]
         public virtual Model.Person Person { get; set; }
 
         /// <summary>
@@ -222,6 +223,7 @@ namespace Rock.Model
         ///   A <see cref="System.Boolean"/> value that is <c>true</c> if the user actually authenticated; otherwise <c>false</c>.
         /// </value>
         [NotMapped]
+        [LavaInclude]
         public virtual bool IsAuthenticated
         {
             get

--- a/Rock/Model/WorkflowActionForm.cs
+++ b/Rock/Model/WorkflowActionForm.cs
@@ -127,6 +127,7 @@ namespace Rock.Model
         /// <value>
         /// The notification system email.
         /// </value>
+        [LavaInclude]
         public virtual SystemEmail NotificationSystemEmail {get;set;}
 
         /// <summary>

--- a/Rock/Model/WorkflowActionFormAttribute.cs
+++ b/Rock/Model/WorkflowActionFormAttribute.cs
@@ -128,6 +128,7 @@ namespace Rock.Model
         /// <value>
         /// The workflow action form.
         /// </value>
+        [LavaInclude]
         public virtual WorkflowActionForm WorkflowActionForm { get; set; }
 
         /// <summary>

--- a/Rock/Model/WorkflowActionType.cs
+++ b/Rock/Model/WorkflowActionType.cs
@@ -139,6 +139,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.WorkflowActivityType" /> that performs this ActionType.
         /// </value>
+        [LavaInclude]
         public virtual WorkflowActivityType ActivityType { get; set; }
 
         /// <summary>

--- a/Rock/Model/WorkflowActivity.cs
+++ b/Rock/Model/WorkflowActivity.cs
@@ -196,6 +196,7 @@ namespace Rock.Model
         /// <value>
         /// The activated by activity.
         /// </value>
+        [LavaInclude]
         public virtual WorkflowActivity ActivatedByActivity { get; set; }
 
         /// <summary>
@@ -218,6 +219,7 @@ namespace Rock.Model
         /// <value>
         /// An enumerable collection containing the active <see cref="Rock.Model.WorkflowAction">WorkflowActions</see> for this WorkflowActivity.
         /// </value>
+        [LavaInclude]
         public virtual IEnumerable<Rock.Model.WorkflowAction> ActiveActions
         {
             get

--- a/Rock/Model/WorkflowActivityType.cs
+++ b/Rock/Model/WorkflowActivityType.cs
@@ -102,6 +102,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.WorkflowType"/> that runs this WorkflowActivityType.
         /// </value>
+        [LavaInclude]
         public virtual WorkflowType WorkflowType { get; set; }
 
         /// <summary>

--- a/Rock/Model/WorkflowLog.cs
+++ b/Rock/Model/WorkflowLog.cs
@@ -74,6 +74,7 @@ namespace Rock.Model
         /// <value>
         /// The <see cref="Rock.Model.Workflow"/> that is being logged.
         /// </value>
+        [LavaInclude]
         public virtual Workflow Workflow { get; set; }
 
         #endregion


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Various model properties were not available in Lava using `dot` syntax but were available using the `Property` filter.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Fix issue #2140.

# Strategy
_How have you implemented your solution?_

Lots and lots of pasting `[LavaInclude]` in various files. Phase 1 approach using grep to locate common properties that are missing the attribute. Some are still missing but use a more difficult syntax to pattern match on.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Shouldn't be any. Ran a few test lava code bits to verify that the Lava interpreter didn't suddenly evolve into HAL 9000.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a