### PR TITLE
Fixed keeping selected row as selected after the postback

### DIFF
--- a/Rock/Web/UI/Controls/Grid/SelectField.cs
+++ b/Rock/Web/UI/Controls/Grid/SelectField.cs
@@ -353,10 +353,6 @@ namespace Rock.Web.UI.Controls
                         object selectValue = DataBinder.Eval( gridViewRow.DataItem, DataSelectedField );
                         cb.Checked = (bool)selectValue;
                     }
-                    else
-                    {
-                        cb.Checked =false;
-                    }
 
                     if ( !string.IsNullOrWhiteSpace( DataVisibleField ) )
                     {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]
Yes

# Goal
_What will this pull request achieve and how will this fix the problem?_
Grid on postback use to reset the control state of Select Field.

# Strategy
Select Field cb_DataBinding function use to override the selected state of Select Field. 
As cb_DataBinding was totally dependent on DataSelectedField.