### PR TITLE
Fixed business photo URL reference.

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -2153,7 +2153,7 @@ namespace Rock.Model
             {
                 if ( recordTypeValueGuid.HasValue && recordTypeValueGuid.Value == SystemGuid.DefinedValue.PERSON_RECORD_TYPE_BUSINESS.AsGuid() )
                 {
-                    photoUrl.Append( "/Assets/Images/business-no-photo.svg?" );
+                    photoUrl.Append( "Assets/Images/business-no-photo.svg?" );
                 }
                 else if ( age.HasValue && age.Value < 18 )
                 {


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
Business photos shown on hover in known relationships do not load because they mistakenly include a `/` a the beginning of the URL.

# Goal
Remove the slash

# Strategy


# Tests
NA

# Possible Implications
N/A

# Screenshots

![screenshot 2017-04-27 15 51 24](https://cloud.githubusercontent.com/assets/374209/25507521/644a0432-2b61-11e7-8bc7-37488e349225.png)


# Documentation
N/A
