### PR TITLE
Add functionality to the Rock Cleanup job to remove orphaned attributes from deleted entities

### DIFF
--- a/Rock/Jobs/RockCleanup.cs
+++ b/Rock/Jobs/RockCleanup.cs
@@ -41,7 +41,7 @@ namespace Rock.Jobs
     [DisallowConcurrentExecution]
     public class RockCleanup : IJob
     {
-        /// <summary> 
+        /// <summary>
         /// Empty constructor for job initilization
         /// <para>
         /// Jobs require a public empty constructor so that the
@@ -79,7 +79,7 @@ namespace Rock.Jobs
 
             try
             {
-                databaseRowsDeleted.Add( "Expired Entity Set", CleanupExpiredEntitySets( dataMap ));
+                databaseRowsDeleted.Add( "Expired Entity Set", CleanupExpiredEntitySets( dataMap ) );
             }
             catch ( Exception ex )
             {
@@ -88,7 +88,7 @@ namespace Rock.Jobs
 
             try
             {
-                databaseRowsDeleted.Add( "Old Interaction", CleanupInteractions( dataMap ));
+                databaseRowsDeleted.Add( "Old Interaction", CleanupInteractions( dataMap ) );
             }
             catch ( Exception ex )
             {
@@ -134,7 +134,7 @@ namespace Rock.Jobs
 
             try
             {
-                databaseRowsDeleted.Add( "Temporary Registration", CleanUpTemporaryRegistrations());
+                databaseRowsDeleted.Add( "Temporary Registration", CleanUpTemporaryRegistrations() );
             }
             catch ( Exception ex )
             {
@@ -143,7 +143,7 @@ namespace Rock.Jobs
 
             try
             {
-                databaseRowsDeleted.Add( "Workflow", CleanUpWorkflows( dataMap ));
+                databaseRowsDeleted.Add( "Workflow", CleanUpWorkflows( dataMap ) );
             }
             catch ( Exception ex )
             {
@@ -152,7 +152,7 @@ namespace Rock.Jobs
 
             try
             {
-                databaseRowsDeleted.Add( "Workflow Log", CleanUpWorkflowLogs( dataMap ));
+                databaseRowsDeleted.Add( "Workflow Log", CleanUpWorkflowLogs( dataMap ) );
             }
             catch ( Exception ex )
             {
@@ -161,7 +161,7 @@ namespace Rock.Jobs
 
             try
             {
-                databaseRowsDeleted.Add( "Orphaned Attribute Value", CleanupOrphanedAttributes( dataMap ));
+                databaseRowsDeleted.Add( "Orphaned Attribute Value", CleanupOrphanedAttributes( dataMap ) );
             }
             catch ( Exception ex )
             {
@@ -237,7 +237,7 @@ namespace Rock.Jobs
 
                 personRockContext.SaveChanges();
             }
-            
+
             //// Add any missing Implied/Known relationship groups
             // Known Relationship Group
             AddMissingRelationshipGroups( GroupTypeCache.Read( Rock.SystemGuid.GroupType.GROUPTYPE_KNOWN_RELATIONSHIPS ), Rock.SystemGuid.GroupRole.GROUPROLE_KNOWN_RELATIONSHIPS_OWNER.AsGuid() );
@@ -256,7 +256,7 @@ namespace Rock.Jobs
             if ( relationshipGroupType != null )
             {
                 var ownerRoleId = relationshipGroupType.Roles
-                    .Where( r => r.Guid.Equals( ownerRoleGuid ) ).Select( a => ( int? ) a.Id ).FirstOrDefault();
+                    .Where( r => r.Guid.Equals( ownerRoleGuid ) ).Select( a => (int?)a.Id ).FirstOrDefault();
                 if ( ownerRoleId.HasValue )
                 {
                     var rockContext = new RockContext();
@@ -664,7 +664,7 @@ WHERE ic.ChannelId = @channelId
                 if ( orphanedAttributeMatrices.Any() )
                 {
                     recordsDeleted += orphanedAttributeMatrices.Count;
-                    attributeMatrixItemService.DeleteRange( orphanedAttributeMatrices.SelectMany(a => a.AttributeMatrixItems) );
+                    attributeMatrixItemService.DeleteRange( orphanedAttributeMatrices.SelectMany( a => a.AttributeMatrixItems ) );
                     attributeMatrixService.DeleteRange( orphanedAttributeMatrices );
                     rockContext.SaveChanges();
                 }
@@ -683,7 +683,7 @@ WHERE ic.ChannelId = @channelId
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        private int CleanupOrphanedAttributeValuesForEntityType<T>() where T:Rock.Data.Entity<T>, IHasAttributes, new()
+        private int CleanupOrphanedAttributeValuesForEntityType<T>() where T : Rock.Data.Entity<T>, IHasAttributes, new()
         {
             int recordsDeleted = 0;
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

![](https://media4.giphy.com/media/l1ug5sWBCJOOGzN84/giphy.gif "I have no idea actually")

# Context
_What is the problem you encountered that lead to you creating this pull request?_

![](http://media2.giphy.com/media/7ILa7CZLxE0Ew/giphy.gif "Stuff doesn't delete when it should")

# Goal
_What will this pull request achieve and how will this fix the problem?_

![](https://media.giphy.com/media/I5S339AJ7FmeY/giphy.gif "Make Rock v7 truly awesome")

# Strategy
_How have you implemented your solution?_

![](https://media.giphy.com/media/ymckEpq27dQ9W/giphy.gif "Read far too many SO blogs about reflection and dynamic types")

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

![](https://media.giphy.com/media/3o7TKHLrYNlqFyT6Q8/giphy.gif "Are we not doing phrasing anymore")

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Ideally [Rock.Rest.Controllers.MetricYTData](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Rest/Controllers/MetricsController.partial.cs#L170) wouldn't be a public `IModel, IEntity, IHasAttributes` object with no context services.  Otherwise the [Where](https://github.com/SparkDevNetwork/Rock/compare/develop...feature-rock-cleanup#diff-50bd58becd76842cd7f87733ac3df1d7R675) clause on L175 would be much cleaner.

![](https://media.giphy.com/media/11lLn6lwsdicLK/giphy.gif "It's 1AM, not changing it now")


