### PR TITLE
Fix SMS Replies Not Matching If Your Defined Value Number Contains a Space

### DIFF
--- a/Rock/Communication/Medium/Sms.cs
+++ b/Rock/Communication/Medium/Sms.cs
@@ -169,6 +169,7 @@ namespace Rock.Communication.Medium
             errorMessage = string.Empty;
             
             string transportPhone = string.Empty;
+            toPhone = toPhone.RemoveSpaces();
 
             using ( Rock.Data.RockContext rockContext = new Rock.Data.RockContext() )
             {

--- a/Rock/Communication/Medium/Sms.cs
+++ b/Rock/Communication/Medium/Sms.cs
@@ -167,26 +167,25 @@ namespace Rock.Communication.Medium
         public void ProcessResponse( string toPhone, string fromPhone, string message, out string errorMessage )
         {
             errorMessage = string.Empty;
-            
-            string transportPhone = string.Empty;
-            toPhone = toPhone.RemoveSpaces();
 
-            using ( Rock.Data.RockContext rockContext = new Rock.Data.RockContext() )
+            string transportPhone = string.Empty;
+
+            using ( var rockContext = new RockContext() )
             {
                 Person toPerson = null;
 
                 // get from person
                 var fromPerson = new PersonService( rockContext ).Queryable()
-                                    .Where( p => p.PhoneNumbers.Any( n => ( n.CountryCode + n.Number ) == fromPhone.Replace( "+", "" ) ) )
+                                    .Where( p => p.PhoneNumbers.Any( n => n.CountryCode + n.Number == fromPhone.Replace( "+", "" ) ) )
                                     .OrderBy( p => p.Id ).FirstOrDefault(); // order by person id to get the oldest person to help with duplicate records of the response recipient
 
                 // get recipient from defined value
-                var definedType = DefinedTypeCache.Read( Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM.AsGuid() );
+                var definedType = DefinedTypeCache.Read( SystemGuid.DefinedType.COMMUNICATION_SMS_FROM.AsGuid() );
                 if ( definedType != null )
                 {
                     if ( definedType.DefinedValues != null && definedType.DefinedValues.Any() )
                     {
-                        var matchValue = definedType.DefinedValues.Where( v => v.Value == toPhone ).OrderBy( v => v.Order ).FirstOrDefault();
+                        var matchValue = definedType.DefinedValues.Where( v => v.Value.RemoveSpaces() == toPhone ).OrderBy( v => v.Order ).FirstOrDefault();
                         if ( matchValue != null )
                         {
                             transportPhone = matchValue.Id.ToString();
@@ -236,7 +235,7 @@ namespace Rock.Communication.Medium
                 }
                 else
                 {
-                    var globalAttributes = Rock.Web.Cache.GlobalAttributesCache.Read();
+                    var globalAttributes = GlobalAttributesCache.Read();
                     string organizationName = globalAttributes.GetValue( "OrganizationName" );
 
                     errorMessage = string.Format( "Could not deliver message. This phone number is not registered in the {0} database.", organizationName );


### PR DESCRIPTION
# Context
The defined values containing our Twilio SMS numbers mysteriously had spaces added for formatting purposes. 

# Goal
To prevent someone having to waste time tracking down a issue that's very difficult to diagnose! Twilio also gives you spaces in your number by default.

# Strategy
Strip whitespace from the `toPhone` number before querying.

# Possible Implications
None
