### PR TITLE
New Lava filter to parse and spit out components of a URL.

### DIFF
--- a/Rock.Tests/Rock/Lava/RockFiltersTests.cs
+++ b/Rock.Tests/Rock/Lava/RockFiltersTests.cs
@@ -696,6 +696,8 @@ namespace Rock.Tests.Rock.Lava
 
         #endregion
 
+        #region DatesFromICal
+
         /// <summary>
         /// For use in Lava -- should return next occurrence for Rock's standard Saturday 4:30PM service datetime.
         /// </summary>
@@ -763,5 +765,140 @@ namespace Rock.Tests.Rock.Lava
             var output = RockFilters.DatesFromICal( iCalStringFirstSaturdayOfMonth, 13, "enddatetime" ).LastOrDefault();
             Assert.Equal( expected, output );
         }
+
+        #endregion
+
+        #region Url
+
+        private string _urlValidHttps = "https://www.rockrms.com/WorkflowEntry/35?PersonId=2";
+        private string _urlValidHttpsPort = "https://www.rockrms.com:443/WorkflowEntry/35?PersonId=2";
+        private string _urlValidHttpNonStdPort = "http://www.rockrms.com:8000/WorkflowEntry/35?PersonId=2";
+        private string _urlInvalid = "thequickbrownfoxjumpsoverthelazydog";
+
+        /// <summary>
+        /// Should extract the host name from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_Host()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "host" );
+            Assert.Equal( output, "www.rockrms.com" );
+        }
+
+        /// <summary>
+        /// Should extract the port number as an integer from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_Port()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "port" );
+            Assert.Equal( output, 443 );
+        }
+
+        /// <summary>
+        /// Should extract all the segments from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_Segments()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "segments" ) as string[];
+            Assert.NotNull( output );
+            Assert.Equal( output.Length, 3 );
+            Assert.Equal( output[0], "/" );
+            Assert.Equal( output[1], "WorkflowEntry/" );
+            Assert.Equal( output[2], "35" );
+        }
+
+        /// <summary>
+        /// Should extract the protocol/scheme from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_Scheme()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "scheme" );
+            Assert.Equal( output, "https" );
+        }
+
+        /// <summary>
+        /// Should extract the protocol/scheme from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_Protocol()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "protocol" );
+            Assert.Equal( output, "https" );
+        }
+
+        /// <summary>
+        /// Should extract the request path from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_LocalPath()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "localpath" );
+            Assert.Equal( output, "/WorkflowEntry/35" );
+        }
+
+        /// <summary>
+        /// Should extract the request path and the query string from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_PathAndQuery()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "pathandquery" );
+            Assert.Equal( output, "/WorkflowEntry/35?PersonId=2" );
+        }
+
+        /// <summary>
+        /// Should extract a single query parameter from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_QueryParameter()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "queryparameter", "PersonId" );
+            Assert.Equal( output, "2" );
+        }
+
+        /// <summary>
+        /// Should extract the full URL from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_Url()
+        {
+            var output = RockFilters.Url( _urlValidHttps, "url" );
+            Assert.Equal( output, _urlValidHttps );
+        }
+
+        /// <summary>
+        /// Should extract the full URL, trimming standard port numbers, from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_UrlStdPort()
+        {
+            var output = RockFilters.Url( _urlValidHttpsPort, "url" );
+            Assert.Equal( output, _urlValidHttpsPort.Replace( ":443", string.Empty ) );
+        }
+
+        /// <summary>
+        /// Should extract the full URL, including the non-standard port number, from the URL.
+        /// </summary>
+        [Fact]
+        public void Url_UrlNonStdPort()
+        {
+            var output = RockFilters.Url( _urlValidHttpNonStdPort, "url" );
+            Assert.Equal( output, _urlValidHttpNonStdPort );
+        }
+
+        /// <summary>
+        /// Should fail to extract the host from an invalid URL.
+        /// </summary>
+        [Fact]
+        public void Url_InvalidUrl()
+        {
+            var output = RockFilters.Url( _urlInvalid, "host" );
+            Assert.Equal( output, string.Empty );
+        }
+
+        #endregion
     }
 }

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -710,6 +710,68 @@ namespace Rock.Lava
             return input.Substring(start, length);
         }
 
+        /// <summary>
+        /// Parse the input string as a URL and then return a specific part of the URL.
+        /// </summary>
+        /// <param name="input">The string to be parsed as a URL.</param>
+        /// <param name="part">The part of the Uri object to retrieve.</param>
+        /// <param name="key">Extra parameter used by the QueryParameter key for which query parameter to retrieve.</param>
+        /// <returns>A string that identifies the part of the URL that was requested.</returns>
+        public static object Url( string input, string part, string key = null )
+        {
+            if ( string.IsNullOrEmpty( input ) || string.IsNullOrEmpty( part ) )
+            {
+                return input;
+            }
+
+            Uri uri;
+            if ( !Uri.TryCreate( input, UriKind.RelativeOrAbsolute, out uri ) )
+            {
+                return input;
+            }
+
+            switch ( part.ToUpper() )
+            {
+                case "HOST":
+                    return uri.Host;
+
+                case "PORT":
+                    return uri.Port;
+
+                case "SEGMENTS":
+                    return uri.Segments;
+
+                case "SCHEME":
+                case "PROTOCOL":
+                    return uri.Scheme;
+
+                case "LOCALPATH":
+                    return uri.LocalPath;
+
+                case "PATHANDQUERY":
+                    return uri.PathAndQuery;
+
+                case "QUERYPARAMETER":
+                    if ( key != null )
+                    {
+                        var parameters = HttpUtility.ParseQueryString( uri.Query );
+
+                        if ( parameters.AllKeys.Contains( key ) )
+                        {
+                            return parameters[key];
+                        }
+                    }
+
+                    return string.Empty;
+
+                case "URL":
+                    return uri.ToString();
+
+                default:
+                    return string.Empty;
+            }
+        }
+
         #endregion
 
         #region DateTime Filters

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -725,9 +725,9 @@ namespace Rock.Lava
             }
 
             Uri uri;
-            if ( !Uri.TryCreate( input, UriKind.RelativeOrAbsolute, out uri ) )
+            if ( !Uri.TryCreate( input, UriKind.Absolute, out uri ) )
             {
-                return input;
+                return string.Empty;
             }
 
             switch ( part.ToUpper() )


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Enhance the well being of our users. #2252 

# Goal
_What will this pull request achieve and how will this fix the problem?_

Make it easier for admins to be able to deal with URLs inside of Lava.

# Strategy
_How have you implemented your solution?_

New Lava filter that acts as a front-end to the Uri C# class.

# Tests

Unit-Test coming (just realized after putting this together that I don't have that yet). Will remove the `in progress` label when that is done.

Lava test and output below.

```
<p>
{% assign url = 'https://www.rockrms.com/WorkflowEntry/35?PersonId=2' %}
<strong>Testing URL {{ url }}<br /></strong>
host - {{ url | Url:'host' }}<br />
port - {{ url | Url:'port' }}<br />
segments - {{ url | Url:'segments' | ToJSON }}<br />
scheme - {{ url | Url:'scheme' }}<br />
protocol - {{ url | Url:'protocol' }}<br />
localpath - {{ url | Url:'localpath' }}<br />
pathandquery - {{ url | Url:'pathandquery' }}<br />
queryparameter no key - {{ url | Url:'queryparameter' }}<br />
queryparameter with key - {{ url | Url:'queryparameter','PersonId' }}<br />
url - {{ url | Url:'url' }}<br />
invalid_part - {{ url | Url:'invalid_part' }}<br />
</p>

<p>
{% assign url = 'https://www.rockrms.com:443/' %}
<strong>Testing URL {{ url }}<br /></strong>
url - {{ url | Url:'url' }}<br />
</p>

<p>
{% assign url = 'http://www.rockrms.com:8000/' %}
<strong>Testing URL {{ url }}<br /></strong>
url - {{ url | Url:'url' }}<br />
port - {{ url | Url:'port' }}<br />
</p>
```

```
Testing URL https://www.rockrms.com/WorkflowEntry/35?PersonId=2
host - www.rockrms.com
port - 443
segments - [ "/", "WorkflowEntry/", "35" ]
scheme - https
protocol - https
localpath - /WorkflowEntry/35
pathandquery - /WorkflowEntry/35?PersonId=2
queryparameter no key -
queryparameter with key - 2
url - https://www.rockrms.com/WorkflowEntry/35?PersonId=2
invalid_part -

Testing URL https://www.rockrms.com:443/
url - https://www.rockrms.com/

Testing URL http://www.rockrms.com:8000/
url - http://www.rockrms.com:8000/
port - 8000
```

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

Lava Filter documentation needs to be written. Hopefully the above test will give a starting point.