### PR TITLE
Support 0.0.0.0:9100 syntax in printer IP addresses

### DIFF
--- a/RockWeb/Blocks/CheckIn/Config/EditLabel.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Config/EditLabel.ascx.cs
@@ -199,10 +199,22 @@ namespace RockWeb.Blocks.CheckIn.Config
                 if ( device != null )
                 {
                     string currentIp = device.IPAddress;
-                    var printerIp = new IPEndPoint( IPAddress.Parse( currentIp ), 9100 );
+                    int printerPort = 9100;
+                    var printerIp = currentIp;
+
+                    // If the user specified in 0.0.0.0:1234 syntax then pull our the IP and port numbers.
+                    if ( printerIp.Contains( ":" ) )
+                    {
+                        var segments = printerIp.Split( ':' );
+
+                        printerIp = segments[0];
+                        printerPort = segments[1].AsInteger();
+                    }
+
+                    var printerEndpoint = new IPEndPoint( IPAddress.Parse( currentIp ), printerPort );
 
                     var socket = new Socket( AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp );
-                    IAsyncResult result = socket.BeginConnect( printerIp, null, null );
+                    IAsyncResult result = socket.BeginConnect( printerEndpoint, null, null );
                     bool success = result.AsyncWaitHandle.WaitOne( 5000, true );
 
                     if ( socket.Connected )

--- a/RockWeb/Blocks/CheckIn/Success.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Success.ascx.cs
@@ -152,10 +152,22 @@ namespace RockWeb.Blocks.CheckIn
                                             }
 
                                             currentIp = label.PrinterAddress;
-                                            var printerIp = new IPEndPoint( IPAddress.Parse( currentIp ), 9100 );
+                                            int printerPort = 9100;
+                                            var printerIp = currentIp;
+
+                                            // If the user specified in 0.0.0.0:1234 syntax then pull our the IP and port numbers.
+                                            if ( printerIp.Contains( ":" ) )
+                                            {
+                                                var segments = printerIp.Split( ':' );
+
+                                                printerIp = segments[0];
+                                                printerPort = segments[1].AsInteger();
+                                            }
+
+                                            var printerEndpoint = new IPEndPoint( IPAddress.Parse( currentIp ), printerPort );
 
                                             socket = new Socket( AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp );
-                                            IAsyncResult result = socket.BeginConnect( printerIp, null, null );
+                                            IAsyncResult result = socket.BeginConnect( printerEndpoint, null, null );
                                             bool success = result.AsyncWaitHandle.WaitOne( 5000, true );
                                         }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Lack of ability to have multiple printers on one IP address (e.g. a single Airport Express with multiple USB printers plugged in).

# Goal
_What will this pull request achieve and how will this fix the problem?_

Add support for printer devices to be defined with 0.0.0.0:9100 syntax. e.g. 10.0.0.42:9102.

This will have a "side effect" of allowing remote server based printing without a VPN with the proper router configuration. You can setup 5 printers in Rock to print to your public IP address, each on a different port (say 9100 - 9104). Then your router can do reverse NAT to direct 9100 -> 10.0.0.42:9100, 9101 -> 10.0.0.43:9100, 9102 -> 10.0.0.44:9100, and so on.

# Strategy
_How have you implemented your solution?_

The code for printing a test label and a full during check-in label have been updated to support the new syntax.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

Would love to come up with a way to unit test printing to a physical printer, but alas I got nothing.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

If somebody was crazy enough to define an IP address in IPv6 notation then this would break printing to that printer. I'm not sure the iOS app even supports IPv6 notation either.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

Check-in docs might need a footnote added here https://www.rockrms.com/Rock/BookContent/10/102#printers