### PR TITLE
Make Team Templates available to Rock in SignNow interface

### DIFF
--- a/Rock.SignNow/SignNow.cs
+++ b/Rock.SignNow/SignNow.cs
@@ -178,7 +178,7 @@ namespace Rock.SignNow
             {
                 foreach ( JObject folder in folders )
                 {
-                    if ( folder.Value<string>( "name" ) == "Templates" )
+                    if ( folder.Value<string>( "name" ) == "Templates" || folder.Value<string>( "name" ) == "Team Templates" )
                     {
                         string folderId = folder.Value<string>( "id" );
                         if ( !string.IsNullOrWhiteSpace( folderId ) )
@@ -196,9 +196,17 @@ namespace Rock.SignNow
                             {
                                 foreach ( JObject document in documents )
                                 {
+                                    string team_name = documentListRes.Value<string>( "team_name" );
+                                    string document_name = document.Value<string>( "document_name" );
+
+                                    if ( !string.IsNullOrWhiteSpace( team_name ) )
+                                    {
+                                        document_name = string.Format( "{0} > {1}", team_name, document_name );
+                                    }
+
                                     templates.AddOrIgnore(
                                         document.Value<string>( "id" ),
-                                        document.Value<string>( "document_name" ) );
+                                        document_name );
                                 }
                             }
                         }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When setting up teams for SignNow so that other users can upload documents rather than IT having to upload the documents manually or give out the credentials, we noticed that Rock does not recognize any templates in the Team folders.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Templates in the team folders are now available in the `Template` drop down when setting up a new document template. Team documents are prefixed with the team name and a greater than character, such as `IT > Test Template`.

# Strategy
_How have you implemented your solution?_

In the Rock.SignNow library the GetTemplates method now checks for folders called "Team Templates" (there can be multiple "Team Templates" folders, one for each team the configured user has access to). If the folder is for a team then the team name is prepended to the document name for display purposes in the drop down list.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img alt="2017-05-12 10_56_59-virtualbox" src="https://cloud.githubusercontent.com/assets/1119863/26010489/eace87ca-3701-11e7-9719-ce015db9746c.png">

(Yes, my test document was called `Google`. Arguably not the best name for a test document, but it was a screenshot of the google homepage).

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a