### PR TITLE
Fixed FundraisingParticipant block to not throw exception when home address missing

### DIFF
--- a/RockWeb/Blocks/Fundraising/FundraisingParticipant.ascx.cs
+++ b/RockWeb/Blocks/Fundraising/FundraisingParticipant.ascx.cs
@@ -603,8 +603,9 @@ namespace RockWeb.Blocks.Fundraising
             }
 
             // if btnContributionsTab is the only visible tab, hide the tab since there is nothing else to tab to
-            if ( !btnUpdatesTab.Visible )
+            if ( !btnUpdatesTab.Visible && btnContributionsTab.Visible )
             {
+                SetActiveTab( "Contributions" );
                 btnContributionsTab.Visible = false;
             }
         }

--- a/RockWeb/Blocks/Fundraising/FundraisingParticipant.ascx.cs
+++ b/RockWeb/Blocks/Fundraising/FundraisingParticipant.ascx.cs
@@ -640,14 +640,16 @@ namespace RockWeb.Blocks.Fundraising
             Literal lAddress = e.Row.FindControl( "lAddress" ) as Literal;
             if ( financialTransaction != null && lAddress != null && financialTransaction.AuthorizedPersonAliasId.HasValue )
             {
-                if ( financialTransaction.ShowAsAnonymous )
+                var personAddress = financialTransaction.AuthorizedPersonAlias.Person.GetHomeLocation();
+
+                if ( financialTransaction.ShowAsAnonymous || personAddress == null )
                 {
                     // don't show the person's address if they wanted to give anonymously
+                    // or if they don't have a home address.
                     lAddress.Text = string.Empty;
                 }
                 else
                 { 
-                    var personAddress = financialTransaction.AuthorizedPersonAlias.Person.GetHomeLocation();
                     lAddress.Text = personAddress.GetFullStreetAddress();
                 }
             }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

If a contributor to a fundraising trip participant has no home address then an exception is thrown because the address is not checked for null before being referenced.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Add null checking.

# Strategy
_How have you implemented your solution?_

Treat a null home address like an anonymous gift (i.e. show an empty string instead of the address).

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a