### PR TITLE
Feature: Independent block for viewing and editing Entity Attribute Values

### DIFF
--- a/RockWeb/Blocks/Utility/EntityAttributeValues.ascx
+++ b/RockWeb/Blocks/Utility/EntityAttributeValues.ascx
@@ -1,0 +1,24 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="EntityAttributeValues.ascx.cs" Inherits="RockWeb.Blocks.Utility.EntityAttributeValues" %>
+
+<asp:UpdatePanel ID="upnlContent" runat="server">
+    <ContentTemplate>
+
+        <asp:Panel ID="pnlDetails" runat="server" CssClass="panel panel-block" Visible="false">
+            <div class="panel-heading"><i class="fa fa-list-ul"></i> <asp:Literal ID="ltTitle" runat="server"></asp:Literal></div>
+            <div class="panel-body">
+                <asp:Panel ID="pnlView" runat="server">
+                    <asp:PlaceHolder ID="phAttributes" runat="server" />
+
+                    <asp:LinkButton ID="btnEdit" runat="server" CssClass="btn btn-primary" Text="Edit" OnClick="btnEdit_Click"></asp:LinkButton>
+                </asp:Panel>
+
+                <asp:Panel ID="pnlEdit" runat="server" Visible="false">
+                    <asp:PlaceHolder ID="phEditAttributes" runat="server"></asp:PlaceHolder>
+
+                    <asp:LinkButton ID="btnSave" runat="server" CssClass="btn btn-primary" Text="Save" OnClick="btnSave_Click"></asp:LinkButton>
+                    <asp:LinkButton ID="btnCancel" runat="server" CssClass="btn btn-link" Text="Cancel" OnClick="btnCancel_Click"></asp:LinkButton>
+                </asp:Panel>
+            </div>
+        </asp:Panel>
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/RockWeb/Blocks/Utility/EntityAttributeValues.ascx.cs
+++ b/RockWeb/Blocks/Utility/EntityAttributeValues.ascx.cs
@@ -1,0 +1,192 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web.UI.WebControls;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Security;
+using Rock.Web.UI;
+
+namespace RockWeb.Blocks.Utility
+{
+    [DisplayName( "Entity Attribute Values" )]
+    [Category( "Utility" )]
+    [Description( "View and edit attribute values for an entity." )]
+
+    [ContextAware]
+    public partial class EntityAttributeValues : RockBlock, ISecondaryBlock
+    {
+        #region Base Method Overrides
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            // this event gets fired after block settings are updated. it's nice to repaint the screen if these settings would alter it
+            this.BlockUpdated += Block_BlockUpdated;
+            this.AddConfigurationUpdateTrigger( upnlContent );
+        }
+
+        /// <summary>
+        /// Initialize basic information about the page structure and setup the default content.
+        /// </summary>
+        /// <param name="sender">Object that is generating this event.</param>
+        /// <param name="e">Arguments that describe this event.</param>
+        protected void Page_Load( object sender, EventArgs e )
+        {
+            IHasAttributes entity = ContextEntity() as IHasAttributes;
+
+            if ( entity == null || entity.Attributes.Count == 0 )
+            {
+                return;
+            }
+
+            if ( !IsPostBack )
+            {
+                var canEdit = IsUserAuthorized( Authorization.EDIT );
+
+                pnlDetails.Visible = true;
+                pnlView.Visible = true;
+                btnEdit.Visible = canEdit;
+
+                ltTitle.Text = string.Format( "{0} Attributes", entity.GetType().GetFriendlyTypeName() );
+            }
+
+            if ( pnlEdit.Visible )
+            {
+                ShowEdit( false );
+            }
+            else
+            {
+                ShowDetails();
+            }
+        }
+
+        /// <summary>
+        /// Allow primary blocks to hide this one. This is common when the primary block goes
+        /// into edit mode.
+        /// </summary>
+        /// <param name="visible">true if this block should be visible, false if it should be hidden.</param>
+        void ISecondaryBlock.SetVisible( bool visible )
+        {
+            pnlDetails.Visible = false;
+        }
+
+        #endregion
+
+        #region Core Methods
+
+        /// <summary>
+        /// Shows the read-only attribute values.
+        /// </summary>
+        protected void ShowDetails()
+        {
+            IHasAttributes entity = ContextEntity() as IHasAttributes;
+
+            if ( entity != null )
+            {
+                phAttributes.Controls.Clear();
+                Rock.Attribute.Helper.AddDisplayControls( entity, phAttributes, null, false, false );
+            }
+        }
+
+        /// <summary>
+        /// Shows the edit attributes controls.
+        /// </summary>
+        /// <param name="setValues">If true then the values are set from the database, otherwise the postback values will be used.</param>
+        protected void ShowEdit( bool setValues )
+        {
+            IHasAttributes entity = ContextEntity() as IHasAttributes;
+
+            if ( entity != null )
+            {
+                phEditAttributes.Controls.Clear();
+                Rock.Attribute.Helper.AddEditControls( entity, phEditAttributes, true, BlockValidationGroup );
+            }
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            pnlEdit.Visible = false;
+            pnlView.Visible = true;
+
+            ShowDetails();
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnEdit_Click( object sender, EventArgs e )
+        {
+            pnlView.Visible = false;
+            pnlEdit.Visible = true;
+
+            ShowEdit( true );
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnSave_Click( object sender, EventArgs e )
+        {
+            pnlView.Visible = true;
+            pnlEdit.Visible = false;
+
+            IHasAttributes entity = ContextEntity() as IHasAttributes;
+            Rock.Attribute.Helper.GetEditValues( phEditAttributes, entity );
+            entity.SaveAttributeValues();
+
+            ShowDetails();
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnCancel_Click( object sender, EventArgs e )
+        {
+            pnlView.Visible = true;
+            pnlEdit.Visible = false;
+
+            ShowDetails();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

"Have you ever wished you could edit attribute values for any entity in the system? Well now you can! No modifications to your database are needed with this handy universal Entity Attribute Values block. Simply install this update and you too can edit attribute values on everything you could imagine - and more! Act now and we'll even throw in the ability to edit attribute values on attribute values!"

# Goal
_What will this pull request achieve and how will this fix the problem?_

Provide a way for tinkerers and developers to edit attribute values on any entity in the system via a standard block. Block Setting allows selection of the type of entity, and then the Page Settings can be used to "map" that entity context to a query string parameter. Example below for adding Attribute Values to Devices.

# Strategy
_How have you implemented your solution?_

Lots of copy and paste and trimming out excess code to be left with a very simple interface.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Developers might wet themselves from over excitement.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![pasted image at 2017_07_11 02_35 pm](https://user-images.githubusercontent.com/1119863/28143810-76bd1ae0-671c-11e7-88d7-0e698bd1e2b1.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
