### PR TITLE
Add support for multiple page layouts to word merge templates

### DIFF
--- a/Rock/MergeTemplates/WordDocumentMergeTemplateType.cs
+++ b/Rock/MergeTemplates/WordDocumentMergeTemplateType.cs
@@ -309,6 +309,15 @@ namespace Rock.MergeTemplates
                                         if ( lastParagraph != null )
                                         {
                                             lastParagraph.AddAfterSelf( pageBreak );
+
+                                            // Add page formatting for the page before the page break.
+                                            var lastSectPr = recordContainerNode.Nodes().OfType<XElement>().Where( a => a.Name.LocalName == "sectPr" ).LastOrDefault();
+                                            if ( lastSectPr != null )
+                                            {
+                                                var paragraphPropertiesXml = new Paragraph( new ParagraphProperties( new SectionProperties( lastSectPr.ToString() ) ) ).OuterXml;
+                                                var paragraphProperties = XElement.Parse( paragraphPropertiesXml, LoadOptions.None );
+                                                pageBreak.AddAfterSelf( paragraphProperties );
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

We have word document merge templates that contain an 8.5x11" letter as page 1 and then a number 10 envelope as page 2. When trying to use this template, only the final page in the output is formatted as an envelope, the rest end up formatted as 8.5x11" letter size.

# Goal
_What will this pull request achieve and how will this fix the problem?_

The same thing I do with every commit. Try and take over the wo... err wait. Sorry bad dream. The goal is to add support for multi-layout word template documents.

# Strategy
_How have you implemented your solution?_

OpenXML word documents normally store the page layout as part of the final paragraph in the page. Since the paragraph tag is duplicated all is well and the page layout information gets copied to the output document. With the exception of the final page. In the final page the layout information is _not_ stored as part of the paragraph, it is stored after the paragraph. This means that when the final paragraph is copied to the output document the page layout information is not copied and it will, by default, inherit the layout of the previous page.

When adding a page break, we now also check for a stand-alone page layout tag and embed that into an empty paragraph tag.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

There are lots of document types (tables, pictures, etc.) that people might be using. I tested the changes with the following sample Rock documents and they all generated correctly:
* Envelope - Home Address
* Name Tags
* Sample Letter

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

I don't think any documentation changes will be necessary.