### PR TITLE
Added ability to link existing Content Channel Items to Calendar Events.

### DIFF
--- a/RockWeb/Blocks/Event/CalendarContentChannelItemList.ascx
+++ b/RockWeb/Blocks/Event/CalendarContentChannelItemList.ascx
@@ -16,6 +16,12 @@
                 <asp:PlaceHolder ID="phContentChannelGrids" runat="server" />
             </div>
 
+            <Rock:ModalDialog ID="mdlLinkExisting" runat="server" Title="Link Existing Content Channel Item" ValidationGroup="LinkExisting" OnSaveClick="mdlLinkExisting_SaveClick">
+                <Content>
+                    <Rock:RockDropDownList ID="ddlLinkExistingItems" runat="server" Label="Item" EnhanceForLongLists="true" ValidationGroup="LinkExisting" Required="true"></Rock:RockDropDownList>
+                </Content>
+            </Rock:ModalDialog>
+
         </asp:panel>
 
     </ContentTemplate>

--- a/RockWeb/Blocks/Event/CalendarContentChannelItemList.ascx.cs
+++ b/RockWeb/Blocks/Event/CalendarContentChannelItemList.ascx.cs
@@ -237,6 +237,104 @@ namespace RockWeb.Blocks.Event
             BindGrids();
         }
 
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbtnLinkExisting_Click( object sender, EventArgs e )
+        {
+            LinkButton lb = ( LinkButton ) sender;
+            int contentChannelId = lb.CommandArgument.AsInteger();
+
+            //
+            // Build a list of the existing Content Channel Items that are
+            // not expired yet and not currently linked to this even occurrence.
+            //
+            ddlLinkExistingItems.Items.Clear();
+            ddlLinkExistingItems.Items.Add( new ListItem() );
+            using ( var rockContext = new RockContext() )
+            {
+                var contentChannelItemService = new ContentChannelItemService( rockContext );
+                DateTime now = RockDateTime.Now;
+
+                var items = contentChannelItemService.Queryable()
+                    .Where( i => i.ContentChannelId == contentChannelId )
+                    .Where( i => !i.ExpireDateTime.HasValue || i.ExpireDateTime.Value >= now )
+                    .Where( i => !i.EventItemOccurrences.Any( o => o.EventItemOccurrenceId == OccurrenceId ) )
+                    .OrderBy( i => i.Title );
+
+                //
+                // Add each item to the list and format the name to be the
+                // title and, conditionally, the start and end date/times.
+                //
+                foreach ( var item in items )
+                {
+                    bool includeTime = item.ContentChannelType.IncludeTime;
+                    string title = item.Title;
+                    DateTime? startDate = null;
+                    DateTime? endDate = null;
+                    string startDateText = null;
+                    string endDateText = null;
+
+                    if ( item.ContentChannelType.DateRangeType == ContentChannelDateType.SingleDate )
+                    {
+                        startDate = item.StartDateTime;
+                    }
+                    else if ( item.ContentChannelType.DateRangeType == ContentChannelDateType.DateRange )
+                    {
+                        startDate = item.StartDateTime;
+                        endDate = item.ExpireDateTime;
+                    }
+
+                    if ( startDate.HasValue )
+                    {
+                        startDateText = includeTime ? startDate.Value.ToString() : startDate.Value.ToShortDateString();
+                    }
+                    if ( endDate.HasValue )
+                    {
+                        endDateText = includeTime ? endDate.Value.ToString() : endDate.Value.ToShortDateString();
+                    }
+
+                    if ( endDateText != null )
+                    {
+                        title += string.Format( " ({0} - {1})", startDateText, endDateText );
+                    }
+                    else if ( startDateText != null )
+                    {
+                        title += string.Format( " ({0})", startDateText );
+                    }
+
+                    ddlLinkExistingItems.Items.Add( new ListItem( title, item.Id.ToString() ) );
+                }
+            }
+
+            mdlLinkExisting.Show();
+        }
+
+        /// <summary>
+        /// Handles the SaveClick event of the control. Creates a new linkage between
+        /// this event occurrence and the selected content channel item.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void mdlLinkExisting_SaveClick( object sender, EventArgs e )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var occurrenceChannelItem = new EventItemOccurrenceChannelItem();
+
+                occurrenceChannelItem.ContentChannelItemId = ddlLinkExistingItems.SelectedValue.AsInteger();
+                occurrenceChannelItem.EventItemOccurrenceId = OccurrenceId.Value;
+                new EventItemOccurrenceChannelItemService( rockContext ).Add( occurrenceChannelItem );
+
+                rockContext.SaveChanges();
+            }
+
+            mdlLinkExisting.Hide();
+            BindGrids();
+        }
+
         #endregion
 
         #region Internal Methods
@@ -292,6 +390,21 @@ namespace RockWeb.Blocks.Event
                     gItems.Actions.AddClick += gItems_Add;
                     gItems.RowSelected += gItems_Edit;
                     gItems.GridRebind += gItems_GridRebind;
+
+                    //
+                    // Add the "Link Existing Item" button.
+                    //
+                    if ( OccurrenceId.HasValue )
+                    {
+                        var lbtnLinkExisting = new LinkButton();
+                        lbtnLinkExisting.Attributes.Add( "title", "Link Existing Item" );
+                        lbtnLinkExisting.CommandArgument = contentChannel.Id.ToString();
+                        lbtnLinkExisting.CssClass = "btn btn-default btn-sm";
+                        lbtnLinkExisting.Click += lbtnLinkExisting_Click;
+                        lbtnLinkExisting.Text = "<i class='fa fa-link'></i>";
+
+                        gItems.Actions.AddCustomActionControl( lbtnLinkExisting );
+                    }
 
                     gItems.Columns.Add( new RockBoundField
                     {

--- a/RockWeb/Blocks/Event/CalendarContentChannelItemList.ascx.cs
+++ b/RockWeb/Blocks/Event/CalendarContentChannelItemList.ascx.cs
@@ -272,28 +272,17 @@ namespace RockWeb.Blocks.Event
                 {
                     bool includeTime = item.ContentChannelType.IncludeTime;
                     string title = item.Title;
-                    DateTime? startDate = null;
-                    DateTime? endDate = null;
                     string startDateText = null;
                     string endDateText = null;
 
                     if ( item.ContentChannelType.DateRangeType == ContentChannelDateType.SingleDate )
                     {
-                        startDate = item.StartDateTime;
+                        startDateText = item.StartDateTime.ToShortDateString();
                     }
                     else if ( item.ContentChannelType.DateRangeType == ContentChannelDateType.DateRange )
                     {
-                        startDate = item.StartDateTime;
-                        endDate = item.ExpireDateTime;
-                    }
-
-                    if ( startDate.HasValue )
-                    {
-                        startDateText = includeTime ? startDate.Value.ToString() : startDate.Value.ToShortDateString();
-                    }
-                    if ( endDate.HasValue )
-                    {
-                        endDateText = includeTime ? endDate.Value.ToString() : endDate.Value.ToShortDateString();
+                        startDateText = item.StartDateTime.ToShortDateString();
+                        endDateText = item.ExpireDateTime.HasValue ? item.ExpireDateTime.Value.ToShortDateString() : null;
                     }
 
                     if ( endDateText != null )


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Darn Tootin' I Have**

# Context
_What is the problem you encountered that lead to you creating this pull request?_

Our staff keeps creating Content Channel Items to advertise an event before it's on the calendar. This currently requires us to use a convoluted URL to force an existing Content Channel Item to link to the calendar event occurrence.

# Goal
_What will this pull request achieve and how will this fix the problem?_

Technically this will work around the problem. The staff will still do things in the wrong order but now we can let them clean up after themselves instead of us cleaning up the mess.

# Strategy
_How have you implemented your solution?_

Magic. When creating a Content Channel Item Rock will now read the user's mind and determine if they intend to create a calendar event item sometime later. If so it will automatically do everything for them in the right order.

I wish.

When viewing the detail screen where the user can create a linked Content Channel Item they are now presented with a `fa fa-link` button that they can click. This will open a dialog in which they can pick an existing Content Channel Item.

The list of Content Channel Items will filter out any expired items or items that are already linked to this event occurrence. The list is sorted alphabetically, and will display the title of the Content Channel Item along with the start and end dates and times as properly configured on the content channel type. Meaning if the channel type is set to not include times, then times will not be displayed. If if it set to only have start dates then only start dates will be displayed. If it is set to have no dates then only the title is displayed.

> Note: The screenshot shows all midnight times, that is simply because the test data is set to include times but the dates generated in the database did not include times.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

No problemo.

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![image](https://user-images.githubusercontent.com/1119863/30232627-e2ce4c34-94a5-11e7-9219-4735fe55c736.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

Documentation is currently a bit vague on this particular process, it could use a refresh with more specific steps on creating new linkages or linking to existing.