### PR TITLE
Fix Group Registration block to not count inactive or pending members when calculating capacity

### DIFF
--- a/RockWeb/Blocks/Groups/GroupRegistration.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupRegistration.ascx.cs
@@ -505,14 +505,18 @@ namespace RockWeb.Blocks.Groups
                     // If the group has a GroupCapacity, check how far we are from hitting that.
                     if ( _group.GroupCapacity.HasValue )
                     {
-                        openGroupSpots = _group.GroupCapacity.Value - _group.Members.Count();
+                        openGroupSpots = _group.GroupCapacity.Value - _group.Members
+                            .Where( m => m.GroupMemberStatus == GroupMemberStatus.Active )
+                            .Count();
                     }
 
                     // When someone registers for a group on the front-end website, they automatically get added with the group's default
                     // GroupTypeRole. If that role exists and has a MaxCount, check how far we are from hitting that.
                     if ( _defaultGroupRole != null && _defaultGroupRole.MaxCount.HasValue )
                     {
-                        openRoleSpots = _defaultGroupRole.MaxCount.Value - _group.Members.Where( m => m.GroupRoleId == _defaultGroupRole.Id ).Count();
+                        openRoleSpots = _defaultGroupRole.MaxCount.Value - _group.Members
+                            .Where( m => m.GroupRoleId == _defaultGroupRole.Id && m.GroupMemberStatus == GroupMemberStatus.Active )
+                            .Count();
                     }
 
                     // Between the group's GroupCapacity and DefaultGroupRole.MaxCount, grab the one we're closest to hitting, and how close we are to


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Issue #2402 

# Goal
_What will this pull request achieve and how will this fix the problem?_

Minor tweaks to the overcapacity rule checking. Still does not fully match the internal logic, but should be closer to what end-users would expect.

# Strategy
_How have you implemented your solution?_

Limit capacity checking to active members.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a