### PR TITLE
Adding a quick check to make the SignNow document filname valid.

### DIFF
--- a/Rock.SignNow/SignNow.cs
+++ b/Rock.SignNow/SignNow.cs
@@ -536,10 +536,10 @@ namespace Rock.SignNow
             }
 
             int i = 1;
-            string fileName = document.Name;
+            string fileName = document.Name.MakeValidFileName();
             while ( File.Exists( Path.Combine( folder.FullName, fileName ) + ".pdf" ) )
             {
-                fileName = string.Format( "{0}_{1}", document.Name, i++ );
+                fileName = string.Format( "{0}_{1}", document.Name.MakeValidFileName(), i++ );
             }
 
             string filePath = Path.Combine( folder.FullName, fileName );


### PR DESCRIPTION


# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_
Yes

# Context

When a Document name contains an illegal character (such as a "|"), the following error is thrown:
```  
Illegal characters in path.
at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
   at System.IO.Path.Combine(String path1, String path2)
   at Rock.SignNow.SignNow.GetDocument(SignatureDocument document, String folderPath, List`1& errors) in C:\DEV\WebApps\Jenkins\workspace\Rock\Rock.SignNow\SignNow.cs:line 555
   at Rock.Model.SignatureDocumentTemplateService.UpdateDocumentStatus(SignatureDocument signatureDocument, String tempFolderPath, List`1& errorMessages) in C:\DEV\WebApps\Jenkins\workspace\Rock\Rock\Model\SignatureDocumentTemplateService.Partial.cs:line 305
   at Rock.Jobs.ProcessSignatureDocuments.Execute(IJobExecutionContext context) in C:\DEV\WebApps\Jenkins\workspace\Rock\Rock\Jobs\ProcessSignatureDocuments.cs:line 100
   at Quartz.Core.JobRunShell.Run()
```

# Goal
This uses the MakeValidFilename string extension to clean up the document name when the file is downloaded from SignNow.

# Strategy
Just clean the filename when we store it.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

We are running this in our production environment already.

# Possible Implications

None.

# Screenshots

N/A

# Documentation

N/A
