### PR TITLE
Updated the active users block to show hints at color dot meanings #2261

### DIFF
--- a/RockWeb/Blocks/Cms/ActiveUsers.ascx
+++ b/RockWeb/Blocks/Cms/ActiveUsers.ascx
@@ -10,6 +10,7 @@
         <script>
             Sys.Application.add_load(function () {
                 $('.active-user').tooltip({ 'html': 'true' });
+                $('.js-current-guests .badge').tooltip();
             });
         </script>
     </ContentTemplate>

--- a/RockWeb/Blocks/Cms/ActiveUsers.ascx.cs
+++ b/RockWeb/Blocks/Cms/ActiveUsers.ascx.cs
@@ -270,12 +270,12 @@ namespace RockWeb.Blocks.Cms
                             guestVisitorsStr = "Current Guests:";
                             if ( numRecentGuests > 0 )
                             {
-                                guestVisitorsStr += string.Format( " <span class=\"badge badge-success\">{0}</span>", numRecentGuests );
+                                guestVisitorsStr += string.Format( " <span class=\"badge badge-success\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"Users active in the past 5 minutes.\">{0}</span>", numRecentGuests );
                             }
 
                             if ( numInactiveGuests > 0 )
                             {
-                                guestVisitorsStr += string.Format( " <span class=\"badge badge-warning\">{0}</span>", numInactiveGuests );
+                                guestVisitorsStr += string.Format( " <span class=\"badge badge-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"Users active in the past 15 minutes.\">{0}</span>", numInactiveGuests );
                             }
                         }
                     }
@@ -284,7 +284,7 @@ namespace RockWeb.Blocks.Cms
                 if ( sbUsers.Length > 0 )
                 {
                     lUsers.Text = string.Format( @"<ul class='activeusers fa-ul'>{0}</ul>", sbUsers.ToString() );
-                    lUsers.Text += string.Format( @"<p class='margin-l-sm'>{0}</p>", guestVisitorsStr );
+                    lUsers.Text += string.Format( @"<p class='margin-l-sm js-current-guests'>{0}</p>", guestVisitorsStr );
                 }
                 else
                 {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

# Context
#2261

# Goal
Add tooltips with JS scoped to the active user block to not impact performance.

# Strategy
Add JS and hints to the badges

# Tests
N/A

# Possible Implications
N/A

# Screenshots

<img width="287" alt="screen shot 2017-07-18 at 3 31 46 pm" src="https://user-images.githubusercontent.com/374209/28342698-5f23094c-6bce-11e7-9b92-edab4a68082f.png">
(Replaced Guests with Users in this PR)

# Documentation
N/A
