### PR TITLE
Made group member attributes appear in a predictable order

### DIFF
--- a/Rock/Attribute/Helper.cs
+++ b/Rock/Attribute/Helper.cs
@@ -608,7 +608,7 @@ namespace Rock.Attribute
                 var attributes = entity.Attributes.Select( a => a.Value );
                 if ( !supressOrdering )
                 {
-                    attributes = attributes.OrderBy( t => t.Order ).ThenBy( t => t.Name );
+                    attributes = attributes.OrderBy(t => t.EntityTypeQualifierValue).ThenBy( t => t.Order ).ThenBy( t => t.Name );
                 }
 
                 return GetAttributeCategories( attributes.ToList(), onlyIncludeGridColumns, allowMultiple );

--- a/RockWeb/Blocks/Groups/GroupMemberDetail.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupMemberDetail.ascx.cs
@@ -664,7 +664,7 @@ namespace RockWeb.Blocks.Groups
             groupMember.LoadAttributes();
             phAttributes.Controls.Clear();
 
-            Rock.Attribute.Helper.AddEditControls( groupMember, phAttributes, true, string.Empty, true );
+            Rock.Attribute.Helper.AddEditControls( groupMember, phAttributes, true, string.Empty );
             if ( readOnly )
             {
                 Rock.Attribute.Helper.AddDisplayControls( groupMember, phAttributesReadOnly );


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
The attribute fields on the group member detail block appear in sort of a random order. Changing the order of the attributes makes no difference.

# Goal
To be able to order the group member attribute fields in the group member edit block. 

# Strategy
I removed the suppressOrdering flag and then added and ordering by EntityTypeQualifierValue before ordering by Order.

# Tests
I tested by looking at the references of GetAttributeCategories(...) and making sure that the ordering continued to work as intended.

# Possible Implications
There shouldn't be any changes in ordering anywhere else.