### PR TITLE
Feature Disable Name Edit

### DIFF
--- a/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
+++ b/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
@@ -45,6 +45,7 @@ namespace RockWeb.Blocks.Cms
     [AttributeField( Rock.SystemGuid.EntityType.GROUP, "GroupTypeId", Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY, "Family Attributes", "The family attributes that should be displayed / edited.", false, true, order: 6 )]
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Attributes (adults)", "The person attributes that should be displayed / edited for adults.", false, true, order: 7 )]
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Attributes (children)", "The person attributes that should be displayed / edited for children.", false, true, order: 8 )]
+    [BooleanField( "Disable Name Edit", "Whether the First and Last Names can be edited.", false, "Advanced", order: 0 )]
 
     public partial class PublicProfileEdit : RockBlock
     {
@@ -954,6 +955,11 @@ namespace RockWeb.Blocks.Cms
 
                         if ( person != null )
                         {
+                            if ( GetAttributeValue( "DisableNameEdit" ).AsBoolean() )
+                            {
+                                tbFirstName.Enabled = false;
+                                tbLastName.Enabled = false;
+                            }
                             imgPhoto.BinaryFileId = person.PhotoId;
                             imgPhoto.NoPictureUrl = Person.GetPersonNoPictureUrl( person, 200, 200 );
                             ddlTitle.SelectedValue = person.TitleValueId.HasValue ? person.TitleValueId.Value.ToString() : string.Empty;

--- a/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
+++ b/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
@@ -45,7 +45,7 @@ namespace RockWeb.Blocks.Cms
     [AttributeField( Rock.SystemGuid.EntityType.GROUP, "GroupTypeId", Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY, "Family Attributes", "The family attributes that should be displayed / edited.", false, true, order: 6 )]
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Attributes (adults)", "The person attributes that should be displayed / edited for adults.", false, true, order: 7 )]
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Attributes (children)", "The person attributes that should be displayed / edited for children.", false, true, order: 8 )]
-    [BooleanField( "Disable Name Edit", "Whether the First and Last Names can be edited.", false, "Advanced", order: 0 )]
+    [BooleanField( "Disable Name Edit", "Whether the First and Last Names can be edited.", false, order: 0 )]
 
     public partial class PublicProfileEdit : RockBlock
     {


### PR DESCRIPTION
+ Added ability to disable First and Last Name editing in Public Profile Edit Block.

# Contributor Agreement
Yup!

# Context
Users are modifying names in the Public Profile Update block in ways that caused data integrity issues.  i.e. `John and Jane` in the First Name Field or completely changing the name to another family member.

# Goal
Allow the data team to decide if the First and Last Name fields should be enabled when End Users edit.

# Strategy
Added an Advanced Block setting to Disable Name Edit.

# Tests
None

# Possible Implications
Defaults to allow editing (like existing behavior) so no impact to most users.

# Screenshots
![disablenameedit](https://user-images.githubusercontent.com/3513589/27797150-870efee8-5fda-11e7-9133-c4d7bbc38825.png)

# Documentation
None
