### PR TITLE
Fix #2079: Grades Changing with Client Culture

### DIFF
--- a/Rock/Web/Cache/GlobalAttributesCache.cs
+++ b/Rock/Web/Cache/GlobalAttributesCache.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Caching;
 using System.Web;
@@ -473,8 +474,15 @@ namespace Rock.Web.Cache
         {
             get
             {
-                var transitionDate = GetValue( "GradeTransitionDate" ).AsDateTime() ?? new DateTime( RockDateTime.Today.Year, 6, 1 );
-                transitionDate = new DateTime( RockDateTime.Today.Year, transitionDate.Month, transitionDate.Day );
+                var formattedTransitionDate = GetValue( "GradeTransitionDate" ) + "/" + RockDateTime.Today.Year;
+                DateTime transitionDate;
+
+                // Check Date Validity
+                if ( !DateTime.TryParseExact( formattedTransitionDate, "MM/dd/yyyy", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AllowWhiteSpaces, out transitionDate ) )
+                {
+                    transitionDate = new DateTime( RockDateTime.Today.Year, 6, 1 );
+                }
                 return RockDateTime.Now.Date < transitionDate ? transitionDate.Year : transitionDate.Year + 1;
             }
         }

--- a/Rock/Web/Cache/GlobalAttributesCache.cs
+++ b/Rock/Web/Cache/GlobalAttributesCache.cs
@@ -478,7 +478,7 @@ namespace Rock.Web.Cache
                 DateTime transitionDate;
 
                 // Check Date Validity
-                if ( !DateTime.TryParseExact( formattedTransitionDate, "MM/dd/yyyy", CultureInfo.InvariantCulture,
+                if ( !DateTime.TryParseExact( formattedTransitionDate, new[] { "MM/dd/yyyy", "M/dd/yyyy", "M/d/yyyy", "MM/d/yyyy" }, CultureInfo.InvariantCulture,
                     DateTimeStyles.AllowWhiteSpaces, out transitionDate ) )
                 {
                     transitionDate = new DateTime( RockDateTime.Today.Year, 6, 1 );


### PR DESCRIPTION
# Context
https://github.com/SparkDevNetwork/Rock/issues/2079

# Goal
It will prevent grades appearing incorrectly (+- a year) depending on the viewer's client culture.

# Strategy
Ideally the date and month would've been parsed using a Rock wide culture setting but it doesn't appear we track that anywhere and since server culture in some hosting environments can't be changed I decided to stick with the existing Lava Tip for the attribute which specifies `mm/dd`. 

I decided to append the current year to date time as there were some instances where trying to do `ParseExact` on a mm/dd format would fail to parse correctly and also there would be some valid inputs where it produced a DateTime that was invalid for the current year because of leap years. 

# Possible Implications
This will only affect churches that are based in a location which uses the mm/dd format. They may need to adjust their existing attribute value if they've input it as dd/mm to reflect their client culture.