### PR TITLE
Fix GroupDetail to not show header multiple times

### DIFF
--- a/RockWeb/Themes/Flat/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/GroupDetail.lava
@@ -103,7 +103,8 @@
 		{% if countPending > -1 %}
 			{% assign icountPending = 0 %}
 
-
+			<div class="well">
+				<h4>Pending Members</h4>
 
 			{% for member in Group.Members %}
 
@@ -112,8 +113,6 @@
 					{% assign loopcycle = icountPending | Modulo:2 %}
 
 					{% if loopcycle == 0 %}
-					<div class="well">
-						<h4>Pending Members</h4>
 						<div class="row">
 					{% endif %}
 
@@ -157,7 +156,6 @@
 
 					{% if loopcycle != 0 or icountPending == countPending %}
 						</div>
-						</div>
 					{% endif %}
 
 					{% assign icountPending = icountPending | Plus: 1 %}
@@ -165,7 +163,7 @@
 				{% endif %}
 
 			{% endfor %}
-
+				</div>
 		{% endif %}
 
 

--- a/RockWeb/Themes/Rock/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/GroupDetail.lava
@@ -103,7 +103,8 @@
 		{% if countPending > -1 %}
 			{% assign icountPending = 0 %}
 
-
+			<div class="well">
+				<h4>Pending Members</h4>
 
 			{% for member in Group.Members %}
 
@@ -112,8 +113,6 @@
 					{% assign loopcycle = icountPending | Modulo:2 %}
 
 					{% if loopcycle == 0 %}
-					<div class="well">
-						<h4>Pending Members</h4>
 						<div class="row">
 					{% endif %}
 
@@ -157,7 +156,6 @@
 
 					{% if loopcycle != 0 or icountPending == countPending %}
 						</div>
-						</div>
 					{% endif %}
 
 					{% assign icountPending = icountPending | Plus: 1 %}
@@ -165,7 +163,7 @@
 				{% endif %}
 
 			{% endfor %}
-
+				</div>
 		{% endif %}
 
 

--- a/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
@@ -103,7 +103,8 @@
 		{% if countPending > -1 %}
 			{% assign icountPending = 0 %}
 
-
+			<div class="well">
+				<h4>Pending Members</h4>
 
 			{% for member in Group.Members %}
 
@@ -112,8 +113,6 @@
 					{% assign loopcycle = icountPending | Modulo:2 %}
 
 					{% if loopcycle == 0 %}
-					<div class="well">
-						<h4>Pending Members</h4>
 						<div class="row">
 					{% endif %}
 
@@ -157,7 +156,6 @@
 
 					{% if loopcycle != 0 or icountPending == countPending %}
 						</div>
-						</div>
 					{% endif %}
 
 					{% assign icountPending = icountPending | Plus: 1 %}
@@ -165,7 +163,7 @@
 				{% endif %}
 
 			{% endfor %}
-
+				</div>
 		{% endif %}
 
 


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
The group detail view lists the "Pending Members" header and adds a new `<div class="well">` for every two pending members.

# Goal
Move the well and header to show once for all pending members. 

# Strategy
Modified all GroupDetail.lava templates

# Tests
N/A

# Possible Implications
None

# Screenshots

Proposed Fix (Sensitive info removed)
![removeedit](https://cloud.githubusercontent.com/assets/374209/26217897/f6c4e356-3bbd-11e7-9acb-07f73e4f1c26.png)


# Documentation
N/A
