### PR TITLE
Campus Filter Only Search Button Fix

### DIFF
--- a/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
@@ -599,7 +599,7 @@ namespace RockWeb.Blocks.Groups
                     // Hide the search button and show the results immediately since there is 
                     // no filter criteria to be entered
                     phFilterControls.Visible = false;
-                    btnSearch.Visible = false;
+                    btnSearch.Visible = GetAttributeValue( "DisplayCampusFilter" ).AsBoolean();
                     pnlResults.Visible = true;
                 }
             }


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Campus filter could not be used without other filters being enabled in Group Finder.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Allow campus filter to be used by itself.

# Strategy
_How have you implemented your solution?_

If other filters aren't enabled in Group Finder check to see if campus filter is enabled before btnSearch visibility is set to false. 

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

No new methods or functions.

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Shouldn't affect anything else.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img width="858" alt="screen shot 2017-09-05 at 3 38 12 pm" src="https://user-images.githubusercontent.com/2990519/30084607-4ddb7586-9250-11e7-8bb3-9329c9849621.png">

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

No new documentation.