### PR TITLE
Fix Check-in Detail page sometimes not showing groups

### DIFF
--- a/RockWeb/Blocks/CheckIn/CheckinGroupList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/CheckinGroupList.ascx.cs
@@ -218,11 +218,11 @@ namespace RockWeb.Blocks.Checkin
                 _addedGroupIds = new List<int>();
                 int? campusId = bddlCampus.SelectedValueAsInt();
 
-                lContent.Text = BuildHeirarchy( groupTypeIds, campusId );
+                lContent.Text = BuildHierarchy( groupTypeIds, campusId );
             } 
         }
 
-        private string BuildHeirarchy( List<int> groupTypeIds, int? campusId )
+        private string BuildHierarchy( List<int> groupTypeIds, int? campusId )
         {
             GroupTypeService groupTypeService = new GroupTypeService( _rockContext );
 
@@ -247,7 +247,7 @@ namespace RockWeb.Blocks.Checkin
 
                         if ( groupType.ChildGroupTypes.Count > 0 )
                         {
-                            groupTypeContent = BuildHeirarchy( groupType.ChildGroupTypes.Select( t => t.Id ).ToList(), campusId );
+                            groupTypeContent = BuildHierarchy( groupType.ChildGroupTypes.Select( t => t.Id ).ToList(), campusId );
                         }
 
                         var groupContent = new StringBuilder();
@@ -298,7 +298,7 @@ namespace RockWeb.Blocks.Checkin
                     {
                         if ( groupType.ChildGroupTypes.Count > 0 )
                         {
-                            content.Append( BuildHeirarchy( groupType.ChildGroupTypes.Select( t => t.Id ).ToList(), campusId ) );
+                            content.Append( BuildHierarchy( groupType.ChildGroupTypes.Select( t => t.Id ).ToList(), campusId ) );
                         }
                     }
                 }

--- a/RockWeb/Blocks/CheckIn/CheckinGroupList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/CheckinGroupList.ascx.cs
@@ -298,7 +298,7 @@ namespace RockWeb.Blocks.Checkin
                     {
                         if ( groupType.ChildGroupTypes.Count > 0 )
                         {
-                            BuildHeirarchy( groupType.ChildGroupTypes.Select( t => t.Id ).ToList(), campusId );
+                            content.Append( BuildHeirarchy( groupType.ChildGroupTypes.Select( t => t.Id ).ToList(), campusId ) );
                         }
                     }
                 }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Depending on how your system is configured (like ours) the CheckinGroupList block would sometimes show empty. This seems to have been from a refactor some time ago where the output of one recursive call was accidently ignored.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Magic

# Strategy
_How have you implemented your solution?_

Append the results of the recursive call to the local content buffer so it actually gets included. @mikejed tested this fix for me on his currently working system and there was no change to his block, so it does not appear to break things if they already work.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

None

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a