### PR TITLE
Added location type options to Postal Code and Geofence filters

### DIFF
--- a/Rock/Reporting/DataFilter/Person/InLocationGeofenceFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/InLocationGeofenceFilter.cs
@@ -24,7 +24,9 @@ using System.Linq.Expressions;
 using System.Web.UI;
 using Rock.Data;
 using Rock.Model;
+using Rock.Web.Cache;
 using Rock.Web.UI.Controls;
+using System.Web.UI.WebControls;
 
 namespace Rock.Reporting.DataFilter.Person
 {
@@ -122,6 +124,8 @@ function() {
         /// </summary>
         private LocationPicker lp = null;
 
+        private RockDropDownList ddlLocationType = null;
+
         /// <summary>
         /// Creates the child controls.
         /// </summary>
@@ -133,9 +137,24 @@ function() {
             lp.Label = "Location";
             lp.AllowedPickerModes = LocationPickerMode.Named | LocationPickerMode.Polygon;
             lp.CurrentPickerMode = lp.GetBestPickerModeForLocation( null );
+            lp.CssClass = "col-lg-4";
             filterControl.Controls.Add( lp );
 
-            return new Control[1] { lp };
+            Panel panel = new Panel();
+            panel.CssClass = "col-lg-8";
+            filterControl.Controls.Add( panel );
+
+            ddlLocationType = new RockDropDownList();
+            ddlLocationType.ID = filterControl.ID + "_ddlLocationType";
+            ddlLocationType.Label = "Location Type";
+            ddlLocationType.DataValueField = "Id";
+            ddlLocationType.DataTextField = "Value";
+            DefinedTypeCache locationDefinedType = DefinedTypeCache.Read( SystemGuid.DefinedType.GROUP_LOCATION_TYPE.AsGuid() );
+            ddlLocationType.BindToDefinedType( locationDefinedType );
+            ddlLocationType.Items.Insert( 0, new ListItem( "(All Location Types)", "" ) );
+            panel.Controls.Add( ddlLocationType );
+
+            return new Control[3] { lp, ddlLocationType, panel };
         }
 
         /// <summary>
@@ -147,10 +166,10 @@ function() {
         /// <param name="controls">The controls.</param>
         public override void RenderControls( Type entityType, FilterField filterControl, HtmlTextWriter writer, Control[] controls )
         {
-            if ( controls.Count() >= 1 )
+            if ( controls.Count() >= 3 )
             {
-                LocationPicker locationPicker = controls[0] as LocationPicker;
-                locationPicker.RenderControl( writer );
+                ( controls[0] as LocationPicker ).RenderControl( writer );
+                ( controls[2] as Panel ).RenderControl( writer );
             }
         }
 
@@ -158,17 +177,16 @@ function() {
         /// Gets the selection.
         /// </summary>
         /// <param name="entityType">Type of the entity.</param>
-        /// <param name="controls">The controls.</param>
+        /// <param name="controls">The controls.</parm>
         /// <returns></returns>
         public override string GetSelection( Type entityType, Control[] controls )
         {
             var location = ( controls[0] as LocationPicker ).Location;
+            var locationTypeId = ( controls[1] as RockDropDownList ).SelectedValue;
 
-            if ( location != null )
-            {
-                return location.Guid.ToString();
-            }
-            return string.Empty;
+            var locationGuid = location != null ? location.Guid : Guid.Empty;
+
+            return string.Format( "{0}|{1}", locationGuid, locationTypeId );
         }
 
         /// <summary>
@@ -179,13 +197,20 @@ function() {
         /// <param name="selection">The selection.</param>
         public override void SetSelection( Type entityType, Control[] controls, string selection )
         {
-            Guid locationGuid = selection.AsGuid();
+            var selections = selection.SplitDelimitedValues();
+            Guid locationGuid = selections[0].AsGuid();
+
             var location = new LocationService( new RockContext() ).Get( locationGuid );
             if ( location != null )
             {
                 LocationPicker locationPicker = controls[0] as LocationPicker;
-                locationPicker.CurrentPickerMode = locationPicker.GetBestPickerModeForLocation( location );
+                locationPicker.GetBestPickerModeForLocation( location );
                 locationPicker.Location = location;
+            }
+
+            if ( selections.Length >= 2 )
+            {
+                ( controls[1] as RockDropDownList ).SetValue( selections[1] );
             }
         }
 
@@ -199,7 +224,8 @@ function() {
         /// <returns></returns>
         public override Expression GetExpression( Type entityType, IService serviceInstance, ParameterExpression parameterExpression, string selection )
         {
-            Guid locationGuid = selection.AsGuid();
+            var selections = selection.SplitDelimitedValues();
+            Guid locationGuid = selections[0].AsGuid();
 
             RockContext rockContext = ( RockContext ) serviceInstance.Context;
 
@@ -209,13 +235,20 @@ function() {
             Guid familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid();
             int familyGroupTypeId = new GroupTypeService( rockContext ).Get( familyGroupTypeGuid ).Id;
 
-            var geoQry = new GroupLocationService( rockContext )
+            var groupLocationQry = new GroupLocationService( rockContext )
                 .GetMappedLocationsByGeofences( new List<DbGeography> { geoFence } )
-                .Where( gl => gl.Group.GroupType.Id == familyGroupTypeId )
-                .SelectMany( g => g.Group.Members );
+                .Where( gl => gl.Group.GroupType.Id == familyGroupTypeId );
+
+            if ( selections.Length >= 2 )
+            {
+                var locationTypeId = selections[1].AsInteger();
+                groupLocationQry = groupLocationQry.Where( gl => gl.GroupLocationTypeValueId == locationTypeId );
+            }
+
+            var groupMemberQry = groupLocationQry.SelectMany( g => g.Group.Members );
 
             var qry = new PersonService( rockContext ).Queryable()
-                .Where( p => geoQry.Any( xx => xx.PersonId == p.Id ) );
+                .Where( p => groupMemberQry.Any( xx => xx.PersonId == p.Id ) );
 
             Expression extractedFilterExpression = FilterExpressionExtractor.Extract<Rock.Model.Person>( qry, parameterExpression, "p" );
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
YES!

# Context
Earlier I created two data views for filtering people by geofence and one by postal code. We use these often, but they pick up all location types. I would like be able to filter only by home address or past address etc...

# Goal
By adding in option to select location type, we can search by only certain location types.

# Strategy
I added a drop down option with the group location types. If one is selected the filter only applies to that location type. If none is selected it applies to all.

# Tests
I tested all options and everything seems good to go. I also tested against existing dataviews we are using.

# Possible Implications
I wrote the enhancement in such a way to be backwards compatible with existing dataviews already using this filter.

# Screenshots
![image](https://cloud.githubusercontent.com/assets/495787/25808092/04a810b8-33d7-11e7-9241-52698aa3f32a.png)
![image](https://cloud.githubusercontent.com/assets/495787/25809108/11fdac02-33da-11e7-9c67-cc5bcf12ae8f.png)

