### PR TITLE
Fixed #2374 Registration person note adds duplicate registered by

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -2644,16 +2644,20 @@ namespace RockWeb.Blocks.Event
                             var noteText = new StringBuilder();
                             noteText.AppendFormat( "Registered for {0}", RegistrationInstanceState.Name );
 
+                            string registrarFullName = string.Empty;
+
                             if ( registrar != null && registrar.Id != registrant.Id )
                             {
-                                noteText.AppendFormat( " by {0}", registrar.FullName );
+                                registrarFullName = string.Format( " by {0}", registrar.FullName );
                                 registrantNames.Add( registrant.FullName );
                             }
 
                             if ( registrar != null && ( RegistrationState.FirstName != registrar.NickName || RegistrationState.LastName != registrar.LastName ) )
                             {
-                                noteText.AppendFormat( " by {0}", RegistrationState.FirstName + " " + RegistrationState.LastName );
+                                registrarFullName = string.Format( " by {0}", RegistrationState.FirstName + " " + RegistrationState.LastName );
                             }
+
+                            noteText.Append( registrarFullName );
 
                             if ( noteText.Length > 0 )
                             {


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]
Yes

# Context

'Registered By' Name is appended Twice when cases are mismatched for the system registered user

![image](https://user-images.githubusercontent.com/10127187/29070008-e00ec9e6-7c5a-11e7-8f1a-889e44b35e56.png)



