### PR TITLE
Fixed #2377 - Attendance history filter options won't clear with "Clear Filter".

### DIFF
--- a/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AttendanceHistoryList.ascx.cs
@@ -223,7 +223,7 @@ namespace RockWeb.Blocks.Checkin
         protected void RFilter_ClearFilterClick( object sender, EventArgs e )
         {
             rFilter.DeleteUserPreferences();
-            BindGrid();
+            BindFilter();
         }
 
         #endregion


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]
Yes

# Context
Attendance history filter options won't clear with "Clear Filter".

# Strategy
BindFilter method was missing in the respective event.
