### PR TITLE
Fixes Date Range Filter in Pledge List

### DIFF
--- a/RockWeb/Blocks/Finance/PledgeList.ascx.cs
+++ b/RockWeb/Blocks/Finance/PledgeList.ascx.cs
@@ -416,17 +416,17 @@ namespace RockWeb.Blocks.Finance
 
             // Last Modified
             drp.DelimitedValues = gfPledges.GetUserPreference( "Last Modified" );
-            filterStartDate = drp.LowerValue ?? DateTime.MinValue;
-            filterEndDate = drp.UpperValue ?? DateTime.MaxValue;
+            var filterModifedStartDate = drp.LowerValue ?? DateTime.MinValue;
+            var filterModifiedEndDate = drp.UpperValue ?? DateTime.MaxValue;
 
-            if (filterEndDate != DateTime.MaxValue)
+            if ( filterModifiedEndDate != DateTime.MaxValue)
             {
-                filterEndDate = filterEndDate.AddDays( 1 );
+                filterModifiedEndDate = filterModifiedEndDate.AddDays( 1 );
             }
 
             if ( drpLastModifiedDates.Visible )
             {
-                pledges = pledges.Where( p => !(p.ModifiedDateTime >= filterEndDate) && !(p.ModifiedDateTime <= filterStartDate) );
+                pledges = pledges.Where( p => !(p.ModifiedDateTime >= filterModifiedEndDate ) && !(p.ModifiedDateTime <= filterModifedStartDate ) );
             }
 
             gPledges.DataSource = sortProperty != null ? pledges.Sort( sortProperty ).ToList() : pledges.OrderBy( p => p.AccountId ).ToList();


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]
Yes

# Context
Date Range Filter was not working as expected in Pledge List block.


# Strategy
Same datetime variables which is value type  were used to filter both date range and modified date range. 
