### PR TITLE
PIN numbers no long keep people from creating accounts

### DIFF
--- a/RockWeb/Blocks/Security/AccountEntry.ascx.cs
+++ b/RockWeb/Blocks/Security/AccountEntry.ascx.cs
@@ -259,7 +259,10 @@ namespace RockWeb.Blocks.Security
             if ( personId > 0 )
             {
                 var userLoginService = new Rock.Model.UserLoginService( new RockContext() );
-                var userLogins = userLoginService.GetByPersonId( personId ).ToList();
+				var databaseEntityTypeId = EntityTypeCache.Read( Rock.SystemGuid.EntityType.AUTHENTICATION_DATABASE.AsGuid() ).Id;
+                var userLogins = userLoginService.GetByPersonId( personId )
+				.Where( ul => ul.EntityTypeId == databaseEntityTypeId )
+				.ToList();
                 if ( userLogins.Count > 0 )
                 {
                     DisplaySendLogin( personId, Direction.Forward );

--- a/RockWeb/Blocks/Security/AccountEntry.ascx.cs
+++ b/RockWeb/Blocks/Security/AccountEntry.ascx.cs
@@ -259,11 +259,10 @@ namespace RockWeb.Blocks.Security
             if ( personId > 0 )
             {
                 var userLoginService = new Rock.Model.UserLoginService( new RockContext() );
-				var databaseEntityTypeId = EntityTypeCache.Read( Rock.SystemGuid.EntityType.AUTHENTICATION_DATABASE.AsGuid() ).Id;
                 var userLogins = userLoginService.GetByPersonId( personId )
-				.Where( ul => ul.EntityTypeId == databaseEntityTypeId )
-				.ToList();
-                if ( userLogins.Count > 0 )
+                .ToList();
+
+                if ( userLogins.Any( ul => !AuthenticationContainer.GetComponent( ul.EntityType.Name ).RequiresRemoteAuthentication ) )
                 {
                     DisplaySendLogin( personId, Direction.Forward );
                 }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
YES!

# Context
Long story: We had a summer program registration that could take payments in installments. A mom used her husbands account to register and used her name and email as the registrar information. This tied the registration to her profile and meant she needed to have a log-in to make payments. She couldn't create a username because she had a PIN attached to her profile.

# Goal
People who have a username attached to their profile should be able to make an account in the account entry block if they don't have an database username already.

# Strategy
Check to see if they have a database username instead of just any username.

# Tests
This would fix our problem

# Possible Implications
Everything security wise works the same except that it allows people to make a database log-in even if they have a different type of username.
