### PR TITLE
Fixed admin bar to allow editing of footer in DashboardStark #1584

### DIFF
--- a/RockWeb/Themes/DashboardStark/Styles/theme.less
+++ b/RockWeb/Themes/DashboardStark/Styles/theme.less
@@ -53,6 +53,11 @@ footer {
   padding-top: 24px;
 }
 
+// Allows for editing of footer zones when admin is editing zones or blocks
+.zone-highlight footer,
+.block-highlight footer {
+  padding-bottom: 36px;
+}
 
 
 // 4. Responsive Overrides


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context

#1584 Mentions DashboardStark overflowing the page bounds. While this no longer appears to be an issue, it's impossible to edit the blocks/zone in the footer because it's affixed to the bottom of the page. This adds padding to the footer when the block/zone edit class is applied, which pushes the admin toolbar out of the way.

# Goal
Make footer editable

# Strategy
Padding to the footer, applied only when editing.

# Tests
N/A

# Possible Implications
When editing the page, extra padding on other page elements that are using the footer element will be added. This is unlikely due to the semantic nature of the footer tag.

# Screenshots
![screen shot 2017-07-12 at 8 24 01 pm](https://user-images.githubusercontent.com/374209/28149154-4d8a8e72-6740-11e7-8163-8fd374acbb51.png)

# Documentation
N/A
