### PR TITLE
Fix modal popups not resizing properly on Stark or Flat themes

### DIFF
--- a/RockWeb/Themes/Flat/Layouts/Dialog.aspx
+++ b/RockWeb/Themes/Flat/Layouts/Dialog.aspx
@@ -138,6 +138,8 @@
 </html>
 <script>
     Sys.Application.add_load(function () {
-        Rock.controls.modal.updateSize();
+        new ResizeSensor($('#dialog'), function () {
+            $('#modal-popup iframe', window.parent.document).height($('#dialog').height());
+        });
     });
 </script>

--- a/RockWeb/Themes/Stark/Layouts/Dialog.aspx
+++ b/RockWeb/Themes/Stark/Layouts/Dialog.aspx
@@ -139,6 +139,9 @@
 </html>
 <script>
     Sys.Application.add_load(function () {
-        Rock.controls.modal.updateSize();
+        new ResizeSensor($('#dialog'), function ()
+        {
+            $('#modal-popup iframe', window.parent.document).height($('#dialog').height());
+        });
     });
 </script>


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

When using sites based on the Stark or Flat themes, dialog popup windows (such as system information) do not resize properly when switching nav pills.

# Goal
_What will this pull request achieve and how will this fix the problem?_

The same thing I do in every commit. Try to take over the world!

# Strategy
_How have you implemented your solution?_

Changed the javascript on the page to use the "new" resize detector previously implemented in a1344cb7107caea0a4669d0768cd9779332552fb two years ago. It was applied to the Rock theme but not the others.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a