### PR TITLE
New Lava filter for checking if digital document is signed.

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -2677,6 +2677,51 @@ namespace Rock.Lava
             return null;
         }
 
+        /// <summary>
+        /// Gets the Notes of the entity
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="input">The input.</param>
+        /// <param name="documentTemplateId">The Id number of the signed document type to query for.</param>
+        /// <param name="trueValue">The value to be returned if the person has signed the document.</param>
+        /// <param name="falseValue">The value to be returned if the person has not signed the document.</param>
+        /// <returns></returns>
+        public static object HasSignedDocument( DotLiquid.Context context, object input, object documentTemplateId, object trueValue = null, object falseValue = null )
+        {
+            int personId;
+            int templateId;
+
+            trueValue = trueValue ?? true;
+            falseValue = falseValue ?? false;
+
+            if ( input == null || documentTemplateId == null )
+            {
+                return falseValue;
+            }
+
+            templateId = documentTemplateId.ToString().AsInteger();
+
+            if ( input is Person )
+            {
+                personId = ( input as Person ).Id;
+            }
+            else
+            {
+                personId = input.ToString().AsInteger();
+            }
+
+            bool found = new SignatureDocumentService( new RockContext() )
+                .Queryable().AsNoTracking()
+                .Where( d =>
+                    d.SignatureDocumentTemplateId == templateId &&
+                    d.Status == SignatureDocumentStatus.Signed &&
+                    d.BinaryFileId.HasValue &&
+                    d.AppliesToPersonAlias.PersonId == personId )
+                .Any();
+
+            return found ? trueValue : falseValue;
+        }
+
         #endregion
 
         #region Misc Filters


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Needed to display a check mark if somebody had signed a e-signature document or an empty square if they had not.

# Goal
_What will this pull request achieve and how will this fix the problem?_

New Lava filter that allows the builder to check if a person has signed a specific document template type.

# Strategy
_How have you implemented your solution?_

New Lava filter can be passed either a Person object or an Id number of the person to check. The first parameter is the Id of the document template. Two additional parameters are available that allow the specification of the return values. This is to allow for simplified lava when you just need to display a simple word difference.

# Examples

Simple conditional check:
```
{% assign hasSigned = CurrentPerson | HasSignedDocument:1 %}
{% if hasSigned %}
  _do something_
{% endif %}
```

Simple formatted check:

`Hi {{ CurrentPerson.NickName }}, you {{ CurrentPerson | HasSignedDocument:1,'have signed','need to sign' }} the waiver for camp.`


Advanced formatted check:

`Waiver status: <a class="fa {{ somePersonId | HasSignedDocument:1,'fa-check-square-o','fa-square-o' }}"></i>`

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

Filter requires database access, so no tests included.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

The documents themselves are not made available so any security impact is minimal.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

Above examples should be translated into documentation on the Lava doc page.