### PR TITLE
Add member to group when Context is person

### DIFF
--- a/RockWeb/Blocks/Groups/GroupList.ascx
+++ b/RockWeb/Blocks/Groups/GroupList.ascx
@@ -42,6 +42,17 @@
 
             </div>
         </div>
+          <Rock:ModalDialog ID="modalDetails" runat="server" Title="Add to Group" ValidationGroup="GroupName">
+            <Content>
+                <div class="row">
+                    <div class="col-md-4">
+                        <Rock:RockDropDownList ID="ddlGroup" runat="server" Label="Group" DataTextField="Name" DataValueField="Id" ValidationGroup="GroupName" />
+                    </div>
+                </div>
 
+            </Content>
+        </Rock:ModalDialog>
+
+        <Rock:NotificationBox ID="nbMessage" runat="server" Title="Error" NotificationBoxType="Danger" Visible="false" />
     </ContentTemplate>
 </asp:UpdatePanel>

--- a/RockWeb/Blocks/Groups/GroupList.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupList.ascx.cs
@@ -140,6 +140,7 @@ namespace RockWeb.Blocks.Groups
                     boundFields["DateAdded"].Visible = true;
                     boundFields["MemberCount"].Visible = false;
                     gGroups.IsDeleteEnabled = true;
+                    gGroups.HideDeleteButtonForIsSystem = false;
                 }
             }
             else
@@ -327,14 +328,14 @@ namespace RockWeb.Blocks.Groups
                         return;
                     }
 
-                    
+
                     if ( !groupService.CanDelete( group, out errorMessage ) )
                     {
                         mdGridWarning.Show( errorMessage, ModalAlertType.Information );
                         return;
                     }
 
-                   
+
                     if ( isSecurityRoleGroup )
                     {
                         Rock.Security.Role.Flush( group.Id );
@@ -742,7 +743,7 @@ namespace RockWeb.Blocks.Groups
                 {
                     Id = g.Id,
                     Name = g.Name
-                } ).ToList();
+                } ).OrderBy( a => a.Name ).ToList();
             ddlGroup.DataBind();
         }
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]

Yes

# Context
https://github.com/SparkDevNetwork/Rock/issues/755

# Goal
Adding Group directly when Context is person

# Strategy
When GroupList block is used on person detail page with a person context ( e.g. Security Roles), a new group could easily be added to the list using the + icon (Add) directly from this block instead of having to navigate to a different page to add person to group. 