### PR TITLE
Fix mispelling in CheckInType - PreventInactivePeopele

### DIFF
--- a/Rock/CheckIn/CheckinType.cs
+++ b/Rock/CheckIn/CheckinType.cs
@@ -208,12 +208,21 @@ namespace Rock.CheckIn
         public bool PreventDuplicateCheckin { get { return GetSetting( "core_checkin_PreventDuplicateCheckin" ).AsBoolean( false ); } }
         
         /// <summary>
-        /// Gets a value indicating whether [prevent inactive peopele].
+        /// Gets a value indicating whether [prevent inactive people]. Obsolete as of 1.7.0.
         /// </summary>
         /// <value>
-        /// <c>true</c> if [prevent inactive peopele]; otherwise, <c>false</c>.
+        /// <c>true</c> if [prevent inactive people]; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete( "Use PreventInactivePeople instead.", true )]
         public bool PreventInactivePeopele { get { return GetSetting( "core_checkin_PreventInactivePeople" ).AsBoolean( false ); } }
+
+        /// <summary>
+        /// Gets a value indicating whether [prevent inactive people].
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [prevent inactive people]; otherwise, <c>false</c>.
+        /// </value>
+        public bool PreventInactivePeople { get { return GetSetting( "core_checkin_PreventInactivePeople" ).AsBoolean( false ); } }
 
         /// <summary>
         /// Gets a value indicating whether [display location count].

--- a/Rock/Workflow/Action/CheckIn/FindFamilies.cs
+++ b/Rock/Workflow/Action/CheckIn/FindFamilies.cs
@@ -168,7 +168,7 @@ namespace Rock.Workflow.Action.CheckIn
                                 m.GroupId == familyId &&
                                 m.Person.NickName != null );
 
-                        if ( checkInState.CheckInType != null && checkInState.CheckInType.PreventInactivePeopele && dvInactive != null )
+                        if ( checkInState.CheckInType != null && checkInState.CheckInType.PreventInactivePeople && dvInactive != null )
                         {
                             familyMemberQry = familyMemberQry
                                 .Where( m =>

--- a/Rock/Workflow/Action/CheckIn/FindFamilyMembers.cs
+++ b/Rock/Workflow/Action/CheckIn/FindFamilyMembers.cs
@@ -56,7 +56,7 @@ namespace Rock.Workflow.Action.CheckIn
                     var service = new GroupMemberService( rockContext );
 
                     var people = service.GetByGroupId( family.Group.Id ).AsNoTracking();
-                    if ( checkInState.CheckInType != null && checkInState.CheckInType.PreventInactivePeopele )
+                    if ( checkInState.CheckInType != null && checkInState.CheckInType.PreventInactivePeople )
                     {
                         var dvInactive = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_INACTIVE.AsGuid() );
                         if ( dvInactive != null )

--- a/Rock/Workflow/Action/CheckIn/FindRelationships.cs
+++ b/Rock/Workflow/Action/CheckIn/FindRelationships.cs
@@ -89,7 +89,7 @@ namespace Rock.Workflow.Action.CheckIn
                 var family = checkInState.CheckIn.CurrentFamily;
                 if ( family != null )
                 {
-                    bool preventInactive = ( checkInState.CheckInType != null && checkInState.CheckInType.PreventInactivePeopele );
+                    bool preventInactive = ( checkInState.CheckInType != null && checkInState.CheckInType.PreventInactivePeople );
                     var dvInactive = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_INACTIVE.AsGuid() );
 
                     var groupMemberService = new GroupMemberService( rockContext );


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Da spell'n of'n da property called `PreventInactivePeopele` is being wrong'n.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Fix'n da spell'n sozen people no sounda like meezen.

# Strategy
_How have you implemented your solution?_

Add new property that pulls the same data but uses the correct spelling. Since this was a public property I have added an Obsolete tag to the original property.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a