### PR TITLE
Generic UI builder controls (models Check-in Config)

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1397,6 +1397,10 @@
     <Compile Include="Web\UI\Controls\Pickers\DataViewsPicker.cs" />
     <Compile Include="Web\UI\Controls\Pickers\DatePartsPicker.cs" />
     <Compile Include="Web\UI\Controls\Pickers\LavaCommandsPicker.cs" />
+    <Compile Include="Web\UI\Controls\Resource Controls\ResourceArea.cs" />
+    <Compile Include="Web\UI\Controls\Resource Controls\ResourceAreaRow.cs" />
+    <Compile Include="Web\UI\Controls\Resource Controls\ResourceGroup.cs" />
+    <Compile Include="Web\UI\Controls\Resource Controls\ResourceGroupRow.cs" />
     <Compile Include="Web\UI\Controls\SSNBox.cs" />
     <Compile Include="Web\UI\RockHiddenFieldPageStatePersister.cs" />
     <Compile Include="Web\UI\Controls\Grid\LavaBoundField.cs" />

--- a/Rock/SystemGuid/DefinedValue.cs
+++ b/Rock/SystemGuid/DefinedValue.cs
@@ -201,6 +201,11 @@ namespace Rock.SystemGuid
         /// </summary>
         public const string GROUPTYPE_PURPOSE_CHECKIN_FILTER = "6BCED84C-69AD-4F5A-9197-5C0F9C02DD34";
 
+        /// <summary>
+        /// Group Type Purpose of Serving Area
+        /// </summary>
+        public const string GROUPTYPE_PURPOSE_SERVING_AREA = "36A554CE-7815-41B9-A435-93F3D52A2828";
+
         #endregion
 
         #region Location Types

--- a/Rock/SystemGuid/DefinedValue.cs
+++ b/Rock/SystemGuid/DefinedValue.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 //
-using System;
 
 namespace Rock.SystemGuid
 {
@@ -152,13 +151,13 @@ namespace Rock.SystemGuid
         /// <summary>
         /// The financial source of Kiosk
         /// </summary>
-        public const string FINANCIAL_SOURCE_TYPE_KIOSK	= "260EEA80-821A-4F79-973F-49DF79C955F7";
-        
+        public const string FINANCIAL_SOURCE_TYPE_KIOSK = "260EEA80-821A-4F79-973F-49DF79C955F7";
+
         /// <summary>
         /// The financial source of Mobile Application
         /// </summary>
-        public const string FINANCIAL_SOURCE_TYPE_MOBILE_APPLICATION	= "8ADCEC72-63FC-4F08-A4CC-72BCE470172C";
-        
+        public const string FINANCIAL_SOURCE_TYPE_MOBILE_APPLICATION = "8ADCEC72-63FC-4F08-A4CC-72BCE470172C";
+
         /// <summary>
         /// The financial source of On-site Collection
         /// </summary>
@@ -351,12 +350,12 @@ namespace Rock.SystemGuid
         #region Person Record Status Reason
 
         /// <summary>
-        /// Inactive record status reason of Deceased 
+        /// Inactive record status reason of Deceased
         /// </summary>
         public const string PERSON_RECORD_STATUS_REASON_DECEASED = "05D35BC4-5816-4210-965F-1BF44F35A16A";
 
         /// <summary>
-        /// Inactive record status reason of No Activity 
+        /// Inactive record status reason of No Activity
         /// </summary>
         public const string PERSON_RECORD_STATUS_REASON_NO_ACTIVITY = "64014FE6-943D-4ACF-8014-FED9F9169AE8";
 
@@ -458,7 +457,7 @@ namespace Rock.SystemGuid
         /// Flot Chart Style
         /// </summary>
         public const string CHART_STYLE_FLOT = "B45DA8E1-B9A6-46FD-9A2B-E8440D7D6AAC";
-        
+
         /// <summary>
         /// Rock Chart Style
         /// </summary>
@@ -476,6 +475,7 @@ namespace Rock.SystemGuid
         #endregion
 
         #region Benevolence
+
         /// <summary>
         /// Benevolence Pending
         /// </summary>
@@ -490,6 +490,7 @@ namespace Rock.SystemGuid
         /// Benevolence Denied
         /// </summary>
         public const string BENEVOLENCE_DENIED = "3720671E-DA48-405F-A6D5-5E2D47436F9A";
+
         #endregion
 
         #region Interactions
@@ -501,7 +502,7 @@ namespace Rock.SystemGuid
 
         /// <summary>
         /// Interaction Channel Type: UrlShortener
-        /// </summary>        
+        /// </summary>
         public const string INTERACTIONCHANNELTYPE_URLSHORTENER = "371066D5-C5F9-4783-88C8-D9AC8DC67468";
 
         /// <summary>
@@ -520,6 +521,5 @@ namespace Rock.SystemGuid
         public const string INTERACTIONCHANNELTYPE_WIFI_PRESENCE = "338CB800-C556-46CD-849D-8AE58FC7CB0E";
 
         #endregion
-
     }
 }

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceArea.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceArea.cs
@@ -15,9 +15,7 @@
 // </copyright>
 //
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Rock.Data;
@@ -41,7 +39,9 @@ namespace Rock.Web.UI.Controls
 
         private PlaceHolder _phGroupTypeAttributes;
 
-        private Grid _gCheckinLabels;
+        protected string _rowLabel;
+
+        //protected bool Enable
 
         /// <summary>
         /// Gets the group type unique identifier.
@@ -99,7 +99,7 @@ namespace Rock.Web.UI.Controls
 
             if ( Page.IsPostBack )
             {
-                HandleGridEvents();
+                //HandleGridEvents();
             }
         }
 
@@ -120,89 +120,6 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
-        /// Handles the grid events.
-        /// </summary>
-        private void HandleGridEvents()
-        {
-            // manually wireup the grid events since they don't seem to do it automatically
-            string eventTarget = Page.Request.Params["__EVENTTARGET"];
-            if ( eventTarget.StartsWith( _gCheckinLabels.UniqueID ) )
-            {
-                List<string> subTargetList = eventTarget.Replace( _gCheckinLabels.UniqueID, string.Empty ).Split( new char[] { '$' }, StringSplitOptions.RemoveEmptyEntries ).ToList();
-                EnsureChildControls();
-
-                string lblAddControlId = subTargetList.Last();
-                var lblAdd = _gCheckinLabels.Actions.FindControl( lblAddControlId );
-                if ( lblAdd != null )
-                {
-                    AddCheckinLabel_Click( this, new EventArgs() );
-                }
-                else
-                {
-                    // rowIndex is determined by the numeric suffix of the control id after the Grid, subtract 2 (one for the header, and another to convert from 0 to 1 based index)
-                    int rowIndex = subTargetList.First().AsNumeric().AsInteger() - 2;
-                    RowEventArgs rowEventArgs = new RowEventArgs( rowIndex, this.CheckinLabels[rowIndex].AttributeKey );
-                    DeleteCheckinLabel_Click( this, rowEventArgs );
-                }
-            }
-        }
-
-        /// <summary>
-        /// special class for storing CheckinLabel attributes for the grid
-        /// </summary>
-        [Serializable]
-        public class CheckinLabelAttributeInfo
-        {
-            /// <summary>
-            /// Gets or sets the attribute key.
-            /// </summary>
-            /// <value>
-            /// The attribute key.
-            /// </value>
-            [DataMember]
-            public string AttributeKey { get; set; }
-
-            /// <summary>
-            /// Gets or sets the binary file unique identifier.
-            /// </summary>
-            /// <value>
-            /// The binary file unique identifier.
-            /// </value>
-            [DataMember]
-            public Guid BinaryFileGuid { get; set; }
-
-            /// <summary>
-            /// Gets or sets the name of the file.
-            /// </summary>
-            /// <value>
-            /// The name of the file.
-            /// </value>
-            [DataMember]
-            public string FileName { get; set; }
-        }
-
-        /// <summary>
-        /// Gets or sets the checkin labels.
-        /// Key is AttributeKey
-        /// Value is BinaryFileName
-        /// </summary>
-        /// <value>
-        /// The checkin labels.
-        /// </value>
-        public List<CheckinLabelAttributeInfo> CheckinLabels
-        {
-            get
-            {
-                return ViewState["CheckinLabels"] as List<CheckinLabelAttributeInfo>;
-            }
-
-            set
-            {
-                ViewState["CheckinLabels"] = value;
-            }
-        }
-
-        /// <summary>
         /// Gets the type of the checkin group.
         /// </summary>
         /// <param name="groupType">Type of the group.</param>
@@ -212,9 +129,10 @@ namespace Rock.Web.UI.Controls
 
             groupType.Name = _tbGroupTypeName.Text;
 
-            // ensure checkin areas get additional options
-            if ( groupType.GroupTypePurposeValue.Guid == Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() )
+            // ensure checkin area types get additional options
+            if ( groupType.GroupTypePurposeValue != null && groupType.GroupTypePurposeValue.Guid == Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() )
             {
+                _rowLabel = "Check-in Area Name";
                 groupType.InheritedGroupTypeId = _ddlGroupTypeInheritFrom.SelectedValueAsId();
                 groupType.AttendanceRule = _ddlAttendanceRule.SelectedValueAsEnum<AttendanceRule>();
                 groupType.AttendancePrintTo = _ddlPrintTo.SelectedValueAsEnum<PrintTo>();
@@ -240,8 +158,8 @@ namespace Rock.Web.UI.Controls
             {
                 GroupTypeGuid = groupType.Guid;
                 _tbGroupTypeName.Text = groupType.Name;
-
-                if ( groupType.GroupTypePurposeValue.Guid == Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() )
+                                                                                                  
+                if ( groupType.GroupTypePurposeValue != null && groupType.GroupTypePurposeValue.Guid == Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() )
                 {
                     _ddlGroupTypeInheritFrom.SetValue( groupType.InheritedGroupTypeId );
                     _ddlAttendanceRule.SetValue( (int)groupType.AttendanceRule );
@@ -250,20 +168,6 @@ namespace Rock.Web.UI.Controls
 
                 CreateGroupTypeAttributeControls( groupType, rockContext );
             }
-        }
-
-        /// <summary>
-        /// Gets the checkin label attribute keys.
-        /// </summary>
-        /// <param name="groupTypeAttribute">The group type attribute.</param>
-        /// <returns></returns>
-        public static Dictionary<string, Rock.Web.Cache.AttributeCache> GetCheckinLabelAttributes( Dictionary<string, Rock.Web.Cache.AttributeCache> groupTypeAttribute )
-        {
-            return groupTypeAttribute
-                .Where( a => a.Value.FieldType.Guid.Equals( new Guid( Rock.SystemGuid.FieldType.BINARY_FILE ) ) )
-                .Where( a => a.Value.QualifierValues.ContainsKey( "binaryFileType" ) )
-                .Where( a => a.Value.QualifierValues["binaryFileType"].Value.Equals( Rock.SystemGuid.BinaryFiletype.CHECKIN_LABEL, StringComparison.OrdinalIgnoreCase ) )
-                .ToDictionary( k => k.Key, v => v.Value );
         }
 
         /// <summary>
@@ -279,7 +183,7 @@ namespace Rock.Web.UI.Controls
 
             _tbGroupTypeName = new DataTextBox();
             _tbGroupTypeName.ID = this.ID + "_tbGroupTypeName";
-            _tbGroupTypeName.Label = "Check-in Area Name";
+            _tbGroupTypeName.Label = _rowLabel;
 
             // set label when they exit the edit field
             _tbGroupTypeName.Attributes["onblur"] = string.Format( "javascript: $('#{0}').text($(this).val());", _lblGroupTypeName.ClientID );
@@ -292,7 +196,7 @@ namespace Rock.Web.UI.Controls
 
             _ddlGroupTypeInheritFrom.Items.Add( Rock.Constants.None.ListItem );
             var groupTypeCheckinFilterList = new GroupTypeService( new RockContext() ).Queryable()
-                .Where( a => a.GroupTypePurposeValue.Guid == new Guid( Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_FILTER ) )
+                //.Where( a => a.GroupTypePurposeValue.Guid == new Guid( Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_FILTER ) )
                 .OrderBy( a => a.Order ).ThenBy( a => a.Name )
                 .Select( a => new { a.Id, a.Name } ).ToList();
 
@@ -324,42 +228,6 @@ namespace Rock.Web.UI.Controls
             Controls.Add( _ddlPrintTo );
             Controls.Add( _tbGroupTypeName );
             Controls.Add( _phGroupTypeAttributes );
-
-            // Check-in Labels grid
-            CreateCheckinLabelsGrid();
-        }
-
-        /// <summary>
-        /// Creates the checkin labels grid.
-        /// </summary>
-        private void CreateCheckinLabelsGrid()
-        {
-            _gCheckinLabels = new Grid();
-
-            // make the ID static so we can handle Postbacks from the Add and Delete actions
-            _gCheckinLabels.ClientIDMode = System.Web.UI.ClientIDMode.Static;
-            _gCheckinLabels.ID = this.ClientID + "_gCheckinLabels";
-            _gCheckinLabels.CssClass = "margin-b-md";
-            _gCheckinLabels.DisplayType = GridDisplayType.Light;
-            _gCheckinLabels.ShowActionRow = true;
-            _gCheckinLabels.RowItemText = "Label";
-            _gCheckinLabels.Actions.ShowAdd = true;
-
-            //// Handle AddClick manually in OnLoad()
-            //// gCheckinLabels.Actions.AddClick += AddCheckinLabel_Click;
-
-            _gCheckinLabels.DataKeyNames = new string[] { "AttributeKey" };
-            _gCheckinLabels.Columns.Add( new BoundField { DataField = "BinaryFileId", Visible = false } );
-            _gCheckinLabels.Columns.Add( new BoundField { DataField = "FileName", HeaderText = "Name" } );
-
-            DeleteField deleteField = new DeleteField();
-
-            //// handle manually in OnLoad()
-            //// deleteField.Click += DeleteCheckinLabel_Click;
-
-            _gCheckinLabels.Columns.Add( deleteField );
-
-            Controls.Add( _gCheckinLabels );
         }
 
         /// <summary>
@@ -382,14 +250,6 @@ namespace Rock.Web.UI.Controls
                 _ddlPrintTo.RenderControl( writer );
 
                 _phGroupTypeAttributes.RenderControl( writer );
-
-                writer.WriteLine( "<h3>Check-in Labels</h3>" );
-                if ( this.CheckinLabels != null )
-                {
-                    _gCheckinLabels.DataSource = this.CheckinLabels;
-                    _gCheckinLabels.DataBind();
-                }
-                _gCheckinLabels.RenderControl( writer );
             }
         }
 
@@ -410,10 +270,6 @@ namespace Rock.Web.UI.Controls
                 {
                     groupType.LoadAttributes( rockContext );
                 }
-
-                // exclude checkin labels
-                List<string> checkinLabelAttributeNames = GetCheckinLabelAttributes( groupType.Attributes ).Select( a => a.Value.Name ).ToList();
-                Rock.Attribute.Helper.AddEditControls( groupType, _phGroupTypeAttributes, true, string.Empty, checkinLabelAttributeNames );
             }
         }
 
@@ -435,41 +291,5 @@ namespace Rock.Web.UI.Controls
                 }
             }
         }
-
-        /// <summary>
-        /// Handles the Click event of the DeleteCheckinLabel control.
-        /// </summary>
-        /// <param name="sender">The source of the event.</param>
-        /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
-        protected void DeleteCheckinLabel_Click( object sender, RowEventArgs e )
-        {
-            if ( DeleteCheckinLabelClick != null )
-            {
-                DeleteCheckinLabelClick( sender, e );
-            }
-        }
-
-        /// <summary>
-        /// Handles the Click event of the AddCheckinLabel control.
-        /// </summary>
-        /// <param name="sender">The source of the event.</param>
-        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        protected void AddCheckinLabel_Click( object sender, EventArgs e )
-        {
-            if ( AddCheckinLabelClick != null )
-            {
-                AddCheckinLabelClick( sender, e );
-            }
-        }
-
-        /// <summary>
-        /// Occurs when [delete checkin label click].
-        /// </summary>
-        public event EventHandler<RowEventArgs> DeleteCheckinLabelClick;
-
-        /// <summary>
-        /// Occurs when [add checkin label click].
-        /// </summary>
-        public event EventHandler AddCheckinLabelClick;
     }
 }

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceArea.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceArea.cs
@@ -330,35 +330,28 @@ namespace Rock.Web.UI.Controls
             _phGroupTypeAttributes = new PlaceHolder();
             _phGroupTypeAttributes.ID = this.ID + "_phGroupTypeAttributes";
 
-            if ( EnableCheckinOptions )
-            {
-                _ddlAttendanceRule = new RockDropDownList();
-                _ddlAttendanceRule.ID = this.ID + "_ddlAttendanceRule";
-                _ddlAttendanceRule.Label = "Check-in Rule";
-                _ddlAttendanceRule.Help = "The rule that check in should use when a person attempts to check in to a group of this type.  If 'None' is selected, user will not be added to group and is not required to belong to group.  If 'Add On Check In' is selected, user will be added to group if they don't already belong.  If 'Already Belongs' is selected, user must already be a member of the group or they will not be allowed to check in.";
-                _ddlAttendanceRule.BindToEnum<Rock.Model.AttendanceRule>();
-
-                _ddlPrintTo = new RockDropDownList();
-                _ddlPrintTo.ID = this.ID + "_ddlPrintTo";
-                _ddlPrintTo.Label = "Print To";
-                _ddlPrintTo.Help = "When printing check-in labels, should the device's printer or the location's printer be used?  Note: the device has a similar setting which takes precedence over this setting.";
-                _ddlPrintTo.Items.Add( new ListItem( "Device Printer", "1" ) );
-                _ddlPrintTo.Items.Add( new ListItem( "Location Printer", "2" ) );
-            }
+            _ddlAttendanceRule = new RockDropDownList();
+            _ddlAttendanceRule.ID = this.ID + "_ddlAttendanceRule";
+            _ddlAttendanceRule.Label = "Check-in Rule";
+            _ddlAttendanceRule.Help = "The rule that check in should use when a person attempts to check in to a group of this type.  If 'None' is selected, user will not be added to group and is not required to belong to group.  If 'Add On Check In' is selected, user will be added to group if they don't already belong.  If 'Already Belongs' is selected, user must already be a member of the group or they will not be allowed to check in.";
+            _ddlAttendanceRule.BindToEnum<Rock.Model.AttendanceRule>();
+            
+            _ddlPrintTo = new RockDropDownList();
+            _ddlPrintTo.ID = this.ID + "_ddlPrintTo";
+            _ddlPrintTo.Label = "Print To";
+            _ddlPrintTo.Help = "When printing check-in labels, should the device's printer or the location's printer be used?  Note: the device has a similar setting which takes precedence over this setting.";
+            _ddlPrintTo.Items.Add( new ListItem( "Device Printer", "1" ) );
+            _ddlPrintTo.Items.Add( new ListItem( "Location Printer", "2" ) );
 
             Controls.Add( _lblGroupTypeName );
             Controls.Add( _ddlGroupTypeInheritFrom );
+            Controls.Add( _ddlAttendanceRule );
+            Controls.Add( _ddlPrintTo );
             Controls.Add( _tbGroupTypeName );
             Controls.Add( _phGroupTypeAttributes );
 
-            if ( EnableCheckinOptions )
-            {
-                Controls.Add( _ddlAttendanceRule );
-                Controls.Add( _ddlPrintTo );
-
-                // Check-in Labels grid
-                CreateCheckinLabelsGrid();
-            }
+            // Check-in Labels grid
+            CreateCheckinLabelsGrid();
         }
 
         /// <summary>
@@ -446,7 +439,7 @@ namespace Rock.Web.UI.Controls
                     groupType.LoadAttributes( rockContext );
                 }
 
-                List<string> checkinLabelAttributeNames = null;
+                var checkinLabelAttributeNames = new List<string>();
                 if ( EnableCheckinOptions )
                 {
                     checkinLabelAttributeNames = GetCheckinLabelAttributes( groupType.Attributes ).Select( a => a.Value.Name ).ToList();

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceArea.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceArea.cs
@@ -1,0 +1,475 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock.Data;
+using Rock.Model;
+
+namespace Rock.Web.UI.Controls
+{
+    /// <summary>
+    /// Report Filter control
+    /// </summary>
+    [ToolboxData( "<{0}:ResourceArea runat=server></{0}:ResourceArea>" )]
+    public class ResourceArea : CompositeControl
+    {
+        private Label _lblGroupTypeName;
+
+        private DataTextBox _tbGroupTypeName;
+
+        private RockDropDownList _ddlGroupTypeInheritFrom;
+        private RockDropDownList _ddlAttendanceRule;
+        private RockDropDownList _ddlPrintTo;
+
+        private PlaceHolder _phGroupTypeAttributes;
+
+        private Grid _gCheckinLabels;
+
+        /// <summary>
+        /// Gets the group type unique identifier.
+        /// </summary>
+        /// <value>
+        /// The group type unique identifier.
+        /// </value>
+        public Guid GroupTypeGuid;
+
+        /// <summary>
+        /// Restores view-state information from a previous request that was saved with the <see cref="M:System.Web.UI.WebControls.WebControl.SaveViewState" /> method.
+        /// </summary>
+        /// <param name="savedState">An object that represents the control state to restore.</param>
+        protected override void LoadViewState( object savedState )
+        {
+            base.LoadViewState( savedState );
+
+            GroupTypeGuid = ViewState["GroupTypeGuid"] as Guid? ?? Guid.NewGuid();
+            using ( var rockContext = new RockContext() )
+            {
+                var groupType = new GroupTypeService( rockContext ).Get( GroupTypeGuid );
+                if ( groupType != null )
+                {
+                    groupType.InheritedGroupTypeId = ViewState["InheritedGroupTypeId"] as int?;
+                    CreateGroupTypeAttributeControls( groupType, rockContext );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the validation group.
+        /// </summary>
+        /// <value>
+        /// The validation group.
+        /// </value>
+        public string ValidationGroup
+        {
+            get
+            {
+                return ViewState["ValidationGroup"] as string;
+            }
+            set
+            {
+                ViewState["ValidationGroup"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            if ( Page.IsPostBack )
+            {
+                HandleGridEvents();
+            }
+        }
+
+        /// <summary>
+        /// Saves any state that was modified after the <see cref="M:System.Web.UI.WebControls.Style.TrackViewState" /> method was invoked.
+        /// </summary>
+        /// <returns>
+        /// An object that contains the current view state of the control; otherwise, if there is no view state associated with the control, null.
+        /// </returns>
+        protected override object SaveViewState()
+        {
+            EnsureChildControls();
+
+            ViewState["GroupTypeGuid"] = GroupTypeGuid;
+            ViewState["InheritedGroupTypeId"] = _ddlGroupTypeInheritFrom.SelectedValueAsId();
+
+            return base.SaveViewState();
+        }
+
+        /// <summary>
+        /// Handles the grid events.
+        /// </summary>
+        private void HandleGridEvents()
+        {
+            // manually wireup the grid events since they don't seem to do it automatically
+            string eventTarget = Page.Request.Params["__EVENTTARGET"];
+            if ( eventTarget.StartsWith( _gCheckinLabels.UniqueID ) )
+            {
+                List<string> subTargetList = eventTarget.Replace( _gCheckinLabels.UniqueID, string.Empty ).Split( new char[] { '$' }, StringSplitOptions.RemoveEmptyEntries ).ToList();
+                EnsureChildControls();
+
+                string lblAddControlId = subTargetList.Last();
+                var lblAdd = _gCheckinLabels.Actions.FindControl( lblAddControlId );
+                if ( lblAdd != null )
+                {
+                    AddCheckinLabel_Click( this, new EventArgs() );
+                }
+                else
+                {
+                    // rowIndex is determined by the numeric suffix of the control id after the Grid, subtract 2 (one for the header, and another to convert from 0 to 1 based index)
+                    int rowIndex = subTargetList.First().AsNumeric().AsInteger() - 2;
+                    RowEventArgs rowEventArgs = new RowEventArgs( rowIndex, this.CheckinLabels[rowIndex].AttributeKey );
+                    DeleteCheckinLabel_Click( this, rowEventArgs );
+                }
+            }
+        }
+
+        /// <summary>
+        /// special class for storing CheckinLabel attributes for the grid
+        /// </summary>
+        [Serializable]
+        public class CheckinLabelAttributeInfo
+        {
+            /// <summary>
+            /// Gets or sets the attribute key.
+            /// </summary>
+            /// <value>
+            /// The attribute key.
+            /// </value>
+            [DataMember]
+            public string AttributeKey { get; set; }
+
+            /// <summary>
+            /// Gets or sets the binary file unique identifier.
+            /// </summary>
+            /// <value>
+            /// The binary file unique identifier.
+            /// </value>
+            [DataMember]
+            public Guid BinaryFileGuid { get; set; }
+
+            /// <summary>
+            /// Gets or sets the name of the file.
+            /// </summary>
+            /// <value>
+            /// The name of the file.
+            /// </value>
+            [DataMember]
+            public string FileName { get; set; }
+        }
+
+        /// <summary>
+        /// Gets or sets the checkin labels.
+        /// Key is AttributeKey
+        /// Value is BinaryFileName
+        /// </summary>
+        /// <value>
+        /// The checkin labels.
+        /// </value>
+        public List<CheckinLabelAttributeInfo> CheckinLabels
+        {
+            get
+            {
+                return ViewState["CheckinLabels"] as List<CheckinLabelAttributeInfo>;
+            }
+
+            set
+            {
+                ViewState["CheckinLabels"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the type of the checkin group.
+        /// </summary>
+        /// <param name="groupType">Type of the group.</param>
+        public void GetGroupTypeValues( GroupType groupType )
+        {
+            EnsureChildControls();
+
+            groupType.Name = _tbGroupTypeName.Text;
+
+            // ensure checkin areas get additional options
+            if ( groupType.GroupTypePurposeValue.Guid == Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() )
+            {
+                groupType.InheritedGroupTypeId = _ddlGroupTypeInheritFrom.SelectedValueAsId();
+                groupType.AttendanceRule = _ddlAttendanceRule.SelectedValueAsEnum<AttendanceRule>();
+                groupType.AttendancePrintTo = _ddlPrintTo.SelectedValueAsEnum<PrintTo>();
+            }
+
+            // Reload Attributes
+            groupType.Attributes = null;
+            groupType.LoadAttributes();
+
+            Rock.Attribute.Helper.GetEditValues( _phGroupTypeAttributes, groupType );
+        }
+
+        /// <summary>
+        /// Sets the type of the group.
+        /// </summary>
+        /// <param name="groupType">Type of the group.</param>
+        /// <param name="rockContext">The rock context.</param>
+        public void SetGroupType( GroupType groupType, RockContext rockContext )
+        {
+            EnsureChildControls();
+
+            if ( groupType != null )
+            {
+                GroupTypeGuid = groupType.Guid;
+                _tbGroupTypeName.Text = groupType.Name;
+
+                if ( groupType.GroupTypePurposeValue.Guid == Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() )
+                {
+                    _ddlGroupTypeInheritFrom.SetValue( groupType.InheritedGroupTypeId );
+                    _ddlAttendanceRule.SetValue( (int)groupType.AttendanceRule );
+                    _ddlPrintTo.SetValue( (int)groupType.AttendancePrintTo );
+                }
+
+                CreateGroupTypeAttributeControls( groupType, rockContext );
+            }
+        }
+
+        /// <summary>
+        /// Gets the checkin label attribute keys.
+        /// </summary>
+        /// <param name="groupTypeAttribute">The group type attribute.</param>
+        /// <returns></returns>
+        public static Dictionary<string, Rock.Web.Cache.AttributeCache> GetCheckinLabelAttributes( Dictionary<string, Rock.Web.Cache.AttributeCache> groupTypeAttribute )
+        {
+            return groupTypeAttribute
+                .Where( a => a.Value.FieldType.Guid.Equals( new Guid( Rock.SystemGuid.FieldType.BINARY_FILE ) ) )
+                .Where( a => a.Value.QualifierValues.ContainsKey( "binaryFileType" ) )
+                .Where( a => a.Value.QualifierValues["binaryFileType"].Value.Equals( Rock.SystemGuid.BinaryFiletype.CHECKIN_LABEL, StringComparison.OrdinalIgnoreCase ) )
+                .ToDictionary( k => k.Key, v => v.Value );
+        }
+
+        /// <summary>
+        /// Called by the ASP.NET page framework to notify server controls that use composition-based implementation to create any child controls they contain in preparation for posting back or rendering.
+        /// </summary>
+        protected override void CreateChildControls()
+        {
+            Controls.Clear();
+
+            _lblGroupTypeName = new Label();
+            _lblGroupTypeName.ClientIDMode = ClientIDMode.Static;
+            _lblGroupTypeName.ID = this.ID + "_lblGroupTypeName";
+
+            _tbGroupTypeName = new DataTextBox();
+            _tbGroupTypeName.ID = this.ID + "_tbGroupTypeName";
+            _tbGroupTypeName.Label = "Check-in Area Name";
+
+            // set label when they exit the edit field
+            _tbGroupTypeName.Attributes["onblur"] = string.Format( "javascript: $('#{0}').text($(this).val());", _lblGroupTypeName.ClientID );
+            _tbGroupTypeName.SourceTypeName = "Rock.Model.GroupType, Rock";
+            _tbGroupTypeName.PropertyName = "Name";
+
+            _ddlGroupTypeInheritFrom = new RockDropDownList();
+            _ddlGroupTypeInheritFrom.ID = this.ID + "_ddlGroupTypeInheritFrom";
+            _ddlGroupTypeInheritFrom.Label = "Inherit from";
+
+            _ddlGroupTypeInheritFrom.Items.Add( Rock.Constants.None.ListItem );
+            var groupTypeCheckinFilterList = new GroupTypeService( new RockContext() ).Queryable()
+                .Where( a => a.GroupTypePurposeValue.Guid == new Guid( Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_FILTER ) )
+                .OrderBy( a => a.Order ).ThenBy( a => a.Name )
+                .Select( a => new { a.Id, a.Name } ).ToList();
+
+            foreach ( var groupType in groupTypeCheckinFilterList )
+            {
+                _ddlGroupTypeInheritFrom.Items.Add( new ListItem( groupType.Name, groupType.Id.ToString() ) );
+            }
+            _ddlGroupTypeInheritFrom.AutoPostBack = true;
+            _ddlGroupTypeInheritFrom.SelectedIndexChanged += _ddlGroupTypeInheritFrom_SelectedIndexChanged;
+            _ddlAttendanceRule = new RockDropDownList();
+            _ddlAttendanceRule.ID = this.ID + "_ddlAttendanceRule";
+            _ddlAttendanceRule.Label = "Check-in Rule";
+            _ddlAttendanceRule.Help = "The rule that check in should use when a person attempts to check in to a group of this type.  If 'None' is selected, user will not be added to group and is not required to belong to group.  If 'Add On Check In' is selected, user will be added to group if they don't already belong.  If 'Already Belongs' is selected, user must already be a member of the group or they will not be allowed to check in.";
+            _ddlAttendanceRule.BindToEnum<Rock.Model.AttendanceRule>();
+
+            _ddlPrintTo = new RockDropDownList();
+            _ddlPrintTo.ID = this.ID + "_ddlPrintTo";
+            _ddlPrintTo.Label = "Print To";
+            _ddlPrintTo.Help = "When printing check-in labels, should the device's printer or the location's printer be used?  Note: the device has a similar setting which takes precedence over this setting.";
+            _ddlPrintTo.Items.Add( new ListItem( "Device Printer", "1" ) );
+            _ddlPrintTo.Items.Add( new ListItem( "Location Printer", "2" ) );
+
+            _phGroupTypeAttributes = new PlaceHolder();
+            _phGroupTypeAttributes.ID = this.ID + "_phGroupTypeAttributes";
+
+            Controls.Add( _lblGroupTypeName );
+            Controls.Add( _ddlGroupTypeInheritFrom );
+            Controls.Add( _ddlAttendanceRule );
+            Controls.Add( _ddlPrintTo );
+            Controls.Add( _tbGroupTypeName );
+            Controls.Add( _phGroupTypeAttributes );
+
+            // Check-in Labels grid
+            CreateCheckinLabelsGrid();
+        }
+
+        /// <summary>
+        /// Creates the checkin labels grid.
+        /// </summary>
+        private void CreateCheckinLabelsGrid()
+        {
+            _gCheckinLabels = new Grid();
+
+            // make the ID static so we can handle Postbacks from the Add and Delete actions
+            _gCheckinLabels.ClientIDMode = System.Web.UI.ClientIDMode.Static;
+            _gCheckinLabels.ID = this.ClientID + "_gCheckinLabels";
+            _gCheckinLabels.CssClass = "margin-b-md";
+            _gCheckinLabels.DisplayType = GridDisplayType.Light;
+            _gCheckinLabels.ShowActionRow = true;
+            _gCheckinLabels.RowItemText = "Label";
+            _gCheckinLabels.Actions.ShowAdd = true;
+
+            //// Handle AddClick manually in OnLoad()
+            //// gCheckinLabels.Actions.AddClick += AddCheckinLabel_Click;
+
+            _gCheckinLabels.DataKeyNames = new string[] { "AttributeKey" };
+            _gCheckinLabels.Columns.Add( new BoundField { DataField = "BinaryFileId", Visible = false } );
+            _gCheckinLabels.Columns.Add( new BoundField { DataField = "FileName", HeaderText = "Name" } );
+
+            DeleteField deleteField = new DeleteField();
+
+            //// handle manually in OnLoad()
+            //// deleteField.Click += DeleteCheckinLabel_Click;
+
+            _gCheckinLabels.Columns.Add( deleteField );
+
+            Controls.Add( _gCheckinLabels );
+        }
+
+        /// <summary>
+        /// Writes the <see cref="T:System.Web.UI.WebControls.CompositeControl" /> content to the specified <see cref="T:System.Web.UI.HtmlTextWriter" /> object, for display on the client.
+        /// </summary>
+        /// <param name="writer">An <see cref="T:System.Web.UI.HtmlTextWriter" /> that represents the output stream to render HTML content on the client.</param>
+        public override void RenderControl( HtmlTextWriter writer )
+        {
+            if ( this.Visible )
+            {
+                writer.AddAttribute( HtmlTextWriterAttribute.Style, "margin-top:0;" );
+                writer.RenderBeginTag( HtmlTextWriterTag.H3 );
+                _lblGroupTypeName.Text = _tbGroupTypeName.Text;
+                _lblGroupTypeName.RenderControl( writer );
+                writer.RenderEndTag();
+
+                _tbGroupTypeName.RenderControl( writer );
+                _ddlGroupTypeInheritFrom.RenderControl( writer );
+                _ddlAttendanceRule.RenderControl( writer );
+                _ddlPrintTo.RenderControl( writer );
+
+                _phGroupTypeAttributes.RenderControl( writer );
+
+                writer.WriteLine( "<h3>Check-in Labels</h3>" );
+                if ( this.CheckinLabels != null )
+                {
+                    _gCheckinLabels.DataSource = this.CheckinLabels;
+                    _gCheckinLabels.DataBind();
+                }
+                _gCheckinLabels.RenderControl( writer );
+            }
+        }
+
+        /// <summary>
+        /// Creates the group type attribute controls.
+        /// </summary>
+        /// <param name="groupType">Type of the group.</param>
+        /// <param name="rockContext">The rock context.</param>
+        public void CreateGroupTypeAttributeControls( GroupType groupType, RockContext rockContext )
+        {
+            EnsureChildControls();
+
+            _phGroupTypeAttributes.Controls.Clear();
+
+            if ( groupType != null )
+            {
+                if ( groupType.Attributes == null )
+                {
+                    groupType.LoadAttributes( rockContext );
+                }
+
+                // exclude checkin labels
+                List<string> checkinLabelAttributeNames = GetCheckinLabelAttributes( groupType.Attributes ).Select( a => a.Value.Name ).ToList();
+                Rock.Attribute.Helper.AddEditControls( groupType, _phGroupTypeAttributes, true, string.Empty, checkinLabelAttributeNames );
+            }
+        }
+
+        /// <summary>
+        /// Handles the SelectedIndexChanged event of the _ddlGroupTypeInheritFrom control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        private void _ddlGroupTypeInheritFrom_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            EnsureChildControls();
+            using ( var rockContext = new RockContext() )
+            {
+                var groupType = new GroupTypeService( rockContext ).Get( GroupTypeGuid );
+                if ( groupType != null )
+                {
+                    GetGroupTypeValues( groupType );
+                    CreateGroupTypeAttributeControls( groupType, rockContext );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the DeleteCheckinLabel control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
+        protected void DeleteCheckinLabel_Click( object sender, RowEventArgs e )
+        {
+            if ( DeleteCheckinLabelClick != null )
+            {
+                DeleteCheckinLabelClick( sender, e );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the AddCheckinLabel control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void AddCheckinLabel_Click( object sender, EventArgs e )
+        {
+            if ( AddCheckinLabelClick != null )
+            {
+                AddCheckinLabelClick( sender, e );
+            }
+        }
+
+        /// <summary>
+        /// Occurs when [delete checkin label click].
+        /// </summary>
+        public event EventHandler<RowEventArgs> DeleteCheckinLabelClick;
+
+        /// <summary>
+        /// Occurs when [add checkin label click].
+        /// </summary>
+        public event EventHandler AddCheckinLabelClick;
+    }
+}

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
@@ -279,7 +279,11 @@ $('.resource-area a.resource-area-add-group').click(function (event) {
 
             _lbAddArea?.RenderControl( writer );
             writer.Write( " " );
-            _lbAddGroup?.RenderControl( writer );
+
+            if ( _lbAddGroup != null )
+            {
+                _lbAddGroup.RenderControl( writer );
+            }
 
             writer.RenderEndTag();  // Div
             writer.RenderEndTag();  // Section

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
@@ -85,17 +85,77 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to enable adding areas.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable adding area]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableAddAreas
+        {
+            get
+            {
+                bool? b = ViewState["EnableAddAreas"] as bool?;
+                return ( b == null ) ? false : b.Value;
+            }
+
+            set
+            {
+                ViewState["EnableAddAreas"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable adding groups.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if enabled or not set; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableAddGroups
+        {
+            get
+            {
+                bool? b = ViewState["EnableAddGroups"] as bool?;
+                return ( b == null ) ? true : b.Value;
+            }
+
+            set
+            {
+                ViewState["EnableAddGroups"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable checkin options.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if enabled or not set; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableCheckinOptions
+        {
+            get
+            {
+                bool? b = ViewState["EnableCheckinOptions"] as bool?;
+                return ( b == null ) ? true : b.Value;
+            }
+
+            set
+            {
+                ViewState["EnableCheckinOptions"] = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="ResourceAreaRow"/> is expanded.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if expanded; otherwise, <c>false</c>.
+        ///   <c>true</c> if enabled or not set; otherwise, <c>false</c>.
         /// </value>
         public bool Expanded
         {
             get
             {
                 EnsureChildControls();
-                return _hfExpanded.Value.AsBooleanOrNull() ?? false;
+                return _hfExpanded.Value.AsBooleanOrNull() ?? true;
             }
 
             set
@@ -179,31 +239,38 @@ $('.resource-area a.resource-area-add-group').click(function (event) {
             _hfGroupTypeGuid = new HiddenField();
             _hfGroupTypeGuid.ID = this.ID + "_hfGroupTypeGuid";
 
+            Controls.Add( _hfGroupTypeGuid );
+
             _lblAreaRowName = new Label();
             _lblAreaRowName.ClientIDMode = ClientIDMode.Static;
             _lblAreaRowName.ID = this.ID + "_lblAreaRowName";
 
-            _lbAddArea = new LinkButton();
-            _lbAddArea.ID = this.ID + "_lblbAddArea";
-            _lbAddArea.CssClass = "btn btn-xs btn-default resource-area-add-area";
-            _lbAddArea.Click += lbAddArea_Click;
-            _lbAddArea.CausesValidation = false;
-            _lbAddArea.ToolTip = "Add New Area";
-            _lbAddArea.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-folder-open'></i>" } );
-
-            _lbAddGroup = new LinkButton();
-            _lbAddGroup.ID = this.ID + "_lbAddGroup";
-            _lbAddGroup.CssClass = "btn btn-xs btn-default resource-area-add-group";
-            _lbAddGroup.Click += lbAddGroup_Click;
-            _lbAddGroup.CausesValidation = false;
-            _lbAddGroup.ToolTip = "Add New Group";
-            _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
-
-            Controls.Add( _hfGroupTypeGuid );
             Controls.Add( _lblAreaRowName );
 
-            Controls.Add( _lbAddArea );
-            Controls.Add( _lbAddGroup );
+            if ( EnableAddAreas )
+            {
+                _lbAddArea = new LinkButton();
+                _lbAddArea.ID = this.ID + "_lblbAddArea";
+                _lbAddArea.CssClass = "btn btn-xs btn-default resource-area-add-area";
+                _lbAddArea.Click += lbAddArea_Click;
+                _lbAddArea.CausesValidation = false;
+                _lbAddArea.ToolTip = "Add New Area";
+                _lbAddArea.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-folder-open'></i>" } );
+                Controls.Add( _lbAddArea );
+            }
+
+            if ( EnableAddGroups )
+            {
+                _lbAddGroup = new LinkButton();
+                _lbAddGroup.ID = this.ID + "_lbAddGroup";
+                _lbAddGroup.CssClass = "btn btn-xs btn-default resource-area-add-group";
+                _lbAddGroup.Click += lbAddGroup_Click;
+                _lbAddGroup.CausesValidation = false;
+                _lbAddGroup.ToolTip = "Add New Group";
+                _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
+
+                Controls.Add( _lbAddGroup );
+            }
         }
 
         /// <summary>
@@ -230,9 +297,9 @@ $('.resource-area a.resource-area-add-group').click(function (event) {
             writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right resource-item-actions rollover-item" );
             writer.RenderBeginTag( HtmlTextWriterTag.Div );
 
-            _lbAddArea.RenderControl( writer );
+            _lbAddArea?.RenderControl( writer );
             writer.Write( " " );
-            _lbAddGroup.RenderControl( writer );
+            _lbAddGroup?.RenderControl( writer );
 
             writer.RenderEndTag();  // Div
             writer.RenderEndTag();  // Section

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
@@ -114,15 +114,8 @@ namespace Rock.Web.UI.Controls
             base.OnInit( e );
 
             string script = @"
-// checkin-area animation
-//$('section.checkin-area').click(function () {
-//    $(this).siblings('div').slideToggle();
-//    $expanded = $(this).children('input.area-expanded');
-//    $expanded.val($expanded.val() == 'True' ? 'False' : 'True');
-//});
-
 // fix so that the Remove button will fire its event, but not the parent event
-$('.checkin-area a.btn-danger').click(function (event) {
+$('.resource-area a.btn-danger').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
@@ -130,7 +123,7 @@ $('.checkin-area a.btn-danger').click(function (event) {
 });
 
 // fix so that the Reorder button will fire its event, but not the parent event
-$('.checkin-area a.checkin-area-reorder').click(function (event) {
+$('.resource-area a.resource-area-reorder').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
@@ -138,15 +131,15 @@ $('.checkin-area a.checkin-area-reorder').click(function (event) {
 });
 
 // fix so that the Add Sub-Area button will fire its event, but not the parent event
-$('.checkin-area a.checkin-area-add-area').click(function (event) {
+$('.resource-area a.resource-area-add-area').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
     }}
 });
 
-// fix so that the Ad Check-in Group button will fire its event, but not the parent event
-$('.checkin-area a.checkin-area-add-group').click(function (event) {
+// fix so that the Add Resource Group button will fire its event, but not the parent event
+$('.resource-area a.resource-area-add-group').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
@@ -192,7 +185,7 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
 
             _lbAddArea = new LinkButton();
             _lbAddArea.ID = this.ID + "_lblbAddArea";
-            _lbAddArea.CssClass = "btn btn-xs btn-default checkin-area-add-area";
+            _lbAddArea.CssClass = "btn btn-xs btn-default resource-area-add-area";
             _lbAddArea.Click += lbAddArea_Click;
             _lbAddArea.CausesValidation = false;
             _lbAddArea.ToolTip = "Add New Area";
@@ -200,7 +193,7 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
 
             _lbAddGroup = new LinkButton();
             _lbAddGroup.ID = this.ID + "_lbAddGroup";
-            _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-area-add-group";
+            _lbAddGroup.CssClass = "btn btn-xs btn-default resource-area-add-group";
             _lbAddGroup.Click += lbAddGroup_Click;
             _lbAddGroup.CausesValidation = false;
             _lbAddGroup.ToolTip = "Add New Group";
@@ -222,19 +215,19 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
             writer.AddAttribute( "data-key", _hfGroupTypeGuid.Value );
             writer.RenderBeginTag( HtmlTextWriterTag.Li );
 
-            writer.AddAttribute( HtmlTextWriterAttribute.Class, string.Format( "checkin-item{0} checkin-area rollover-container", Selected ? " checkin-item-selected" : "" ) );
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, string.Format( "resource-item{0} resource-area rollover-container", Selected ? " resource-item-selected" : "" ) );
             writer.AddAttribute( HtmlTextWriterAttribute.Id, this.ID + "_section" );
             writer.RenderBeginTag( "section" );
 
             // Hidden Field to track expansion
             _hfExpanded.RenderControl( writer );
 
-            writer.WriteLine( "<a class='checkin-area-reorder'><i class='fa fa-bars'></i></a>" );
-            writer.WriteLine( "<a class='checkin-area-expand'><i class='checkin-area-state fa fa-folder-open'></i></a>" );
+            writer.WriteLine( "<a class='resource-area-reorder'><i class='fa fa-bars'></i></a>" );
+            writer.WriteLine( "<a class='resource-area-expand'><i class='resource-area-state fa fa-folder-open'></i></a>" );
 
             _lblAreaRowName.RenderControl( writer );
 
-            writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right checkin-item-actions rollover-item" );
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right resource-item-actions rollover-item" );
             writer.RenderBeginTag( HtmlTextWriterTag.Div );
 
             _lbAddArea.RenderControl( writer );
@@ -254,7 +247,7 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
             var areaRows = this.Controls.OfType<ResourceAreaRow>();
             if ( areaRows.Any() )
             {
-                writer.AddAttribute( HtmlTextWriterAttribute.Class, "checkin-list js-checkin-area-list" );
+                writer.AddAttribute( HtmlTextWriterAttribute.Class, "resource-list js-resource-area-list" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Ul );
                 foreach ( var areaRow in areaRows )
                 {
@@ -267,7 +260,7 @@ $('.checkin-area a.checkin-area-add-group').click(function (event) {
             var groupRows = this.Controls.OfType<ResourceGroupRow>();
             if ( groupRows.Any() )
             {
-                writer.AddAttribute( HtmlTextWriterAttribute.Class, "checkin-list js-checkin-group-list" );
+                writer.AddAttribute( HtmlTextWriterAttribute.Class, "resource-list js-resource-group-list" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Ul );
                 foreach ( var groupRow in groupRows )
                 {

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
@@ -125,26 +125,6 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to enable checkin options.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if enabled or not set; otherwise, <c>false</c>.
-        /// </value>
-        public bool EnableCheckinOptions
-        {
-            get
-            {
-                bool? b = ViewState["EnableCheckinOptions"] as bool?;
-                return ( b == null ) ? true : b.Value;
-            }
-
-            set
-            {
-                ViewState["EnableCheckinOptions"] = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="ResourceAreaRow"/> is expanded.
         /// </summary>
         /// <value>

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceAreaRow.cs
@@ -1,0 +1,338 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock.Model;
+
+namespace Rock.Web.UI.Controls
+{
+    /// <summary>
+    /// Report Filter control
+    /// </summary>
+    [ToolboxData( "<{0}:ResourceAreaRow runat=server></{0}:ResourceAreaRow>" )]
+    public class ResourceAreaRow : CompositeControl
+    {
+        private HiddenFieldWithClass _hfExpanded;
+        private HiddenField _hfGroupTypeGuid;
+
+        private Label _lblAreaRowName;
+
+        private LinkButton _lbAddArea;
+        private LinkButton _lbAddGroup;
+
+        /// <summary>
+        /// Gets the group type unique identifier.
+        /// </summary>
+        /// <value>
+        /// The group type unique identifier.
+        /// </value>
+        public Guid GroupTypeGuid
+        {
+            get
+            {
+                return new Guid( _hfGroupTypeGuid.Value );
+            }
+        }
+
+        /// <summary>
+        /// Gets the parent row.
+        /// </summary>
+        /// <value>
+        /// The parent area row.
+        /// </value>
+        public ResourceAreaRow ParentRow
+        {
+            get
+            {
+                return this.Parent as ResourceAreaRow;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is selected.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is selected; otherwise, <c>false</c>.
+        /// </value>
+        public bool Selected
+        {
+            get
+            {
+                bool? b = ViewState["Selected"] as bool?;
+                return ( b == null ) ? false : b.Value;
+            }
+
+            set
+            {
+                ViewState["Selected"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="ResourceAreaRow"/> is expanded.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if expanded; otherwise, <c>false</c>.
+        /// </value>
+        public bool Expanded
+        {
+            get
+            {
+                EnsureChildControls();
+                return _hfExpanded.Value.AsBooleanOrNull() ?? false;
+            }
+
+            set
+            {
+                EnsureChildControls();
+                _hfExpanded.Value = value.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            string script = @"
+// checkin-area animation
+//$('section.checkin-area').click(function () {
+//    $(this).siblings('div').slideToggle();
+//    $expanded = $(this).children('input.area-expanded');
+//    $expanded.val($expanded.val() == 'True' ? 'False' : 'True');
+//});
+
+// fix so that the Remove button will fire its event, but not the parent event
+$('.checkin-area a.btn-danger').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});
+
+// fix so that the Reorder button will fire its event, but not the parent event
+$('.checkin-area a.checkin-area-reorder').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});
+
+// fix so that the Add Sub-Area button will fire its event, but not the parent event
+$('.checkin-area a.checkin-area-add-area').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});
+
+// fix so that the Ad Check-in Group button will fire its event, but not the parent event
+$('.checkin-area a.checkin-area-add-group').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});";
+
+            ScriptManager.RegisterStartupScript( this.Page, this.Page.GetType(), "ResourceAreaRow", script, true );
+        }
+
+        /// <summary>
+        /// Sets the type of the group.
+        /// </summary>
+        /// <param name="groupType">Type of the group.</param>
+        public void SetGroupType( GroupType groupType )
+        {
+            EnsureChildControls();
+            if ( groupType != null )
+            {
+                _hfGroupTypeGuid.Value = groupType.Guid.ToString();
+                _lblAreaRowName.Text = groupType.Name;
+            }
+        }
+
+        /// <summary>
+        /// Called by the ASP.NET page framework to notify server controls that use composition-based implementation to create any child controls they contain in preparation for posting back or rendering.
+        /// </summary>
+        protected override void CreateChildControls()
+        {
+            Controls.Clear();
+
+            _hfExpanded = new HiddenFieldWithClass();
+            Controls.Add( _hfExpanded );
+            _hfExpanded.ID = this.ID + "_hfExpanded";
+            _hfExpanded.CssClass = "area-expanded";
+            _hfExpanded.Value = "False";
+
+            _hfGroupTypeGuid = new HiddenField();
+            _hfGroupTypeGuid.ID = this.ID + "_hfGroupTypeGuid";
+
+            _lblAreaRowName = new Label();
+            _lblAreaRowName.ClientIDMode = ClientIDMode.Static;
+            _lblAreaRowName.ID = this.ID + "_lblAreaRowName";
+
+            _lbAddArea = new LinkButton();
+            _lbAddArea.ID = this.ID + "_lblbAddArea";
+            _lbAddArea.CssClass = "btn btn-xs btn-default checkin-area-add-area";
+            _lbAddArea.Click += lbAddArea_Click;
+            _lbAddArea.CausesValidation = false;
+            _lbAddArea.ToolTip = "Add New Area";
+            _lbAddArea.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-folder-open'></i>" } );
+
+            _lbAddGroup = new LinkButton();
+            _lbAddGroup.ID = this.ID + "_lbAddGroup";
+            _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-area-add-group";
+            _lbAddGroup.Click += lbAddGroup_Click;
+            _lbAddGroup.CausesValidation = false;
+            _lbAddGroup.ToolTip = "Add New Group";
+            _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
+
+            Controls.Add( _hfGroupTypeGuid );
+            Controls.Add( _lblAreaRowName );
+
+            Controls.Add( _lbAddArea );
+            Controls.Add( _lbAddGroup );
+        }
+
+        /// <summary>
+        /// Writes the <see cref="T:System.Web.UI.WebControls.CompositeControl" /> content to the specified <see cref="T:System.Web.UI.HtmlTextWriter" /> object, for display on the client.
+        /// </summary>
+        /// <param name="writer">An <see cref="T:System.Web.UI.HtmlTextWriter" /> that represents the output stream to render HTML content on the client.</param>
+        public override void RenderControl( HtmlTextWriter writer )
+        {
+            writer.AddAttribute( "data-key", _hfGroupTypeGuid.Value );
+            writer.RenderBeginTag( HtmlTextWriterTag.Li );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, string.Format( "checkin-item{0} checkin-area rollover-container", Selected ? " checkin-item-selected" : "" ) );
+            writer.AddAttribute( HtmlTextWriterAttribute.Id, this.ID + "_section" );
+            writer.RenderBeginTag( "section" );
+
+            // Hidden Field to track expansion
+            _hfExpanded.RenderControl( writer );
+
+            writer.WriteLine( "<a class='checkin-area-reorder'><i class='fa fa-bars'></i></a>" );
+            writer.WriteLine( "<a class='checkin-area-expand'><i class='checkin-area-state fa fa-folder-open'></i></a>" );
+
+            _lblAreaRowName.RenderControl( writer );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right checkin-item-actions rollover-item" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            _lbAddArea.RenderControl( writer );
+            writer.Write( " " );
+            _lbAddGroup.RenderControl( writer );
+
+            writer.RenderEndTag();  // Div
+            writer.RenderEndTag();  // Section
+
+            if ( !Expanded )
+            {
+                writer.AddStyleAttribute( "display", "none" );
+            }
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            // Render child area rows
+            var areaRows = this.Controls.OfType<ResourceAreaRow>();
+            if ( areaRows.Any() )
+            {
+                writer.AddAttribute( HtmlTextWriterAttribute.Class, "checkin-list js-checkin-area-list" );
+                writer.RenderBeginTag( HtmlTextWriterTag.Ul );
+                foreach ( var areaRow in areaRows )
+                {
+                    areaRow.RenderControl( writer );
+                }
+                writer.RenderEndTag();
+            }
+
+            // Render child group rows
+            var groupRows = this.Controls.OfType<ResourceGroupRow>();
+            if ( groupRows.Any() )
+            {
+                writer.AddAttribute( HtmlTextWriterAttribute.Class, "checkin-list js-checkin-group-list" );
+                writer.RenderBeginTag( HtmlTextWriterTag.Ul );
+                foreach ( var groupRow in groupRows )
+                {
+                    groupRow.RenderControl( writer );
+                }
+                writer.RenderEndTag();
+            }
+
+            writer.RenderEndTag();  // Div
+
+            writer.RenderEndTag();  // Li
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbAddArea control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbAddArea_Click( object sender, EventArgs e )
+        {
+            if ( AddAreaClick != null )
+            {
+                AddAreaClick( this, e );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbAddGroup control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbAddGroup_Click( object sender, EventArgs e )
+        {
+            if ( AddGroupClick != null )
+            {
+                AddGroupClick( this, e );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lblDeleteArea control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lblDeleteArea_Click( object sender, EventArgs e )
+        {
+            if ( DeleteAreaClick != null )
+            {
+                DeleteAreaClick( this, e );
+            }
+        }
+
+        /// <summary>
+        /// Occurs when [add area click].
+        /// </summary>
+        public event EventHandler AddAreaClick;
+
+        /// <summary>
+        /// Occurs when [add group click].
+        /// </summary>
+        public event EventHandler AddGroupClick;
+
+        /// <summary>
+        /// Occurs when [delete area click].
+        /// </summary>
+        public event EventHandler DeleteAreaClick;
+    }
+}

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
@@ -60,6 +60,26 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether [enable add locations].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable add locations] or not set; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableAddLocations
+        {
+            get
+            {
+                bool? b = ViewState["EnableAddLocations"] as bool?;
+                return ( b == null ) ? true : b.Value;
+            }
+
+            set
+            {
+                ViewState["EnableAddLocations"] = value;
+            }
+        }
+
+        /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
         /// </summary>
         /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
@@ -298,7 +318,7 @@ namespace Rock.Web.UI.Controls
         {
             _gLocations = new Grid();
 
-            _gLocations.ID = this.ID + "_gLocations";
+            _gLocations.ID = this.ID + "_gCheckinLabels";
 
             _gLocations.DisplayType = GridDisplayType.Light;
             _gLocations.ShowActionRow = true;
@@ -347,13 +367,17 @@ namespace Rock.Web.UI.Controls
                 _cbIsActive.RenderBaseControl( writer );
                 _phGroupAttributes.RenderControl( writer );
 
-                if ( this.Locations != null )
+                if ( EnableAddLocations )
                 {
                     writer.WriteLine( "<h3>Locations</h3>" );
-                    _gLocations.DataSource = this.Locations.OrderBy( l => l.Order ).ThenBy( l => l.FullNamePath ).ToList();
-                    _gLocations.DataBind();
+                    if ( this.Locations != null )
+                    {   
+                        _gLocations.DataSource = this.Locations.OrderBy( l => l.Order ).ThenBy( l => l.FullNamePath ).ToList();
+                        _gLocations.DataBind();
+                    }
+
+                    _gLocations.RenderControl( writer );
                 }
-                _gLocations.RenderControl( writer );
             }
         }
 

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
@@ -288,7 +288,7 @@ namespace Rock.Web.UI.Controls
             Controls.Add( _phGroupAttributes );
 
             // Locations Grid
-            //CreateLocationsGrid();
+            CreateLocationsGrid();
         }
 
         /// <summary>

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
@@ -459,20 +459,20 @@ namespace Rock.Web.UI.Controls
     }
 
     /// <summary>
-    /// An event args class used for reordering a check-in group's locations
+    /// An event args class used for reordering a resource group's locations
     /// </summary>
     public class ResourceGroupEventArg : EventArgs
     {
         /// <summary>
-        /// Gets or sets the check-in group unique identifier.
+        /// Gets or sets the resource group unique identifier.
         /// </summary>
         /// <value>
-        /// The check-in group's unique identifier.
+        /// The resource group's unique identifier.
         /// </value>
         public Guid GroupGuid { get; set; }
 
         /// <summary>
-        /// Gets or sets the check-in group location id.
+        /// Gets or sets the resource group location id.
         /// </summary>
         /// <value>
         /// The location id.

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
@@ -265,7 +265,7 @@ namespace Rock.Web.UI.Controls
 
             _tbGroupName = new DataTextBox();
             _tbGroupName.ID = this.ID + "_tbGroupName";
-            _tbGroupName.Label = "Check-in Group Name";
+            _tbGroupName.Label = "Group Name";
 
             _cbIsActive = new RockCheckBox();
             _cbIsActive.ID = this.ID + "_cbIsActive";
@@ -288,7 +288,7 @@ namespace Rock.Web.UI.Controls
             Controls.Add( _phGroupAttributes );
 
             // Locations Grid
-            CreateLocationsGrid();
+            //CreateLocationsGrid();
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Rock.Web.UI.Controls
         {
             _gLocations = new Grid();
 
-            _gLocations.ID = this.ID + "_gCheckinLabels";
+            _gLocations.ID = this.ID + "_gLocations";
 
             _gLocations.DisplayType = GridDisplayType.Light;
             _gLocations.ShowActionRow = true;
@@ -347,9 +347,9 @@ namespace Rock.Web.UI.Controls
                 _cbIsActive.RenderBaseControl( writer );
                 _phGroupAttributes.RenderControl( writer );
 
-                writer.WriteLine( "<h3>Locations</h3>" );
                 if ( this.Locations != null )
                 {
+                    writer.WriteLine( "<h3>Locations</h3>" );
                     _gLocations.DataSource = this.Locations.OrderBy( l => l.Order ).ThenBy( l => l.FullNamePath ).ToList();
                     _gLocations.DataBind();
                 }

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroup.cs
@@ -1,0 +1,498 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock.Data;
+using Rock.Model;
+
+namespace Rock.Web.UI.Controls
+{
+    /// <summary>
+    /// Report Filter control
+    /// </summary>
+    [ToolboxData( "<{0}:ResourceGroup runat=server></{0}:ResourceGroup>" )]
+    public class ResourceGroup : CompositeControl, IHasValidationGroup
+    {
+        private HiddenField _hfGroupGuid;
+        private HiddenField _hfGroupId;
+        private HiddenField _hfGroupTypeId;
+        private Literal _lblGroupName;
+
+        private DataTextBox _tbGroupName;
+        private RockCheckBox _cbIsActive;
+        private PlaceHolder _phGroupAttributes;
+        private Grid _gLocations;
+
+        /// <summary>
+        /// Gets or sets the validation group.
+        /// </summary>
+        /// <value>
+        /// The validation group.
+        /// </value>
+        public string ValidationGroup
+        {
+            get
+            {
+                return ViewState["ValidationGroup"] as string;
+            }
+            set
+            {
+                ViewState["ValidationGroup"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            if ( Page.IsPostBack )
+            {
+                HandleGridEvents();
+            }
+        }
+
+        /// <summary>
+        /// Handles the grid events.
+        /// </summary>
+        private void HandleGridEvents()
+        {
+            // manually wireup the grid events since they don't seem to do it automatically
+            string eventTarget = Page.Request.Params["__EVENTTARGET"];
+            if ( eventTarget.StartsWith( _gLocations.UniqueID ) )
+            {
+                List<string> subTargetList = eventTarget.Replace( _gLocations.UniqueID, string.Empty ).Split( new char[] { '$' }, StringSplitOptions.RemoveEmptyEntries ).ToList();
+                EnsureChildControls();
+
+                // make sure it's not a reorder event
+                if ( subTargetList.Count != 0 )
+                {
+                    string lblAddControlId = subTargetList.Where( n => n.EndsWith( "Add" ) ).LastOrDefault();
+                    if ( lblAddControlId != null )
+                    {
+                        AddLocation_Click( this, new EventArgs() );
+                    }
+                    else
+                    {
+                        // rowIndex is determined by the numeric suffix of the control id after the Grid, subtract 2 (one for the header, and another to convert from 0 to 1 based index)
+                        int rowIndex = subTargetList.First().AsNumeric().AsInteger() - 2;
+                        RowEventArgs rowEventArgs = new RowEventArgs( rowIndex, this.Locations.OrderBy( l => l.Order ).ThenBy( l => l.FullNamePath ).ToList()[rowIndex].LocationId );
+                        DeleteLocation_Click( this, rowEventArgs );
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Serializable]
+        public class LocationGridItem
+        {
+            /// <summary>
+            /// Gets or sets the location unique identifier.
+            /// </summary>
+            /// <value>
+            /// The location unique identifier.
+            /// </value>
+            [DataMember]
+            public int LocationId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the name.
+            /// </summary>
+            /// <value>
+            /// The name.
+            /// </value>
+            [DataMember]
+            public string Name { get; set; }
+
+            /// <summary>
+            /// Gets or sets the name in the format ParentLocation1 > ParentLocation0 > Name
+            /// </summary>
+            /// <value>
+            /// The full name path.
+            /// </value>
+            [DataMember]
+            public string FullNamePath { get; set; }
+
+            /// <summary>
+            /// Gets or sets the parent location identifier.
+            /// </summary>
+            /// <value>
+            /// The parent location identifier.
+            /// </value>
+            [DataMember]
+            public int? ParentLocationId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the order.
+            /// </summary>
+            /// <value>
+            /// The order.
+            /// </value>
+            [DataMember]
+            public int? Order { get; set; }
+        }
+
+        /// <summary>
+        /// Gets or sets the locations.
+        /// </summary>
+        /// <value>
+        /// The locations.
+        /// </value>
+        public List<LocationGridItem> Locations
+        {
+            get
+            {
+                return ViewState["Locations"] as List<LocationGridItem>;
+            }
+
+            set
+            {
+                ViewState["Locations"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the group unique identifier.
+        /// </summary>
+        /// <value>
+        /// The group unique identifier.
+        /// </value>
+        public Guid GroupGuid
+        {
+            get
+            {
+                EnsureChildControls();
+                return new Guid( _hfGroupGuid.Value );
+            }
+        }
+
+        /// <summary>
+        /// Gets the group type unique identifier.
+        /// </summary>
+        /// <value>
+        /// The group type unique identifier.
+        /// </value>
+        public int GroupTypeId
+        {
+            get
+            {
+                EnsureChildControls();
+                return _hfGroupTypeId.ValueAsInt();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the group.
+        /// </summary>
+        /// <param name="group">The group.</param>
+        /// <value>
+        /// The group.
+        /// </value>
+        public void GetGroupValues( Group group )
+        {
+            group.Name = _tbGroupName.Text;
+            group.IsActive = _cbIsActive.Checked;
+            Rock.Attribute.Helper.GetEditValues( _phGroupAttributes, group );
+        }
+
+        /// <summary>
+        /// Sets the group.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="rockContext">The rock context.</param>
+        public void SetGroup( Group value, RockContext rockContext )
+        {
+            EnsureChildControls();
+
+            //// NOTE:  A Group that was added will have an Id since it hasn't been saved to the database.
+            //// So, we'll use Guid to uniquely identify in this Control since that'll work in both Saved and Unsaved cases.
+            //// If it is saved, we do need the Id so that Attributes will work
+
+            if ( value != null )
+            {
+                _hfGroupGuid.Value = value.Guid.ToString();
+                _hfGroupId.Value = value.Id.ToString();
+                _hfGroupTypeId.Value = value.GroupTypeId.ToString();
+                _tbGroupName.Text = value.Name;
+                _cbIsActive.Checked = value.IsActive;
+
+                CreateGroupAttributeControls( value, rockContext );
+            }
+        }
+
+        /// <summary>
+        /// Called by the ASP.NET page framework to notify server controls that use composition-based implementation to create any child controls they contain in preparation for posting back or rendering.
+        /// </summary>
+        protected override void CreateChildControls()
+        {
+            Controls.Clear();
+
+            _hfGroupGuid = new HiddenField();
+            _hfGroupGuid.ID = this.ID + "_hfGroupGuid";
+
+            _hfGroupId = new HiddenField();
+            _hfGroupId.ID = this.ID + "_hfGroupId";
+
+            _hfGroupTypeId = new HiddenField();
+            _hfGroupTypeId.ID = this.ID + "_hfGroupTypeId";
+
+            _lblGroupName = new Literal();
+            _lblGroupName.ID = this.ID + "_lblGroupName";
+
+            _tbGroupName = new DataTextBox();
+            _tbGroupName.ID = this.ID + "_tbGroupName";
+            _tbGroupName.Label = "Check-in Group Name";
+
+            _cbIsActive = new RockCheckBox();
+            _cbIsActive.ID = this.ID + "_cbIsActive";
+            _cbIsActive.Text = "Active";
+
+            // set label when they exit the edit field
+            _tbGroupName.Attributes["onblur"] = string.Format( "javascript: $('#{0}').text($(this).val());", _lblGroupName.ID );
+            _tbGroupName.SourceTypeName = "Rock.Model.Group, Rock";
+            _tbGroupName.PropertyName = "Name";
+
+            _phGroupAttributes = new PlaceHolder();
+            _phGroupAttributes.ID = this.ID + "_phGroupAttributes";
+
+            Controls.Add( _hfGroupGuid );
+            Controls.Add( _hfGroupId );
+            Controls.Add( _hfGroupTypeId );
+            Controls.Add( _lblGroupName );
+            Controls.Add( _tbGroupName );
+            Controls.Add( _cbIsActive );
+            Controls.Add( _phGroupAttributes );
+
+            // Locations Grid
+            CreateLocationsGrid();
+        }
+
+        /// <summary>
+        /// Creates the locations grid.
+        /// </summary>
+        private void CreateLocationsGrid()
+        {
+            _gLocations = new Grid();
+
+            _gLocations.ID = this.ID + "_gCheckinLabels";
+
+            _gLocations.DisplayType = GridDisplayType.Light;
+            _gLocations.ShowActionRow = true;
+            _gLocations.RowItemText = "Location";
+            _gLocations.Actions.ShowAdd = true;
+
+            //// Handle AddClick manually in OnLoad()
+            _gLocations.Actions.AddClick += AddLocation_Click;
+            _gLocations.GridReorder += gLocations_Reorder;
+
+            var reorderField = new ReorderField();
+            _gLocations.Columns.Add( reorderField );
+            _gLocations.ShowHeader = false;
+            _gLocations.DataKeyNames = new string[] { "LocationId" };
+            _gLocations.Columns.Add( new BoundField { DataField = "FullNamePath", HeaderText = "Name" } );
+
+            DeleteField deleteField = new DeleteField();
+
+            //// handle manually in OnLoad()
+            deleteField.Click += DeleteLocation_Click;
+
+            _gLocations.Columns.Add( deleteField );
+
+            Controls.Add( _gLocations );
+        }
+
+        /// <summary>
+        /// Writes the <see cref="T:System.Web.UI.WebControls.CompositeControl" /> content to the specified <see cref="T:System.Web.UI.HtmlTextWriter" /> object, for display on the client.
+        /// </summary>
+        /// <param name="writer">An <see cref="T:System.Web.UI.HtmlTextWriter" /> that represents the output stream to render HTML content on the client.</param>
+        public override void RenderControl( HtmlTextWriter writer )
+        {
+            if ( this.Visible )
+            {
+                _hfGroupGuid.RenderControl( writer );
+                _hfGroupId.RenderControl( writer );
+                _hfGroupTypeId.RenderControl( writer );
+
+                writer.AddAttribute( HtmlTextWriterAttribute.Style, "margin-top:0;" );
+                writer.RenderBeginTag( HtmlTextWriterTag.H3 );
+                _lblGroupName.Text = _tbGroupName.Text;
+                _lblGroupName.RenderControl( writer );
+                writer.RenderEndTag();
+
+                _tbGroupName.RenderControl( writer );
+                _cbIsActive.RenderBaseControl( writer );
+                _phGroupAttributes.RenderControl( writer );
+
+                writer.WriteLine( "<h3>Locations</h3>" );
+                if ( this.Locations != null )
+                {
+                    _gLocations.DataSource = this.Locations.OrderBy( l => l.Order ).ThenBy( l => l.FullNamePath ).ToList();
+                    _gLocations.DataBind();
+                }
+                _gLocations.RenderControl( writer );
+            }
+        }
+
+        /// <summary>
+        /// Creates the group attribute controls.
+        /// </summary>
+        /// <param name="group">The group.</param>
+        /// <param name="rockContext">The rock context.</param>
+        public void CreateGroupAttributeControls( Group group, RockContext rockContext )
+        {
+            EnsureChildControls();
+
+            _phGroupAttributes.Controls.Clear();
+
+            if ( group != null )
+            {
+                if ( group.Attributes == null )
+                {
+                    group.LoadAttributes( rockContext );
+                }
+                Rock.Attribute.Helper.AddEditControls( group, _phGroupAttributes, true, this.ValidationGroup );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Reorder event of the gLocations control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="GridReorderEventArgs"/> instance containing the event data.</param>
+        protected void gLocations_Reorder( object sender, GridReorderEventArgs e )
+        {
+            if ( ReorderLocationClick != null )
+            {
+                var eventArg = new ResourceGroupEventArg( GroupGuid, e.DataKey, e.OldIndex, e.NewIndex );
+                ReorderLocationClick( this, eventArg );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the DeleteLocation control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
+        protected void DeleteLocation_Click( object sender, RowEventArgs e )
+        {
+            if ( DeleteLocationClick != null )
+            {
+                DeleteLocationClick( sender, e );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the AddLocation control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void AddLocation_Click( object sender, EventArgs e )
+        {
+            if ( AddLocationClick != null )
+            {
+                AddLocationClick( sender, e );
+            }
+        }
+
+        /// <summary>
+        /// Occurs when [reorder field click].
+        /// </summary>
+        public event EventHandler<ResourceGroupEventArg> ReorderLocationClick;
+
+        /// <summary>
+        /// Occurs when [delete location click].
+        /// </summary>
+        public event EventHandler<RowEventArgs> DeleteLocationClick;
+
+        /// <summary>
+        /// Occurs when [add location click].
+        /// </summary>
+        public event EventHandler AddLocationClick;
+    }
+
+    /// <summary>
+    /// An event args class used for reordering a check-in group's locations
+    /// </summary>
+    public class ResourceGroupEventArg : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the check-in group unique identifier.
+        /// </summary>
+        /// <value>
+        /// The check-in group's unique identifier.
+        /// </value>
+        public Guid GroupGuid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the check-in group location id.
+        /// </summary>
+        /// <value>
+        /// The location id.
+        /// </value>
+        public int LocationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the old index.
+        /// </summary>
+        /// <value>
+        /// The old index.
+        /// </value>
+        public int OldIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new index.
+        /// </summary>
+        /// <value>
+        /// The new index.
+        /// </value>
+        public int NewIndex { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceGroupEventArg"/> class.
+        /// </summary>
+        /// <param name="groupGuid">The resource group unique identifier.</param>
+        public ResourceGroupEventArg( Guid groupGuid )
+        {
+            GroupGuid = groupGuid;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceGroupEventArg"/> class.
+        /// </summary>
+        /// <param name="groupGuid">The resource group unique identifier.</param>
+        /// <param name="dataKey">The resource group location Id.</param>
+        /// <param name="oldIndex">The old index.</param>
+        /// <param name="newIndex">The new index.</param>
+        public ResourceGroupEventArg( Guid groupGuid, string dataKey, int oldIndex, int newIndex )
+        {
+            GroupGuid = groupGuid;
+            LocationId = dataKey.AsInteger();
+            OldIndex = oldIndex;
+            NewIndex = newIndex;
+        }
+    }
+}

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroupRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroupRow.cs
@@ -71,6 +71,26 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to enable adding groups.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if enabled or not set; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableAddGroups
+        {
+            get
+            {
+                bool? b = ViewState["EnableAddGroups"] as bool?;
+                return ( b == null ) ? true : b.Value;
+            }
+
+            set
+            {
+                ViewState["EnableAddGroups"] = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="ResourceGroupRow"/> is expanded.
         /// </summary>
         /// <value>
@@ -168,14 +188,17 @@ $('.resource-group a.resource-group-add-group').click(function (event) {
             _lblGroupRowName.ID = this.ID + "_lblGroupRowName";
             Controls.Add( _lblGroupRowName );
 
-            _lbAddGroup = new LinkButton();
-            _lbAddGroup.ID = this.ID + "_lbAddGroup";
-            _lbAddGroup.CssClass = "btn btn-xs btn-default resource-group-add-group";
-            _lbAddGroup.Click += lbAddGroup_Click;
-            _lbAddGroup.CausesValidation = false;
-            _lbAddGroup.ToolTip = "Add New Group";
-            _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
-            Controls.Add( _lbAddGroup );
+            if ( EnableAddGroups )
+            {
+                _lbAddGroup = new LinkButton();
+                _lbAddGroup.ID = this.ID + "_lbAddGroup";
+                _lbAddGroup.CssClass = "btn btn-xs btn-default resource-group-add-group";
+                _lbAddGroup.Click += lbAddGroup_Click;
+                _lbAddGroup.CausesValidation = false;
+                _lbAddGroup.ToolTip = "Add New Group";
+                _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
+                Controls.Add( _lbAddGroup );
+            }
         }
 
         /// <summary>

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroupRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroupRow.cs
@@ -1,0 +1,280 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock.Model;
+
+namespace Rock.Web.UI.Controls
+{
+    /// <summary>
+    /// Report Filter control
+    /// </summary>
+    [ToolboxData( "<{0}:ResourceGroupRow runat=server></{0}:ResourceGroupRow>" )]
+    public class ResourceGroupRow : CompositeControl
+    {
+        private Group _group;
+        private HiddenFieldWithClass _hfExpanded;
+        private HiddenField _hfGroupGuid;
+
+        private Label _lblGroupRowName;
+
+        private LinkButton _lbAddGroup;
+
+        /// <summary>
+        /// Gets the group type unique identifier.
+        /// </summary>
+        /// <value>
+        /// The group type unique identifier.
+        /// </value>
+        public Guid GroupGuid
+        {
+            get
+            {
+                return new Guid( _hfGroupGuid.Value );
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is selected.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is selected; otherwise, <c>false</c>.
+        /// </value>
+        public bool Selected
+        {
+            get
+            {
+                bool? b = ViewState["Selected"] as bool?;
+                return ( b == null ) ? false : b.Value;
+            }
+
+            set
+            {
+                ViewState["Selected"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="ResourceGroupRow"/> is expanded.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if expanded; otherwise, <c>false</c>.
+        /// </value>
+        public bool Expanded
+        {
+            get
+            {
+                EnsureChildControls();
+                return _hfExpanded.Value.AsBooleanOrNull() ?? false;
+            }
+
+            set
+            {
+                EnsureChildControls();
+                _hfExpanded.Value = value.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            string script = @"
+// group animation
+//$('section.checkin-group').click(function () {
+//    $(this).siblings('div').slideToggle();
+//    $expanded = $(this).children('input.group-expanded');
+//    $expanded.val($expanded.val() == 'True' ? 'False' : 'True');
+//});
+
+// fix so that the Remove button will fire its event, but not the parent event
+$('.checkin-group a.btn-danger').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});
+
+// fix so that the Edit Group button will fire its event, but not the parent event
+$('.checkin-group a.checkin-group-edit-group').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});
+
+// fix so that the Ad Check-in Group button will fire its event, but not the parent event
+$('.checkin-group a.checkin-group-add-group').click(function (event) {
+    event.stopImmediatePropagation();
+    if ( isDirty() ) {{
+        return false;
+    }}
+});";
+
+            ScriptManager.RegisterStartupScript( this.Page, this.Page.GetType(), "ResourceGroupRow", script, true );
+        }
+
+        /// <summary>
+        /// Sets the type of the group.
+        /// </summary>
+        /// <param name="group">Type of the group.</param>
+        public void SetGroup( Group group )
+        {
+            if ( group != null )
+            {
+                _group = group;
+                EnsureChildControls();
+                _hfGroupGuid.Value = group.Guid.ToString();
+                _lblGroupRowName.Text = group.Name;
+                if ( !group.IsActive )
+                {
+                    _lblGroupRowName.Text += " <small>(Inactive)</small>";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called by the ASP.NET page framework to notify server controls that use composition-based implementation to create any child controls they contain in preparation for posting back or rendering.
+        /// </summary>
+        protected override void CreateChildControls()
+        {
+            Controls.Clear();
+
+            _hfExpanded = new HiddenFieldWithClass();
+            Controls.Add( _hfExpanded );
+            _hfExpanded.ID = this.ID + "_hfExpanded";
+            _hfExpanded.CssClass = "group-expanded";
+            _hfExpanded.Value = "False";
+
+            _hfGroupGuid = new HiddenField();
+            _hfGroupGuid.ID = this.ID + "_hfGroupGuid";
+            Controls.Add( _hfGroupGuid );
+
+            _lblGroupRowName = new Label();
+            _lblGroupRowName.ClientIDMode = ClientIDMode.Static;
+            _lblGroupRowName.ID = this.ID + "_lblGroupRowName";
+            Controls.Add( _lblGroupRowName );
+
+            _lbAddGroup = new LinkButton();
+            _lbAddGroup.ID = this.ID + "_lbAddGroup";
+            _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-group-add-group";
+            _lbAddGroup.Click += lbAddGroup_Click;
+            _lbAddGroup.CausesValidation = false;
+            _lbAddGroup.ToolTip = "Add New Group";
+            _lbAddGroup.Controls.Add( new LiteralControl { Text = "<i class='fa fa-plus'></i> <i class='fa fa-check-circle'></i>" } );
+            Controls.Add( _lbAddGroup );
+        }
+
+        /// <summary>
+        /// Writes the <see cref="T:System.Web.UI.WebControls.CompositeControl" /> content to the specified <see cref="T:System.Web.UI.HtmlTextWriter" /> object, for display on the client.
+        /// </summary>
+        /// <param name="writer">An <see cref="T:System.Web.UI.HtmlTextWriter" /> that represents the output stream to render HTML content on the client.</param>
+        public override void RenderControl( HtmlTextWriter writer )
+        {
+            writer.AddAttribute( "data-key", _hfGroupGuid.Value );
+            writer.RenderBeginTag( HtmlTextWriterTag.Li );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, string.Format( "checkin-item{0} checkin-group rollover-container {1}", Selected ? " checkin-item-selected" : "", !_group.IsActive ? " is-inactive" : "" ) );
+            writer.AddAttribute( HtmlTextWriterAttribute.Id, this.ID + "_section" );
+            writer.RenderBeginTag( "section" );
+
+            // Hidden Field to track expansion
+            _hfExpanded.RenderControl( writer );
+
+            writer.WriteLine( "<a class='checkin-group-reorder'><i class='fa fa-bars'></i></a>" );
+            writer.WriteLine( "<a class='checkin-group-expand'><i class='checkin-group-state fa fa-check-circle'></i></a>" );
+
+            _lblGroupRowName.RenderControl( writer );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right checkin-item-actions rollover-item" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            if ( _lbAddGroup != null )
+            {
+                _lbAddGroup.RenderControl( writer );
+                writer.Write( " " );
+            }
+
+            writer.RenderEndTag();  // Div
+            writer.RenderEndTag();  // Section
+
+            if ( !Expanded )
+            {
+                writer.AddStyleAttribute( "display", "none" );
+            }
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            var groupRows = this.Controls.OfType<ResourceGroupRow>();
+            if ( groupRows.Any() )
+            {
+                writer.AddAttribute( HtmlTextWriterAttribute.Class, "checkin-list js-checkin-group-list" );
+                writer.RenderBeginTag( HtmlTextWriterTag.Ul );
+                foreach ( var groupRow in groupRows )
+                {
+                    groupRow.RenderControl( writer );
+                }
+                writer.RenderEndTag();
+            }
+
+            writer.RenderEndTag();  // Div
+
+            writer.RenderEndTag();  // Li
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbAddGroup control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbAddGroup_Click( object sender, EventArgs e )
+        {
+            if ( AddGroupClick != null )
+            {
+                AddGroupClick( this, e );
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lblDeleteGroup control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lblDeleteGroup_Click( object sender, EventArgs e )
+        {
+            if ( DeleteGroupClick != null )
+            {
+                DeleteGroupClick( this, e );
+            }
+        }
+
+        /// <summary>
+        /// Occurs when [add group click].
+        /// </summary>
+        public event EventHandler AddGroupClick;
+
+        /// <summary>
+        /// Occurs when [delete group click].
+        /// </summary>
+        public event EventHandler DeleteGroupClick;
+    }
+}

--- a/Rock/Web/UI/Controls/Resource Controls/ResourceGroupRow.cs
+++ b/Rock/Web/UI/Controls/Resource Controls/ResourceGroupRow.cs
@@ -100,15 +100,8 @@ namespace Rock.Web.UI.Controls
             base.OnInit( e );
 
             string script = @"
-// group animation
-//$('section.checkin-group').click(function () {
-//    $(this).siblings('div').slideToggle();
-//    $expanded = $(this).children('input.group-expanded');
-//    $expanded.val($expanded.val() == 'True' ? 'False' : 'True');
-//});
-
 // fix so that the Remove button will fire its event, but not the parent event
-$('.checkin-group a.btn-danger').click(function (event) {
+$('.resource-group a.btn-danger').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
@@ -116,15 +109,15 @@ $('.checkin-group a.btn-danger').click(function (event) {
 });
 
 // fix so that the Edit Group button will fire its event, but not the parent event
-$('.checkin-group a.checkin-group-edit-group').click(function (event) {
+$('.resource-group a.resource-group-edit-group').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
     }}
 });
 
-// fix so that the Ad Check-in Group button will fire its event, but not the parent event
-$('.checkin-group a.checkin-group-add-group').click(function (event) {
+// fix so that the Add Resource Group button will fire its event, but not the parent event
+$('.resource-group a.resource-group-add-group').click(function (event) {
     event.stopImmediatePropagation();
     if ( isDirty() ) {{
         return false;
@@ -177,7 +170,7 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
 
             _lbAddGroup = new LinkButton();
             _lbAddGroup.ID = this.ID + "_lbAddGroup";
-            _lbAddGroup.CssClass = "btn btn-xs btn-default checkin-group-add-group";
+            _lbAddGroup.CssClass = "btn btn-xs btn-default resource-group-add-group";
             _lbAddGroup.Click += lbAddGroup_Click;
             _lbAddGroup.CausesValidation = false;
             _lbAddGroup.ToolTip = "Add New Group";
@@ -194,19 +187,19 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
             writer.AddAttribute( "data-key", _hfGroupGuid.Value );
             writer.RenderBeginTag( HtmlTextWriterTag.Li );
 
-            writer.AddAttribute( HtmlTextWriterAttribute.Class, string.Format( "checkin-item{0} checkin-group rollover-container {1}", Selected ? " checkin-item-selected" : "", !_group.IsActive ? " is-inactive" : "" ) );
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, string.Format( "resource-item{0} resource-group rollover-container {1}", Selected ? " resource-item-selected" : "", !_group.IsActive ? " is-inactive" : "" ) );
             writer.AddAttribute( HtmlTextWriterAttribute.Id, this.ID + "_section" );
             writer.RenderBeginTag( "section" );
 
             // Hidden Field to track expansion
             _hfExpanded.RenderControl( writer );
 
-            writer.WriteLine( "<a class='checkin-group-reorder'><i class='fa fa-bars'></i></a>" );
-            writer.WriteLine( "<a class='checkin-group-expand'><i class='checkin-group-state fa fa-check-circle'></i></a>" );
+            writer.WriteLine( "<a class='resource-group-reorder'><i class='fa fa-bars'></i></a>" );
+            writer.WriteLine( "<a class='resource-group-expand'><i class='resource-group-state fa fa-check-circle'></i></a>" );
 
             _lblGroupRowName.RenderControl( writer );
 
-            writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right checkin-item-actions rollover-item" );
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "pull-right resource-item-actions rollover-item" );
             writer.RenderBeginTag( HtmlTextWriterTag.Div );
 
             if ( _lbAddGroup != null )
@@ -227,7 +220,7 @@ $('.checkin-group a.checkin-group-add-group').click(function (event) {
             var groupRows = this.Controls.OfType<ResourceGroupRow>();
             if ( groupRows.Any() )
             {
-                writer.AddAttribute( HtmlTextWriterAttribute.Class, "checkin-list js-checkin-group-list" );
+                writer.AddAttribute( HtmlTextWriterAttribute.Class, "resource-list js-resource-group-list" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Ul );
                 foreach ( var groupRow in groupRows )
                 {


### PR DESCRIPTION
# Context
_What is the problem you encountered that lead to you creating this pull request?_

While beefing up Event Registration capabilities (future separate PR coming), I liked the UX speed and usability of the Check-in Config areas and wanted to follow the same functional pattern.  However, since the user would be able to add more generic Event resources, I need to be able to hide Check-in specific items.   I also wanted to control if/when resources could be added.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Adds four new user controls that are a direct rip from Checkin Config:
- CheckinAreaRow -> ResourceAreaRow
- CheckinArea -> ResourceArea
- CheckinGroupRow -> ResourceGroupRow
- CheckinGroup -> ResourceGroup

Note: this functionality is not difficult to add directly to the CheckinXXX controls, but since it represents a usability shift I assumed it would be better to add completely new controls.

# Strategy
_How have you implemented your solution?_

I've copied the existing controls and renamed them (more generically) ResourceXXX, then added specific options for each control: 

ResourceArea.EnableCheckinOptions
- Will show or hide the `Check-in Labels` header and grid 
- Visible option in markup

ResourceAreaRow.EnableAddAreas
- Will enable or disable the Add button for new areas
- Not visible in markup, set from code-behind 

ResourceAreaRow.EnableAddGroups
- Will enable or disable the Add button for new groups
- Not visible in markup, set from code-behind 

ResourceAreaRow.btnDelete
- Visibility controlled from code-behind

ResourceGroup.EnableAddLocations
- Will show or hide the `Locations` header and grid
- Visible option in markup

ResourceGroupRow.EnableAddGroups
- Will enable or disable the Add button for new groups
- Not visible in markup, set from code-behind 

ResourceGroupRow.btnDelete
- Visibility controlled from code-behind

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

N/A, additional functionality.


# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

### Before:

![screen shot 2017-08-23 at 12 32 57 pm](https://user-images.githubusercontent.com/1210933/29629524-28058af2-8807-11e7-837d-5fcbb35fca4a.png)


![screen shot 2017-08-23 at 12 33 32 pm](https://user-images.githubusercontent.com/1210933/29629537-30c5811a-8807-11e7-9342-b88ddfd2b2f5.png)

### After:

![screen shot 2017-08-23 at 1 12 26 pm](https://user-images.githubusercontent.com/1210933/29629527-29d14844-8807-11e7-9304-5aa7b371687b.png)

![screen shot 2017-08-23 at 1 12 46 pm](https://user-images.githubusercontent.com/1210933/29629540-34a3797c-8807-11e7-8c07-c8bffd6c22f9.png)



# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

See above.