### PR TITLE
Fixed fundraising and event lava to not use embedded filters in if statements

### DIFF
--- a/RockWeb/Themes/Flat/Assets/Lava/CalendarItem.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/CalendarItem.lava
@@ -34,10 +34,10 @@
       <h4> {{ EventItemOccurrence.Campus.Name }} Campus</h4>
       {% endif %}
 
-      {% if (EventItemOccurrence.ContactPersonAlias.Person.Fullname | Trim != '') or EventItemOccurrence.ContactEmail != '' or EventItemOccurrence.ContactPhone != '' %}
+      {% if EventItemOccurrence.ContactPersonAliasId != null or EventItemOccurrence.ContactEmail != '' or EventItemOccurrence.ContactPhone != '' %}
       <p>
         <strong>Contact</strong><br />
-        {% if EventItemOccurrence.ContactPersonAlias.Person.Fullname | Trim != '' %}
+        {% if EventItemOccurrence.ContactPersonAliasId != null %}
         {{ EventItemOccurrence.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 

--- a/RockWeb/Themes/Flat/Assets/Lava/FundraisingOpportunitySidebar.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/FundraisingOpportunitySidebar.lava
@@ -41,10 +41,10 @@
       <div class='label label-default text-center' style='display: block; padding: 8px; margin-bottom: 12px;'>Registration Closed</div>
     {% endif %}
 
-    {% if (RegistrationInstance.ContactPersonAlias.Person.Fullname | Trim != '') or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
+    {% if RegistrationInstance.ContactPersonAliasId != '' or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
     <p>
         <strong>Contact</strong><br />
-        {% if RegistrationInstance.ContactPersonAlias.Person.FullName | Trim != '' %}
+        {% if RegistrationInstance.ContactPersonAliasId != '' %}
         {{ RegistrationInstance.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 

--- a/RockWeb/Themes/Flat/Assets/Lava/FundraisingOpportunitySidebar.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/FundraisingOpportunitySidebar.lava
@@ -41,10 +41,10 @@
       <div class='label label-default text-center' style='display: block; padding: 8px; margin-bottom: 12px;'>Registration Closed</div>
     {% endif %}
 
-    {% if RegistrationInstance.ContactPersonAliasId != '' or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
+    {% if RegistrationInstance.ContactPersonAliasId != null or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
     <p>
         <strong>Contact</strong><br />
-        {% if RegistrationInstance.ContactPersonAliasId != '' %}
+        {% if RegistrationInstance.ContactPersonAliasId != null %}
         {{ RegistrationInstance.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 

--- a/RockWeb/Themes/Rock/Assets/Lava/CalendarItem.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/CalendarItem.lava
@@ -34,10 +34,10 @@
       <h4> {{ EventItemOccurrence.Campus.Name }} Campus</h4>
       {% endif %}
 
-      {% if (EventItemOccurrence.ContactPersonAlias.Person.Fullname | Trim != '') or EventItemOccurrence.ContactEmail != '' or EventItemOccurrence.ContactPhone != '' %}
+      {% if EventItemOccurrence.ContactPersonAliasId != null or EventItemOccurrence.ContactEmail != '' or EventItemOccurrence.ContactPhone != '' %}
       <p>
         <strong>Contact</strong><br />
-        {% if EventItemOccurrence.ContactPersonAlias.Person.Fullname | Trim != '' %}
+        {% if EventItemOccurrence.ContactPersonAliasId != null %}
         {{ EventItemOccurrence.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 

--- a/RockWeb/Themes/Rock/Assets/Lava/FundraisingOpportunitySidebar.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/FundraisingOpportunitySidebar.lava
@@ -41,10 +41,10 @@
       <div class='label label-default text-center' style='display: block; padding: 8px; margin-bottom: 12px;'>Registration Closed</div>
     {% endif %}
 
-    {% if (RegistrationInstance.ContactPersonAlias.Person.Fullname | Trim != '') or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
+    {% if RegistrationInstance.ContactPersonAliasId != null or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
     <p>
         <strong>Contact</strong><br />
-        {% if RegistrationInstance.ContactPersonAlias.Person.FullName | Trim != '' %}
+        {% if RegistrationInstance.ContactPersonAliasId != null %}
         {{ RegistrationInstance.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 

--- a/RockWeb/Themes/Stark/Assets/Lava/CalendarItem.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/CalendarItem.lava
@@ -34,10 +34,10 @@
       <h4> {{ EventItemOccurrence.Campus.Name }} Campus</h4>
       {% endif %}
 
-      {% if (EventItemOccurrence.ContactPersonAlias.Person.Fullname | Trim != '') or EventItemOccurrence.ContactEmail != '' or EventItemOccurrence.ContactPhone != '' %}
+      {% if EventItemOccurrence.ContactPersonAliasId != null or EventItemOccurrence.ContactEmail != '' or EventItemOccurrence.ContactPhone != '' %}
       <p>
         <strong>Contact</strong><br />
-        {% if EventItemOccurrence.ContactPersonAlias.Person.Fullname | Trim != '' %}
+        {% if EventItemOccurrence.ContactPersonAliasId != null %}
         {{ EventItemOccurrence.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 

--- a/RockWeb/Themes/Stark/Assets/Lava/FundraisingOpportunitySidebar.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/FundraisingOpportunitySidebar.lava
@@ -41,10 +41,10 @@
       <div class='label label-default text-center' style='display: block; padding: 8px; margin-bottom: 12px;'>Registration Closed</div>
     {% endif %}
 
-    {% if (RegistrationInstance.ContactPersonAlias.Person.Fullname | Trim != '') or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
+    {% if RegistrationInstance.ContactPersonAliasId != null or RegistrationInstance.ContactEmail != '' or RegistrationInstance.ContactPhone != '' %}
     <p>
         <strong>Contact</strong><br />
-        {% if RegistrationInstance.ContactPersonAlias.Person.FullName | Trim != '' %}
+        {% if RegistrationInstance.ContactPersonAliasId != null %}
         {{ RegistrationInstance.ContactPersonAlias.Person.FullName }} <br />
         {% endif %}
 


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
#2249 + Fix for a nearly identical call in fundraising opportunities lava.

# Goal
Change all if statements to use the `ContactPersonAliasId`, which is more efficient than running a trim statement on a `FullName` which would always exist if there's a contact person alias. 

# Strategy
Lava

# Tests
N/A

# Possible Implications
N/A

# Documentation
N/A
