### PR TITLE
Fixed initial validation of check box list

### DIFF
--- a/Rock/Web/UI/Controls/RockCheckBoxList.cs
+++ b/Rock/Web/UI/Controls/RockCheckBoxList.cs
@@ -176,12 +176,7 @@ namespace Rock.Web.UI.Controls
         {
             get
             {
-                if ( this.Required )
-                {
-                    return this.SelectedIndex != -1;
-                }
-
-                return true;
+                return !Required || CustomValidator == null || CustomValidator.IsValid;
             }
         }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

In a workflow that has multiple forms, where a later form has a required multi-select, the validation was firing the first time you see the page and styling the field with has-error immediately because it was received via a postback.  Refreshing the page would remove that styling because a refresh is not a postback. 

# Goal
_What will this pull request achieve and how will this fix the problem?_

The has-error styling should only be used after attempting to move forward from the screen in question.

# Strategy
_How have you implemented your solution?_

@edmistj had changed the logic of IsValid when he implemented CustomValidator to return false anytime there was not at least one selected, even though CustomValidator.IsValid may be true. I reverted the logic back to the old way it was handled, using CustomValidator instead of RequiredFieldValidator.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

This change fixes the problem I have had, but I was not able to reproduce the problem on the demo site, and there may be a reason Jon implemented it this way that I am not aware of.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
