### PR TITLE
+ Added Workflow Actions for setting a Property or Attribute of any Entity.

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1905,6 +1905,8 @@
     <Compile Include="Workflow\Action\Utility\InteractionAdd.cs" />
     <Compile Include="Workflow\Action\Utility\CreateShortLink.cs" />
     <Compile Include="Workflow\Action\Utility\LavaRun.cs" />
+    <Compile Include="Workflow\Action\Utility\SetEntityAttribute.cs" />
+    <Compile Include="Workflow\Action\Utility\SetEntityProperty.cs" />
     <Compile Include="Workflow\Action\WorkflowControl\Redirect.cs" />
     <Compile Include="Workflow\Action\Utility\RunJob.cs" />
     <Compile Include="Workflow\Action\Utility\RunSQL.cs" />

--- a/Rock/Workflow/Action/Utility/SetEntityAttribute.cs
+++ b/Rock/Workflow/Action/Utility/SetEntityAttribute.cs
@@ -1,0 +1,124 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Sets an entity attribute.
+    /// </summary>
+    [ActionCategory( "Utility" )]
+    [Description( "Sets an entity attribute." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Entity Attribute Set" )]
+
+    [EntityTypeField( "Entity Type", false, "The type of Entity.", true, "", 0, "EntityType" )]
+    [WorkflowTextOrAttribute( "Entity Id or Guid", "Entity Attribute", "The id or guid of the entity. <span class='tip tip-lava'></span>", true, "", "", 1, "EntityIdGuid" )]
+    [WorkflowTextOrAttribute( "Attribute Key", "Attribute Key Attribute", "The key of the attribute to set. <span class='tip tip-lava'></span>", true, "", "", 2, "AttributeKey" )]
+    [WorkflowTextOrAttribute( "Attribute Value", "Attribute Value Attribute", "The value to set. <span class='tip tip-lava'></span>", false, "", "", 3, "AttributeValue" )]
+    public class SetEntityAttribute : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            // Get the entity type
+            EntityTypeCache entityType = null;
+            var entityTypeGuid = GetAttributeValue( action, "EntityType" ).AsGuidOrNull();
+            if ( entityTypeGuid.HasValue )
+            {
+                entityType = EntityTypeCache.Read( entityTypeGuid.Value );
+            }
+            if ( entityType == null )
+            {
+                errorMessages.Add( string.Format( "Entity Type could not be found for selected value ('{0}')!", entityTypeGuid.ToString() ) );
+                return false;
+            }
+
+            var mergeFields = GetMergeFields( action );
+            RockContext _rockContext = new RockContext();
+
+            // Get the entity
+            EntityTypeService entityTypeService = new EntityTypeService( _rockContext );
+            IEntity entityObject = null;
+            string entityIdGuidString = GetAttributeValue( action, "EntityIdGuid", true ).ResolveMergeFields( mergeFields ).Trim();
+            var entityGuid = entityIdGuidString.AsGuidOrNull();
+            if ( entityGuid.HasValue )
+            {
+                entityObject = entityTypeService.GetEntity( entityType.Id, entityGuid.Value );
+            }
+            else
+            {
+                var entityId = entityIdGuidString.AsIntegerOrNull();
+                if ( entityId.HasValue )
+                {
+                    entityObject = entityTypeService.GetEntity( entityType.Id, entityId.Value );
+                }
+            }
+
+            if ( entityObject == null )
+            {
+                errorMessages.Add( string.Format( "Entity could not be found for selected value ('{0}')!", entityIdGuidString ) );
+                return false;
+            }
+
+            var entityWithAttributes = entityObject as IHasAttributes;
+            if ( entityWithAttributes == null )
+            {
+                errorMessages.Add( string.Format( "Entity does not support attributes ('{0}')!", entityIdGuidString ) );
+                return false;
+            }
+
+            // Get the property settings
+            string attributeKey = GetAttributeValue( action, "AttributeKey", true ).ResolveMergeFields( mergeFields );
+            string attributeValue = GetAttributeValue( action, "AttributeValue", true ).ResolveMergeFields( mergeFields );
+
+            entityWithAttributes.LoadAttributes(_rockContext);
+            entityWithAttributes.SetAttributeValue( attributeKey, attributeValue );
+
+            try
+            {
+                entityWithAttributes.SaveAttributeValue( attributeKey, _rockContext );
+            }
+            catch ( Exception ex )
+            {
+                errorMessages.Add( string.Format( "Could not save value ('{0}')! {1}", attributeValue, ex.Message ) );
+                return false;
+            }
+
+            action.AddLogEntry( string.Format( "Set '{0}' attribute to '{1}'.", attributeKey, attributeValue ) );
+
+            return true;
+        }
+    }
+}

--- a/Rock/Workflow/Action/Utility/SetEntityProperty.cs
+++ b/Rock/Workflow/Action/Utility/SetEntityProperty.cs
@@ -1,0 +1,181 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Reflection;
+
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action
+{
+    /// <summary>
+    /// Sets an entity property.
+    /// </summary>
+    [ActionCategory( "Utility" )]
+    [Description( "Sets an entity property." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Entity Property Set" )]
+
+    [EntityTypeField( "Entity Type", false, "The type of Entity.", true, "", 0, "EntityType" )]
+    [WorkflowTextOrAttribute( "Entity Id or Guid", "Entity Attribute", "The id or guid of the entity. <span class='tip tip-lava'></span>", true, "", "", 1, "EntityIdGuid" )]
+    [WorkflowTextOrAttribute( "Property Name", "Property Name Attribute", "The name of the property to set. <span class='tip tip-lava'></span>", true, "", "", 2, "PropertyName" )]
+    [WorkflowTextOrAttribute( "Property Value", "Property Value Attribute", "The value to set. <span class='tip tip-lava'></span>", false, "", "", 3, "PropertyValue" )]
+    [CustomDropdownListField( "Empty Value Handling", "How to handle empty property values.", "IGNORE^Ignore empty values,EMPTY^Set to empty,NULL^Set to NULL", true, "", "", 4, "EmptyValueHandling" )]
+    public class SetEntityProperty : ActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            // Get the entity type
+            EntityTypeCache entityType = null;
+            var entityTypeGuid = GetAttributeValue( action, "EntityType" ).AsGuidOrNull();
+            if ( entityTypeGuid.HasValue )
+            {
+                entityType = EntityTypeCache.Read( entityTypeGuid.Value );
+            }
+            if ( entityType == null )
+            {
+                errorMessages.Add( string.Format( "Entity Type could not be found for selected value ('{0}')!", entityTypeGuid.ToString() ) );
+                return false;
+            }
+
+            var mergeFields = GetMergeFields( action );
+            RockContext _rockContext = new RockContext();
+
+            // Get the entity
+            EntityTypeService entityTypeService = new EntityTypeService( _rockContext );
+            IEntity entityObject = null;
+            string entityIdGuidString = GetAttributeValue( action, "EntityIdGuid", true ).ResolveMergeFields( mergeFields ).Trim();
+            var entityGuid = entityIdGuidString.AsGuidOrNull();
+            if ( entityGuid.HasValue )
+            {
+                entityObject = entityTypeService.GetEntity( entityType.Id, entityGuid.Value );
+            }
+            else
+            {
+                var entityId = entityIdGuidString.AsIntegerOrNull();
+                if ( entityId.HasValue )
+                {
+                    entityObject = entityTypeService.GetEntity( entityType.Id, entityId.Value );
+                }
+            }
+
+            if ( entityObject == null )
+            {
+                errorMessages.Add( string.Format( "Entity could not be found for selected value ('{0}')!", entityIdGuidString ) );
+                return false;
+            }
+
+            // Get the property settings
+            string propertyName = GetAttributeValue( action, "PropertyName", true ).ResolveMergeFields( mergeFields );
+            string propertyValue = GetAttributeValue( action, "PropertyValue", true ).ResolveMergeFields( mergeFields );
+            string emptyValueHandling = GetAttributeValue( action, "EmptyValueHandling" );
+
+            if ( emptyValueHandling == "IGNORE" && String.IsNullOrWhiteSpace( propertyValue ) )
+            {
+                action.AddLogEntry( "Skipping empty value." );
+                return true;
+            }
+
+            PropertyInfo propInf = entityObject.GetType().GetProperty( propertyName, BindingFlags.Public | BindingFlags.Instance );
+
+            if ( propInf == null )
+            {
+                errorMessages.Add( string.Format( "Property does not exist ('{0}')!", propertyName ) );
+                return false;
+            }
+
+            if ( !propInf.CanWrite )
+            {
+                errorMessages.Add( string.Format( "Property is not writable ('{0}')!", entityIdGuidString ) );
+                return false;
+            }
+
+            try
+            {
+                propInf.SetValue( entityObject, ConvertObject( propertyValue, propInf.PropertyType, emptyValueHandling == "NULL" ), null );
+            }
+            catch ( Exception ex ) when ( ex is InvalidCastException || ex is FormatException || ex is OverflowException )
+            {
+                errorMessages.Add( string.Format( "Could not convert property value ('{0}')! {1}", propertyValue, ex.Message ) );
+                return false;
+            }
+
+            if ( !entityObject.IsValid )
+            {
+                errorMessages.Add( string.Format( "Invalid property value ('{0}')! {1}", propertyValue, entityObject.ValidationResults.Select( r => r.ErrorMessage ).ToList().AsDelimited( " " ) ) );
+                return false;
+            }
+
+            try
+            {
+                _rockContext.SaveChanges();
+            }
+            catch ( Exception ex )
+            {
+                errorMessages.Add( string.Format( "Could not save value ('{0}')! {1}", propertyValue, ex.Message ) );
+                return false;
+            }
+
+            action.AddLogEntry( string.Format( "Set '{0}' property to '{1}'.", propertyName, propertyValue ) );
+
+            return true;
+        }
+
+        /// <summary>
+        /// Converts a string to the specified type of object.
+        /// </summary>
+        /// <param name="theObject">The string to convert.</param>
+        /// <param name="objectType">The type of object desired.</param>
+        /// <param name="tryToNull">If empty strings should return as null.</param>
+        /// <returns></returns>
+        private static object ConvertObject( string theObject, Type objectType, bool tryToNull = true )
+        {
+            if ( objectType.IsEnum )
+            {
+                return string.IsNullOrWhiteSpace( theObject ) ? null : Enum.Parse( objectType, theObject, true );
+            }
+
+            Type underType = Nullable.GetUnderlyingType( objectType );
+            if ( underType == null ) // not nullable
+            {
+                return Convert.ChangeType( theObject, objectType );
+            }
+
+            if ( tryToNull && string.IsNullOrWhiteSpace( theObject ) )
+            {
+                return null;
+            }
+            return Convert.ChangeType( theObject, underType );
+        }
+    }
+}


### PR DESCRIPTION
# Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

👍 

# Context
_What is the problem you encountered that lead to you creating this pull request?_

As discussed in #2104, It would be great to have a way of setting attributes (and properties) on any entity inside a workflow. This would allow us to work with any entity we want, instead of being limited to the existing Actions or resorting to SQL 😨 to update things.

# Goal
_What will this pull request achieve and how will this fix the problem?_

This change adds two new Workflow Actions for setting a property or attribute value for any entity.

# Strategy
_How have you implemented your solution?_

I've added two new workflow actions - **Set Entity Property** and **Set Entity Attribute**

Both actions take an Entity Type, the Entity's Id or Guid, and the key and value of the attribute/property to set.

### Set Entity Property
This action sets a property on an entity. Property values are converted to their appropriate type and empty values are set depending on the `Empty Value Handling` option (Explanation here: https://github.com/SparkDevNetwork/Rock/issues/2104#issuecomment-328620103). Entity Framework and SQL Server ensure values are still valid (You can't change an Entity's Id for example).

### Set Entity Attribute
This action sets an attribute's value for an entity.

# Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

🤷‍♂️ 

# Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

🚫 

# Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

### Set Entity Property
![firefox_2017-09-13_14-22-22](https://user-images.githubusercontent.com/2406499/30393813-42b66a86-988f-11e7-942e-7718fc7d79f4.png)

### Set Entity Attribute
![firefox_2017-09-13_14-23-51](https://user-images.githubusercontent.com/2406499/30393827-4693637a-988f-11e7-90c9-af7ba98b2118.png)

# Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

📖

Both of these new actions will need documented with the other workflow actions (https://www.rockrms.com/WorkflowActions)

# Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

🚫 
