### PR TITLE
Changed tag styles to accomidate longer tags

### DIFF
--- a/RockWeb/Styles/rock-components/tags.less
+++ b/RockWeb/Styles/rock-components/tags.less
@@ -31,17 +31,27 @@ div.tagsinput {
     }
 
     span {
+      cursor: default;
       display: block;
       float: left;
       max-width: 120px;
       overflow: hidden;
       text-overflow: ellipsis;
+      transition: all 2s;
       white-space: nowrap;
     }
 
     a {
+      font-size: 11px;
+      font-weight: bold;
+      color: @tag-text-color;
+      text-decoration: none;
+      opacity: 0;
       display: block;
       float: left;
+      max-width: 0px;
+      transition-duration: .5s;
+      transition-delay: 1s;
     }
 
     small {
@@ -75,6 +85,19 @@ div.tagsinput {
       border-radius: 2px;
       box-shadow: -1px -1px 2px @tag-bg;
     }
+
+    &:hover {
+      span {
+        max-width: 1000px;
+      }
+
+      a {
+        opacity: 1;
+        padding: 0px 2px;
+        max-width: 100px;
+        transition-delay: 0s;
+      }
+    }
   }
 }
 
@@ -91,20 +114,6 @@ div.tagsinput {
     &:before {
       border-color: transparent @tag-bg-alt transparent transparent;
     }
-  }
-
-  span.tag a {
-    font-size: 11px;
-    font-weight: bold;
-    color: @tag-text-color;
-    text-decoration: none;
-    opacity: 0;
-    -webkit-transition: opacity .3s ease 0s, color .3s ease 0s, background .3s ease 0s;
-       -moz-transition: opacity .3s ease 0s, color .3s ease 0s, background .3s ease 0s;
-  }
-
-  span.tag:hover a {
-    opacity: 1;
   }
 
   input {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
YES! 

# Context
We have tagged some folks in as Missional Community Leaders and others as Missional Community Coaches. When you look at the persons profile the tag names get cut off and you can't tell the difference.

# Goal
The goal is to make it so that you can see the full tag name on mouseover.

# Strategy
The text span width is limited 120px. When mousing over the tag it expands the max-width to 1000px. This allows for a smooth transition that isn't possible by just by removing the max-width. 

# Tests
Tested in FF, Chrome, IE, and Chrome mobile.

# Possible Implications
It should just change the styling of the tags.

# Screenshots
![tags](https://cloud.githubusercontent.com/assets/495787/25675584/02d515b0-300d-11e7-9f74-507132684e02.gif)
