### PR TITLE
Added support for editing Device attributes.

### DIFF
--- a/RockWeb/Blocks/Core/DeviceDetail.ascx
+++ b/RockWeb/Blocks/Core/DeviceDetail.ascx
@@ -11,6 +11,7 @@
         <asp:Panel ID="pnlDetails" CssClass="panel panel-block" runat="server" Visible="false">
 
             <asp:HiddenField ID="hfDeviceId" runat="server" />
+            <asp:HiddenField ID="hfTypeId" runat="server" />
 
             <div class="panel-heading">
                 <h1 class="panel-title"><i class="fa fa-desktop"></i>
@@ -67,6 +68,12 @@
                                         Help="When this device needs to print, where should the printing be initiated from?  Either the server running Rock, or from the actual client device? " />
                                 </div>
                             </asp:Panel>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <Rock:DynamicPlaceHolder ID="phAttributes" runat="server" />
                         </div>
                     </div>
 

--- a/RockWeb/Blocks/Core/DeviceList.ascx.cs
+++ b/RockWeb/Blocks/Core/DeviceList.ascx.cs
@@ -15,6 +15,7 @@
 // </copyright>
 //
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Web.UI;
@@ -36,7 +37,7 @@ namespace RockWeb.Blocks.Core
 
     [LinkedPage("Detail Page")]
     public partial class DeviceList : RockBlock
-    { 
+    {
         #region Control Methods
 
         /// <summary>
@@ -55,6 +56,8 @@ namespace RockWeb.Blocks.Core
             gDevice.Actions.ShowAdd = true;
             gDevice.Actions.AddClick += gDevice_Add;
             gDevice.GridRebind += gDevice_GridRebind;
+
+            AddAttributeColumns();
 
             // Block Security and special attributes (RockPage takes care of View)
             bool canAddEditDelete = IsUserAuthorized( Authorization.EDIT );
@@ -214,6 +217,55 @@ namespace RockWeb.Blocks.Core
         #region Internal Methods
 
         /// <summary>
+        /// Add all the common attribute columns that are defined on Devices.
+        /// </summary>
+        protected void AddAttributeColumns()
+        {
+            // Remove attribute columns
+            foreach ( var column in gDevice.Columns.OfType<AttributeField>().ToList() )
+            {
+                gDevice.Columns.Remove( column );
+            }
+
+            var deleteColumn = gDevice.Columns.OfType<DeleteField>().FirstOrDefault();
+            var insertAt = gDevice.Columns.Count;
+            if ( deleteColumn != null )
+            {
+                insertAt = gDevice.Columns.IndexOf( deleteColumn );
+            }
+
+            // Add attribute columns
+            int entityTypeId = EntityTypeCache.Read( typeof( Rock.Model.Device ) ).Id;
+            foreach ( var attribute in new AttributeService( new RockContext() ).Queryable()
+                .Where( a =>
+                    a.EntityTypeId == entityTypeId &&
+                    a.IsGridColumn && 
+                    a.EntityTypeQualifierColumn == string.Empty
+                    )
+                .OrderBy( a => a.Order )
+                .ThenBy( a => a.Name ) )
+            {
+                string dataFieldExpression = attribute.Key;
+                bool columnExists = gDevice.Columns.OfType<AttributeField>().FirstOrDefault( a => a.DataField.Equals( dataFieldExpression ) ) != null;
+                if ( !columnExists )
+                {
+                    AttributeField boundField = new AttributeField();
+                    boundField.DataField = dataFieldExpression;
+                    boundField.AttributeId = attribute.Id;
+                    boundField.HeaderText = attribute.Name;
+
+                    var attributeCache = Rock.Web.Cache.AttributeCache.Read( attribute.Id );
+                    if ( attributeCache != null )
+                    {
+                        boundField.ItemStyle.HorizontalAlign = attributeCache.FieldType.Field.AlignValue;
+                    }
+
+                    gDevice.Columns.Insert( insertAt, boundField );
+                }
+            }
+        }
+
+        /// <summary>
         /// Binds the filter.
         /// </summary>
         private void BindFilter()
@@ -254,19 +306,7 @@ namespace RockWeb.Blocks.Core
             var sortProperty = gDevice.SortProperty;
             gDevice.EntityTypeId = EntityTypeCache.Read<Device>().Id;
 
-            var queryable = deviceService.Queryable().Select( a =>
-                new
-                {
-                    a.Id,
-                    a.Name,
-                    DeviceTypeName = a.DeviceType.Value,
-                    a.IPAddress,
-                    a.PrintToOverride,
-                    a.PrintFrom,
-                    PrinterDeviceName = a.PrinterDevice.Name,
-                    a.PrinterDeviceId,
-                    a.DeviceTypeValueId
-                } );
+            var queryable = deviceService.Queryable();
 
             string name = fDevice.GetUserPreference( "Name" );
             if ( !string.IsNullOrWhiteSpace( name ) )
@@ -304,14 +344,31 @@ namespace RockWeb.Blocks.Core
                 PrintFrom printFrom = (PrintFrom)System.Enum.Parse( typeof( PrintFrom ), fDevice.GetUserPreference( "Print From" ) ); ;
                 queryable = queryable.Where( d => d.PrintFrom == printFrom );
             }
-                   
+
+            gDevice.ObjectList = new Dictionary<string, object>();
+            queryable.ToList().ForEach( d => gDevice.ObjectList.Add( d.Id.ToString(), d ) );
+
+            var gridList = queryable.Select( a =>
+                new
+                {
+                    a.Id,
+                    a.Name,
+                    DeviceTypeName = a.DeviceType.Value,
+                    a.IPAddress,
+                    a.PrintToOverride,
+                    a.PrintFrom,
+                    PrinterDeviceName = a.PrinterDevice.Name,
+                    a.PrinterDeviceId,
+                    a.DeviceTypeValueId
+                } );
+
             if ( sortProperty != null )
             {
-                gDevice.DataSource = queryable.Sort( sortProperty ).ToList();
+                gDevice.DataSource = gridList.Sort( sortProperty ).ToList();
             }
             else
             {
-                gDevice.DataSource = queryable.OrderBy( d => d.Name ).ToList();
+                gDevice.DataSource = gridList.OrderBy( d => d.Name ).ToList();
             }
 
             gDevice.EntityTypeId = EntityTypeCache.Read<Rock.Model.Device>().Id;


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Could not add attributes to devices unless I went through SQL which is not ideal.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Allow administrators to have a safe and comfortable user interface that allows them to view and edit device attributes. Our goal should always be to make administrators feel like they are empowered on their own installation of Rock. Whenever possible we should do so in a way that makes them feel safe in providing powerful features to their users. If we fail at this task then we should be ashamed of ourselves.

# Strategy
_How have you implemented your solution?_

Copied and pasted a lot of code from the content channel blocks.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Administrators may be stuck with their new found freedom of empowerment.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![image](https://user-images.githubusercontent.com/1119863/28082933-bb1db892-6628-11e7-9cbb-0a829d998a37.png)

![image](https://user-images.githubusercontent.com/1119863/28082989-e75f2314-6628-11e7-9e5d-81704db316e3.png)

![image](https://user-images.githubusercontent.com/1119863/28083068-1d712966-6629-11e7-927e-645ced235e23.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a