### PR TITLE
Update FundraisingProgress styles and add functionality for single participant progress

### DIFF
--- a/RockWeb/Blocks/Fundraising/FundraisingProgress.ascx
+++ b/RockWeb/Blocks/Fundraising/FundraisingProgress.ascx
@@ -4,6 +4,7 @@
     <ContentTemplate>
         <asp:Panel ID="pnlView" runat="server">
             <asp:HiddenField ID="hfGroupId" runat="server" />
+            <asp:HiddenField ID="hfGroupMemberId" runat="server" />
             <div class="panel panel-block">
                 <div class="panel-heading">
                     <h1 class="panel-title">
@@ -11,26 +12,25 @@
                         <asp:Literal ID="lTitle" runat="server" />
                     </h1>
                 </div>
-                <div class="panel-body">
-                    
-                    <div class="well">
-                        <div class="clearfix">
-                            <b>Total Individual Goals</b>
-                            <p class="pull-right"><strong>$<%=this.GroupContributionTotal%>/$<%=this.GroupIndividualFundraisingGoal%></strong></p>
-                        </div>
+                
+                <asp:Panel ID="pnlHeader" runat="server" class="bg-color padding-t-md padding-l-md padding-r-md padding-b-sm">
+                    <div class="clearfix">
+                        <b>Total Individual Goals</b>
+                        <p class="pull-right"><strong>$<%=this.GroupContributionTotal%>/$<%=this.GroupIndividualFundraisingGoal%></strong></p>
+                    </div>
 
-                         <div class="progress">
-                            <div class="progress-bar progress-bar-<%=this.ProgressCssClass %>" role="progressbar" aria-valuenow="<%=this.PercentComplete%>" aria-valuemin="0" aria-valuemax="100" style="width: <%=this.PercentComplete%>%;">
-                                <%=this.PercentComplete%>% Complete
-                            </div>
+                    <div class="progress">
+                        <div class="progress-bar progress-bar-<%=this.ProgressCssClass %>" role="progressbar" aria-valuenow="<%=this.PercentComplete%>" aria-valuemin="0" aria-valuemax="100" style="width: <%=this.PercentComplete%>%;">
+                            <%=this.PercentComplete%>% Complete
                         </div>
                     </div>
+                </asp:Panel>
                     
-
+                <ul class="list-group">
                     <asp:Repeater ID="rptFundingProgress" runat="server">
                         <ItemTemplate>
-                            <hr />
-                            <div class="row">
+                            <li class="list-group-item">
+                                <div class="row">
                                 <div class="col-md-12">
                                     <p class="pull-right">$<%#Eval("ContributionTotal") %>/$<%#Eval("IndividualFundraisingGoal") %></p>
 
@@ -45,11 +45,10 @@
                                         </div>
                                     </div>
                                 </div>
-                            </div>
+                            </li>
                         </ItemTemplate>
                     </asp:Repeater>
-
-                </div>
+                </ul>
             </div>
         </asp:Panel>
     </ContentTemplate>


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**SÍ**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Matching block styles a little more closely to other Rock blocks.

# Goal
_What will this pull request achieve and how will this fix the problem?_

1. Match block styles more closely with standard Rock styles.
2. Make the block hide itself when given a group that is _not_ a Fundraising Opportunity.
3. Make the block functional when viewing a single participant via `?GroupMemberId=123`

Items 2 and 3 allow for the block to be placed on the standard Group Detail and Group Member Detail pages and they only show up in the UI when viewing fundraising groups.

# Strategy
_How have you implemented your solution?_

Gave my cat a red bull and sat back and watched while she wrote the code for me.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

UI Before changes:

<img alt="2017-08-07 16_51_25-virtualbox" src="https://user-images.githubusercontent.com/1119863/29051179-9bdc1e56-7b95-11e7-8221-536513754487.png">

UI After changes:

<img alt="2017-08-07 16_52_48-virtualbox" src="https://user-images.githubusercontent.com/1119863/29051185-a4166e8c-7b95-11e7-9da2-b44ed7880d2c.png">

Group Member UI:

<img alt="2017-08-07 17_11_58-virtualbox" src="https://user-images.githubusercontent.com/1119863/29051188-a8874004-7b95-11e7-8053-4c1cb70cd308.png">

Yes, I have some freaking expensive fundraising opportunities on my dev box.

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a