### PR TITLE
Fix IdleRedirect block triggering too soon after a partial postback

### DIFF
--- a/RockWeb/Blocks/Utility/IdleRedirect.ascx.cs
+++ b/RockWeb/Blocks/Utility/IdleRedirect.ascx.cs
@@ -47,6 +47,10 @@ namespace RockWeb.Blocks.Utility
             int ms = idleSeconds * 1000;
             string script = string.Format( @"
             $(function () {{
+                Sys.WebForms.PageRequestManager.getInstance().add_pageLoading(function () {{
+                    $.idleTimer('destroy');
+                }});
+
                 $.idleTimer({0});
                 $(document).bind('idle.idleTimer', function() {{
                     window.location = '{1}';


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Similar issue to the check-in on the welcome page getting stuck at 0. The idle redirect timer didn't get destroyed on a partial postback which caused it to fire even if there was activity.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Make the Idle Redirect block true to it's documentation.

# Strategy
_How have you implemented your solution?_

Destroyed timer in javascript during a partial postback so that it does not fire.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a