### PR TITLE
New Rapid Attendance Entry block

### DIFF
--- a/RockWeb/Blocks/CheckIn/RapidAttendanceEntry.ascx
+++ b/RockWeb/Blocks/CheckIn/RapidAttendanceEntry.ascx
@@ -1,0 +1,75 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="RapidAttendanceEntry.ascx.cs" Inherits="RockWeb.Blocks.CheckIn.RapidAttendanceEntry" %>
+
+<asp:UpdatePanel ID="upnlContent" runat="server">
+    <ContentTemplate>
+        <Rock:NotificationBox ID="nbWarning" runat="server" NotificationBoxType="Warning" />
+
+        <asp:Panel ID="pnlEntry" runat="server" CssClass="panel panel-block">
+            <div class="panel-heading">
+                <div class="pull-right">
+                    <Rock:HighlightLabel ID="hlCurrentCount" runat="server" LabelType="Info" Text="Current Attendance: 0" />
+                </div>
+                <h3 class="panel-title">Rapid Attendance</h3>
+            </div>
+            
+            <div class="panel-body">
+                <div class="row">
+                    <asp:Panel ID="pnlGroupPicker" runat="server" CssClass="col-md-4">
+                        <Rock:RockDropDownList ID="ddlGroup" runat="server" Label="Group" Required="true" OnSelectedIndexChanged="ddlGroup_SelectedIndexChanged" AutoPostBack="true" />
+                    </asp:Panel>
+
+                    <asp:Panel ID="pnlLocationPicker" runat="server" CssClass="col-md-4">
+                        <Rock:RockDropDownList ID="ddlLocation" runat="server" Label="Location" Required="true" OnSelectedIndexChanged="ddlLocation_SelectedIndexChanged" AutoPostBack="true" />
+                    </asp:Panel>
+
+                    <asp:Panel ID="pnlSchedulePicker" runat="server" CssClass="col-md-4">
+                        <Rock:RockDropDownList ID="ddlSchedule" runat="server" Label="Schedule" Required="true" OnSelectedIndexChanged="ddlSchedule_SelectedIndexChanged" AutoPostBack="true" />
+                    </asp:Panel>
+                </div>
+
+                <Rock:DatePicker ID="dpAttendanceDate" runat="server" Required="true" Label="Attendance Date" Help="The date to use when recording the person as having attended." OnTextChanged="dpAttendanceDate_TextChanged" AutoPostBack="true" />
+                
+                <hr />
+
+                <div class="row">
+                    <div class="col-md-4">
+                        <Rock:PersonPicker ID="ppAttendee" runat="server" Label="Attendee" Required="true" CssClass="js-attendee" OnSelectPerson="ppAttendee_SelectPerson" />
+                        <asp:LinkButton ID="btnSave" runat="server" CssClass="btn btn-primary" AccessKey="s" Text="Save" OnClick="btnSave_Click" />
+                        <asp:LinkButton ID="btnSaveActivate" runat="server" CssClass="btn btn-default pull-right" AccessKey="a" Text="Activate & Save" OnClick="btnSave_Click" Visible="false" />
+                    </div>
+
+                    <div class="col-md-8">
+                        <Rock:NotificationBox ID="nbInactivePerson" runat="server" NotificationBoxType="Warning" Text="This person record is currently inactive." Visible="false" />
+                        <Rock:NotificationBox ID="nbAttended" runat="server" NotificationBoxType="Success" Text="" />
+                    </div>
+                </div>
+            </div>
+        </asp:Panel>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="pull-right padding-r-sm">
+                    <asp:CheckBox ID="cbShowCurrent" runat="server" OnCheckedChanged="cbShowCurrent_CheckedChanged" Text="Show Current Attendees" AutoPostBack="true" />
+                </div>
+            </div>
+        </div>
+
+        <asp:Panel ID="pnlCurrentAttendees" runat="server" CssClass="panel panel-block">
+            <div class="panel-heading">
+                <h3 class="panel-title">Current Attendees</h3>
+            </div>
+
+            <div class="panel-body">
+                <div class="grid grid-panel">
+                    <Rock:Grid ID="gAttendees" runat="server" DataKeyNames="Id">
+                        <Columns>
+                            <asp:BoundField DataField="PersonAlias.Person.FullNameReversed" HeaderText="Name" />
+                            <asp:BoundField DataField="CreatedByPersonName" HeaderText="Entered By" />
+                            <Rock:DeleteField OnClick="gAttendeesDelete_Click"></Rock:DeleteField>
+                        </Columns>
+                    </Rock:Grid>
+                </div>
+            </div>
+        </asp:Panel>
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/RockWeb/Blocks/CheckIn/RapidAttendanceEntry.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/RapidAttendanceEntry.ascx.cs
@@ -1,0 +1,490 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+
+namespace RockWeb.Blocks.CheckIn
+{
+    [DisplayName( "Rapid Attendance Entry" )]
+    [Category( "Check-in" )]
+    [Description( "Provides a way to manually enter attendance for a large group of people in an efficient manner." )]
+
+    [GroupField( "Parent Group", "Select the parent group whose immediate childeren will be displayed as options to take attendance for.", required: true, order: 0 )]
+    [BooleanField( "Include Parent Group", "If true then the parent group will be included as an option in addition to it's children.", false, order: 1 )]
+    [BooleanField( "Default Show Current Attendees", "Should the Current Attendees grid be visible by default. When the grid is enabled performance will be reduced.", false, order: 1 )]
+    public partial class RapidAttendanceEntry : RockBlock
+    {
+        #region Base Method Overrides
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            // this event gets fired after block settings are updated. it's nice to repaint the screen if these settings would alter it
+            this.BlockUpdated += Block_BlockUpdated;
+            this.AddConfigurationUpdateTrigger( upnlContent );
+            gAttendees.GridRebind += gAttendees_GridRebind;
+        }
+
+        /// <summary>
+        /// Initialize basic information about the page structure and setup the default content.
+        /// </summary>
+        /// <param name="sender">Object that is generating this event.</param>
+        /// <param name="e">Arguments that describe this event.</param>
+        protected void Page_Load( object sender, EventArgs e )
+        {
+            if ( !IsPostBack )
+            {
+                ShowDetails();
+            }
+        }
+
+        #endregion
+
+        #region Core Methods
+
+        /// <summary>
+        /// Show all details. This also clears any existing selections the user may have made.
+        /// </summary>
+        private void ShowDetails()
+        {
+            var groups = new List<Group>();
+            var rockContext = new RockContext();
+            var parentGroup = new GroupService( rockContext ).Get( GetAttributeValue( "ParentGroup" ).AsGuid() );
+
+            //
+            // Clear existing values.
+            //
+            dpAttendanceDate.SelectedDate = null;
+            ppAttendee.SetValue( null );
+
+            //
+            // Clear group picker.
+            //
+            pnlGroupPicker.Visible = false;
+            ddlGroup.Items.Clear();
+            ddlGroup.Items.Add( new ListItem() );
+
+            //
+            // Get the list of groups to be displayed in the picker.
+            //
+            if ( parentGroup != null )
+            {
+                groups = parentGroup.Groups.Where( g => g.IsActive ).OrderBy( g => g.Order ).ToList();
+
+                if ( GetAttributeValue( "IncludeParentGroup" ).AsBoolean( false ) )
+                {
+                    groups.Insert( 0, parentGroup );
+                }
+            }
+
+            //
+            // Add all the groups to the drop down list.
+            //
+            foreach ( var group in groups )
+            {
+                ddlGroup.Items.Add( new ListItem( group.Name, group.Id.ToString() ) );
+            }
+
+            //
+            // If there is only one group then select it, otherwise show the picker and let the user select.
+            //
+            if ( groups.Count == 1 )
+            {
+                ddlGroup.SelectedIndex = 1;
+            }
+            else
+            {
+                pnlGroupPicker.Visible = true;
+            }
+
+            UpdateLocations();
+
+            //
+            // Set default state of the attendees grid.
+            //
+            pnlCurrentAttendees.Visible = cbShowCurrent.Checked = GetAttributeValue( "DefaultShowCurrentAttendees" ).AsBoolean( false );
+            BindAttendees();
+        }
+
+        /// <summary>
+        /// Update the locations drop down to match the valid locations for the currently
+        /// selected group.
+        /// </summary>
+        private void UpdateLocations()
+        {
+            //
+            // Clear the location picker.
+            //
+            pnlLocationPicker.Visible = false;
+            ddlLocation.Items.Clear();
+            ddlLocation.Items.Add( new ListItem() );
+
+            if ( !string.IsNullOrWhiteSpace( ddlGroup.SelectedValue ) )
+            {
+                var group = new GroupService( new RockContext() ).Get( ddlGroup.SelectedValue.AsInteger() );
+                var groupLocations = group.GroupLocations;
+
+                //
+                // Add all the locations to the drop down list.
+                //
+                foreach ( var groupLocation in groupLocations )
+                {
+                    ddlLocation.Items.Add( new ListItem( groupLocation.Location.Name, groupLocation.Id.ToString() ) );
+                }
+
+                //
+                // If there is only one location then select it, otherwise show the picker and let the user select.
+                //
+                if ( groupLocations.Count == 1 )
+                {
+                    ddlLocation.SelectedIndex = 1;
+                }
+                else
+                {
+                    pnlLocationPicker.Visible = true;
+                }
+            }
+
+            UpdateSchedules();
+        }
+
+        /// <summary>
+        /// Update the schedules drop down to match the valid schedules for the currently
+        /// selected group locations.
+        /// </summary>
+        private void UpdateSchedules()
+        {
+            //
+            // Clear the schedule picker.
+            //
+            pnlSchedulePicker.Visible = false;
+            ddlSchedule.Items.Clear();
+            ddlSchedule.Items.Add( new ListItem() );
+
+            if ( !string.IsNullOrWhiteSpace( ddlLocation.SelectedValue ) )
+            {
+                var rockContext = new RockContext();
+                var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValue.AsInteger() );
+                var groupLocation = new GroupLocationService( rockContext ).Get( ddlLocation.SelectedValue.AsInteger() );
+                var schedules = groupLocation.Schedules.ToList();
+
+                // TODO: Should keep?
+                if ( group.Schedule != null )
+                {
+                    schedules.Add( group.Schedule );
+                }
+
+                //
+                // Add all the schedules to the drop down list.
+                //
+                foreach ( var schedule in schedules )
+                {
+                    ddlSchedule.Items.Add( new ListItem( schedule.Name, schedule.Id.ToString() ) );
+                }
+
+                //
+                // If ther is only one schedule then select it, otherwise show the picker and let the user select.
+                //
+                if ( schedules.Count == 1 )
+                {
+                    ddlSchedule.SelectedIndex = 1;
+                }
+                else
+                {
+                    pnlSchedulePicker.Visible = true;
+                }
+
+                BindAttendees();
+            }
+        }
+
+        /// <summary>
+        /// Bind the grid of current attendees. Can be called any time, internally checks if
+        /// all user-entered values are correct and binds an empty result set if not.
+        /// </summary>
+        private void BindAttendees()
+        {
+            var rockContext = new RockContext();
+            var attendanceService = new AttendanceService( rockContext );
+            var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValue.AsInteger() );
+            var groupLocationId = ddlLocation.SelectedValue.AsIntegerOrNull();
+            var scheduleId = ddlSchedule.SelectedValue.AsIntegerOrNull();
+            var dateTime = dpAttendanceDate.SelectedDate;
+            IEnumerable<Attendance> attendance = new List<Attendance>();
+
+            if ( group != null && groupLocationId != null && scheduleId != null && dateTime != null )
+            {
+                var groupLocation = new GroupLocationService( rockContext ).Get( groupLocationId.Value );
+
+                //
+                // Check for existing attendance records.
+                //
+                attendance = attendanceService.Queryable()
+                    .Where( a => a.DidAttend == true && a.GroupId == group.Id && a.StartDateTime == dateTime.Value && a.LocationId == groupLocation.LocationId && a.ScheduleId == scheduleId )
+                    .OrderBy( a => a.PersonAlias.Person.LastName )
+                    .ThenBy( a => a.PersonAlias.Person.FirstName );
+
+                hlCurrentCount.Text = string.Format( "Current Attendance: {0}", attendance.Count() );
+            }
+
+            if ( cbShowCurrent.Checked )
+            {
+                gAttendees.DataSource = attendance.ToList();
+            }
+            else
+            {
+                gAttendees.DataSource = null;
+            }
+
+            gAttendees.DataBind();
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            ShowDetails();
+        }
+
+        /// <summary>
+        /// Handles the Click event of the btnSave control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnSave_Click( object sender, EventArgs e )
+        {
+            var rockContext = new RockContext();
+            var attendanceService = new AttendanceService( rockContext );
+            var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValue.AsInteger() );
+            var person = new PersonService( rockContext ).Get( ppAttendee.PersonId.Value );
+            var scheduleId = ddlSchedule.SelectedValue.AsIntegerOrNull();
+            var dateTime = dpAttendanceDate.SelectedDate.Value;
+            var groupLocation = new GroupLocationService( rockContext ).Get( ddlLocation.SelectedValue.AsInteger() );
+
+            //
+            // Check for existing attendance record.
+            //
+            var attendance = attendanceService.Queryable()
+                .Where( a => a.GroupId == group.Id && a.PersonAlias.PersonId == person.Id && a.StartDateTime == dateTime && a.LocationId == groupLocation.LocationId && a.ScheduleId == scheduleId )
+                .FirstOrDefault();
+
+            //
+            // If the user is using the activate and save button then mark the
+            // person as active too.
+            //
+            if ( sender == btnSaveActivate )
+            {
+                person.RecordStatusValueId = new DefinedValueService( rockContext ).Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_ACTIVE.AsGuid() ).Id;
+            }
+
+            //
+            // If not found then create a new one.
+            //
+            if ( attendance == null )
+            {
+                attendance = new Attendance();
+
+                attendance.GroupId = group.Id;
+                attendance.PersonAliasId = person.PrimaryAliasId;
+                attendance.StartDateTime = dateTime;
+                attendance.CampusId = group.CampusId;
+                attendance.LocationId = groupLocation.LocationId;
+                attendance.ScheduleId = scheduleId;
+
+                attendanceService.Add( attendance );
+            }
+
+            attendance.DidAttend = true;
+            rockContext.SaveChanges();
+
+            //
+            // Flush the attendance cache.
+            //
+            if ( attendance.LocationId.HasValue )
+            {
+                Rock.CheckIn.KioskLocationAttendance.Flush( attendance.LocationId.Value );
+            }
+
+            nbAttended.Text = string.Format( "{0} has been marked attended.", person.FullName );
+
+            //
+            // Clear the person picker and open it so it's ready to go.
+            //
+            ppAttendee.SetValue( null );
+            btnSaveActivate.Visible = false;
+            nbInactivePerson.Visible = false;
+
+            //
+            // Autoexpand the person picker for next entry.
+            //
+            var personPickerStartupScript = @"(function () {
+                var runOnce = true;
+                Sys.Application.add_load(function () {
+                    if ( runOnce ) {
+                        var personPicker = $('.js-attendee');
+                        var currentPerson = personPicker.find('.picker-selectedperson').html();
+                        if (currentPerson != null && currentPerson.length == 0) {
+                            $(personPicker).find('a.picker-label').trigger('click');
+                        }
+                        runOnce = false;
+                    }
+                })
+            })();";
+            ScriptManager.RegisterStartupScript( btnSave, this.GetType(), "StartupScript", personPickerStartupScript, true );
+
+            BindAttendees();
+        }
+
+        /// <summary>
+        /// Handles the user changed the checked state of the cbShowCurrent control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void cbShowCurrent_CheckedChanged( object sender, EventArgs e )
+        {
+            pnlCurrentAttendees.Visible = cbShowCurrent.Checked;
+
+            if ( cbShowCurrent.Checked )
+            {
+                BindAttendees();
+            }
+        }
+
+        /// <summary>
+        /// Handles the GridRebind event of the gAttendees control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="GridRebindEventArgs"/> instance containing the event data.</param>
+        protected void gAttendees_GridRebind( object sender, Rock.Web.UI.Controls.GridRebindEventArgs e )
+        {
+            BindAttendees();
+        }
+
+        /// <summary>
+        /// Handles the user clicking the delete button in the gAttendees control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void gAttendeesDelete_Click( object sender, Rock.Web.UI.Controls.RowEventArgs e )
+        {
+            var rockContext = new RockContext();
+            var attendanceService = new AttendanceService( rockContext );
+            var attendance = attendanceService.Get( e.RowKeyId );
+
+            attendance.DidAttend = false;
+            rockContext.SaveChanges();
+
+            if ( attendance.LocationId != null )
+            {
+                Rock.CheckIn.KioskLocationAttendance.Flush( attendance.LocationId.Value );
+            }
+
+            nbAttended.Text = string.Format( "{0} has been removed from attendance.", attendance.PersonAlias.Person.FullName );
+
+            BindAttendees();
+        }
+
+        /// <summary>
+        /// Handles the user selecting an item of the ddlGroup control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ddlGroup_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            UpdateLocations();
+        }
+
+        /// <summary>
+        /// Handles the user selecting an item of the ddlLocation control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ddlLocation_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            UpdateSchedules();
+        }
+
+        /// <summary>
+        /// Handles the user selecting an item of the ddlSchedule control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ddlSchedule_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            BindAttendees();
+        }
+
+        /// <summary>
+        /// Handles the user changing the date in the dpAttendanceDate control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void dpAttendanceDate_TextChanged( object sender, EventArgs e )
+        {
+            BindAttendees();
+        }
+
+        /// <summary>
+        /// Handles the user changign the selected person in the ppAttendee control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ppAttendee_SelectPerson( object sender, EventArgs e )
+        {
+            nbAttended.Text = string.Empty;
+            nbInactivePerson.Visible = false;
+            btnSaveActivate.Visible = false;
+
+            if ( ppAttendee.PersonId != null )
+            {
+                var person = new PersonService( new RockContext() ).Get( ppAttendee.PersonId.Value );
+
+                if ( person != null && person.RecordStatusValue.Guid == Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_INACTIVE.AsGuid() )
+                {
+                    nbInactivePerson.Visible = true;
+                    btnSaveActivate.Visible = true;
+                }
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Entering attendance for a large group of people (for example a worship service) is slow and time consuming.

# Goal
_What will this pull request achieve and how will this fix the problem?_

A block which allows data to be entered as quickly as possible.

# Strategy
_How have you implemented your solution?_

New block. Configuration allows selection of the parent group whose immediate children will be available for selection. When you select a group any locations defined for that group will be available for selection (if only one then it is auto-selected). Once a location is selected then all schedules for that group/location will be available for selection (if only one then it is auto-selected). User can enter the date for the attendance to be recorded on.

At this point the user can begin to enter attendance quickly. After selecting a person they can click the Save button, at which point the attendance record is saved and the person picker is cleared and ready to search again.

If the selected person's record status is `Inactive` then a warning message shows up indicating they are inactive. Also a second Save button will appear titled `Activate & Save` which will re-activate the person and then record their attendance.

The block will show a running total of the current attendance for that "service" in the top right corner. If the `Show Current Attendees` checkbox is turned on then the list of attendees will be displayed (though this will slow down entry when you are talking about attendance for a few hundred or thousand individuals).

Save button has the standard `s` meta key (e.g. Shift-Alt-S) to activate from keyboard. The Activate & Save button has a meta key of `a` defined. The only time the user needs to touch the mouse is to select the person in the person picker (I'm going to look at making that respond to keyboard arrow events too in another PR).

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Your staff may not know what to do with all the extra time you will free up.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![screen shot 2017-07-13 at 4 26 32 pm](https://user-images.githubusercontent.com/1119863/28192416-e4eac2c8-67ea-11e7-9f5a-ab84f1d455c0.png)

![screen shot 2017-07-13 at 4 33 58 pm](https://user-images.githubusercontent.com/1119863/28192419-e84177e6-67ea-11e7-94b6-1031b2987bc4.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

Nothing specific. Not sure how often we document individual blocks. Might be worth a mention in the check-in guide or groups guide.