### PR TITLE
Fixed Required Field Validation for RockRating Control

### DIFF
--- a/Rock/Web/UI/Controls/RockRating.cs
+++ b/Rock/Web/UI/Controls/RockRating.cs
@@ -239,6 +239,16 @@ namespace Rock.Web.UI.Controls
             get { return ViewState["Max"] as int? ?? 5; }
             set { ViewState["Max"] = value; }
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RockRating" /> class.
+        /// </summary>
+        public RockRating()
+            : base()
+        {
+            RockControlHelper.Init( this );
+        }
+
         /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
         /// </summary>


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement]
Yes

# Context
Fixed Required Field Validation for RockRating Control

# Goal
 RockControlHelper.Init method was missing to be called inside RockRating due to which RequiredFieldValidator was never initialized  for the Rating control.