### PR TITLE
+ Added search option for Additional Accounts to Transaction Entry

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionEntry.ascx
+++ b/RockWeb/Blocks/Finance/TransactionEntry.ascx
@@ -37,6 +37,17 @@
                                         </asp:Repeater>
                                         <Rock:ButtonDropDownList ID="btnAddAccount" runat="server" Visible="false" Label=" "
                                             DataTextField="PublicName" DataValueField="Id" OnSelectionChanged="btnAddAccount_SelectionChanged" />
+                                        
+                                        <asp:Panel ID="pnlSearchCollapse" ClientIDMode="Static" runat="server" class="form-group well" Style="height: auto;">
+                                            <Rock:RockTextBox ID="rtbSearchBox" ClientIDMode="Static" runat="server"></Rock:RockTextBox>
+                                            <asp:Repeater ID="rptSearchAccounts" runat="server" OnItemDataBound="rptSearchAccountList_ItemDataBound">
+                                                <HeaderTemplate><div id="searchCollapse"></HeaderTemplate>
+                                                <ItemTemplate>
+                                                    <asp:LinkButton ID="lbSearchAccountsResult" runat="server" CssClass="btn btn-default btn-block" OnClick="lbSearchAccountsResult_Click"></asp:LinkButton>
+                                                </ItemTemplate>
+                                                <FooterTemplate></div></FooterTemplate>
+                                            </asp:Repeater>
+                                        </asp:Panel>
 
                                         <div class="form-group">
                                             <label runat="server" id="lblTotalAmountLabel">Total</label>

--- a/RockWeb/Scripts/transaction-entry-search.js
+++ b/RockWeb/Scripts/transaction-entry-search.js
@@ -1,0 +1,26 @@
+﻿(function ($) {
+    $(document).ready(function () {
+        SearchAccounts();
+    });
+}(jQuery));
+
+Sys.WebForms.PageRequestManager.getInstance().add_endRequest(SearchAccounts);
+
+function SearchAccounts() {
+    (function ($) {
+        $('#rtbSearchBox').keyup(function () {
+
+            var rex = new RegExp($(this).val(), 'i');
+            $('#searchCollapse .btn').hide();
+            $('#searchCollapse .btn').filter(function () {
+                return rex.test($(this).text());
+            }).show();
+
+            if ($(this).val().length == 0) {
+                $('#searchCollapse .btn').hide();
+            }
+
+        })
+
+    }(jQuery));
+}


### PR DESCRIPTION
# Contributor Agreement
Yes

# Context
When there are numerous Additional Accounts, it's difficult to find the desired Account.

# Goal
Provide a search feature for the Transaction Entry block which allows for all Additional Funds to be displayed in a quick search tool.

# Strategy
Added a block setting to populate a new repeater in the Transaction Entry block.  The search functionality is powered by JavaScript showing/hiding the returned Accounts.

# Tests
N/A

# Possible Implications
Should not affect anything.

# Screenshots
![fundsearchquickdemo720](https://user-images.githubusercontent.com/3513589/27607482-06dcc3e0-5b52-11e7-932c-9c04df3369ac.gif)


# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
