### PR TITLE
Fix Group Finder Block map links to detail pages

### DIFF
--- a/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupFinder.ascx.cs
@@ -84,7 +84,7 @@ namespace RockWeb.Blocks.Groups
 </div>
 
 {% if LinkedPages.GroupDetailPage and LinkedPages.GroupDetailPage != '' %}
-    <a class='btn btn-xs btn-action margin-r-sm' href='|{{ LinkedPages.GroupDetailPage }}|?GroupId={{ Group.Id }}'>View {{ Group.GroupType.GroupTerm }}</a>
+    <a class='btn btn-xs btn-action margin-r-sm' href='{{ LinkedPages.GroupDetailPage }}?GroupId={{ Group.Id }}'>View {{ Group.GroupType.GroupTerm }}</a>
 {% endif %}
 
 {% if LinkedPages.RegisterPage and LinkedPages.RegisterPage != '' %}


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

# Context

Issue #2172

# Goal
Fix errant pipe default on new instances of block.

**A migration needs to be created for:**
Block GUID: `7332DD26-D5F5-4736-BFCF-FC4AD97DD571`
Attribute GUID: `9DA54BB6-986C-4723-8FE1-E3EF53119C6A`

Changing:
`{% if LinkedPages.GroupDetailPage != '' %}` to `{% if LinkedPages.GroupDetailPage and LinkedPages.GroupDetailPage != '' %}`
`{% if LinkedPages.RegisterPage != '' %}` to `{% if LinkedPages.RegisterPage and LinkedPages.RegisterPage != '' %}`

Fixing `and` formatting:
`{% if Location.FormattedHtmlAddress && Location.FormattedHtmlAddress != '' %}` to `{% if Location.FormattedHtmlAddress and Location.FormattedHtmlAddress != '' %}`

# Strategy
Remove pipes on block default

# Tests
N/A

# Possible Implications
N/A

# Screenshots
N/A

# Documentation
N/A
