### PR TITLE
Change Login Block To Honour Locked & Unconfirmed External Accounts

### DIFF
--- a/RockWeb/Blocks/Security/Login.ascx.cs
+++ b/RockWeb/Blocks/Security/Login.ascx.cs
@@ -50,10 +50,10 @@ Thank you for logging in, however, we need to confirm the email associated with 
     [CodeEditorField( "Locked Out Caption", "The text (HTML) to display when a user's account has been locked.", CodeEditorMode.Html, CodeEditorTheme.Rock, 100, false, @"
 Sorry, your account has been locked.  Please contact our office at {{ 'Global' | Attribute:'OrganizationPhone' }} or email {{ 'Global' | Attribute:'OrganizationEmail' }} to resolve this.  Thank you. 
 ", "", 5 )]
-    [BooleanField("Hide New Account Option", "Should 'New Account' option be hidden?  For site's that require user to be in a role (Internal Rock Site for example), users shouldn't be able to create their own account.", false, "", 6, "HideNewAccount" )]
+    [BooleanField( "Hide New Account Option", "Should 'New Account' option be hidden?  For site's that require user to be in a role (Internal Rock Site for example), users shouldn't be able to create their own account.", false, "", 6, "HideNewAccount" )]
     [TextField( "New Account Text", "The text to show on the New Account button.", false, "Register", "", 7, "NewAccountButtonText" )]
-    [CodeEditorField("No Account Text", "The text to show when no account exists. <span class='tip tip-lava'></span>.", CodeEditorMode.Html, CodeEditorTheme.Rock, 100, false, @"Sorry, we couldn't find an account matching that username/password. Can we help you <a href='{{HelpPage}}'>recover your account information</a>?", "", 8, "NoAccountText")]
-    [RemoteAuthsField("Remote Authorization Types", "Which of the active remote authorization types should be displayed as an option for user to use for authentication.", false, "", "", 9)]
+    [CodeEditorField( "No Account Text", "The text to show when no account exists. <span class='tip tip-lava'></span>.", CodeEditorMode.Html, CodeEditorTheme.Rock, 100, false, @"Sorry, we couldn't find an account matching that username/password. Can we help you <a href='{{HelpPage}}'>recover your account information</a>?", "", 8, "NoAccountText" )]
+    [RemoteAuthsField( "Remote Authorization Types", "Which of the active remote authorization types should be displayed as an option for user to use for authentication.", false, "", "", 9 )]
     [CodeEditorField( "Prompt Message", "Optional text (HTML) to display above username and password fields.", CodeEditorMode.Html, CodeEditorTheme.Rock, 100, false, @"", "", 10 )]
     [LinkedPage( "Redirect Page", "Page to redirect user to upon successful login. The 'returnurl' query string will always override this setting for database authenticated logins. Redirect Page Setting will override third-party authentication 'returnurl'.", false, "", "", 11 )]
 
@@ -103,12 +103,12 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
                         {
                             if ( !string.IsNullOrWhiteSpace( redirectUrlSetting ) )
                             {
-                                LoginUser( userName, redirectUrlSetting, true );
+                                CheckConfirmationAndLockedOut( userName, redirectUrlSetting, true );
                                 break;
                             }
                             else
                             {
-                                LoginUser( userName, returnUrl, true );
+                                CheckConfirmationAndLockedOut( userName, returnUrl, true );
                                 break;
                             }
                         }
@@ -158,7 +158,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
             {
                 lPromptMessage.Text = GetAttributeValue( "PromptMessage" );
 
-                if ((bool?)Session["InvalidPersonToken" ] == true)
+                if ( ( bool? ) Session["InvalidPersonToken"] == true )
                 {
                     var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
                     lInvalidPersonTokenText.Text = GetAttributeValue( "InvalidPersonTokenText" ).ResolveMergeFields( mergeFields );
@@ -185,42 +185,17 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
             if ( Page.IsValid )
             {
                 var rockContext = new RockContext();
-                var userLoginService = new UserLoginService(rockContext);
+                var userLoginService = new UserLoginService( rockContext );
                 var userLogin = userLoginService.GetByUserName( tbUserName.Text );
-                if ( userLogin != null && userLogin.EntityType != null)
+                if ( userLogin != null && userLogin.EntityType != null )
                 {
-                    var component = AuthenticationContainer.GetComponent(userLogin.EntityType.Name);
-                    if (component != null && component.IsActive && !component.RequiresRemoteAuthentication)
+                    var component = AuthenticationContainer.GetComponent( userLogin.EntityType.Name );
+                    if ( component != null && component.IsActive && !component.RequiresRemoteAuthentication )
                     {
                         if ( component.Authenticate( userLogin, tbPassword.Text ) )
                         {
-                            if ( ( userLogin.IsConfirmed ?? true ) && !(userLogin.IsLockedOut ?? false ) )
-                            {
-                                string returnUrl = Request.QueryString["returnurl"];
-                                LoginUser( tbUserName.Text, returnUrl, cbRememberMe.Checked );
-                            }
-                            else
-                            {
-                                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
-
-                                if ( userLogin.IsLockedOut ?? false )
-                                {
-                                    lLockedOutCaption.Text = GetAttributeValue( "LockedOutCaption" ).ResolveMergeFields( mergeFields );
-
-                                    pnlLogin.Visible = false;
-                                    pnlLockedOut.Visible = true;
-                                }
-                                else
-                                {
-                                    SendConfirmation( userLogin );
-
-                                    lConfirmCaption.Text = GetAttributeValue( "ConfirmCaption" ).ResolveMergeFields( mergeFields );
-
-                                    pnlLogin.Visible = false;
-                                    pnlConfirmation.Visible = true;
-                                }
-                            }
-
+                            CheckConfirmationAndLockedOut( userLogin.UserName, Request.QueryString["returnurl"],
+                                cbRememberMe.Checked, userLoginService );
                             return;
                         }
                     }
@@ -229,18 +204,60 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
 
             string helpUrl = string.Empty;
 
-            if (!string.IsNullOrWhiteSpace(GetAttributeValue("HelpPage")))
+            if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "HelpPage" ) ) )
             {
-                helpUrl = LinkedPageUrl("HelpPage");
+                helpUrl = LinkedPageUrl( "HelpPage" );
             }
             else
             {
-                helpUrl = ResolveRockUrl("~/ForgotUserName");
+                helpUrl = ResolveRockUrl( "~/ForgotUserName" );
             }
 
-            var mergeFieldsNoAccount = Rock.Lava.LavaHelper.GetCommonMergeFields(this.RockPage, this.CurrentPerson);
-            mergeFieldsNoAccount.Add("HelpPage", helpUrl);
-            DisplayError( GetAttributeValue("NoAccountText").ResolveMergeFields(mergeFieldsNoAccount) );
+            var mergeFieldsNoAccount = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
+            mergeFieldsNoAccount.Add( "HelpPage", helpUrl );
+            DisplayError( GetAttributeValue( "NoAccountText" ).ResolveMergeFields( mergeFieldsNoAccount ) );
+        }
+
+        /// <summary>
+        /// Checks if a userLogin is locked out or needs confirmation, and handles those events
+        /// </summary>
+        /// <param name="userName">The username to use to lookup a login</param>
+        /// <param name="returnUrl">Where to redirect next</param>
+        /// <param name="rememberMe">True for external auth, the checkbox for internal auth</param>
+        /// <param name="userLoginService">The UserLoginService, should be null for external auth but we reuse a previous service for internal logins</param>
+        private void CheckConfirmationAndLockedOut( string userName, string returnUrl, bool rememberMe, UserLoginService userLoginService = null )
+        {
+            if ( userLoginService == null )
+            {
+                userLoginService = new UserLoginService( new RockContext() );
+            }
+
+            var userLogin = userLoginService.GetByUserName( userName );
+            if ( ( userLogin.IsConfirmed ?? true ) && !( userLogin.IsLockedOut ?? false ) )
+            {
+                LoginUser( userName, returnUrl, rememberMe );
+            }
+            else
+            {
+                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( RockPage, CurrentPerson );
+
+                if ( userLogin.IsLockedOut ?? false )
+                {
+                    lLockedOutCaption.Text = GetAttributeValue( "LockedOutCaption" ).ResolveMergeFields( mergeFields );
+
+                    pnlLogin.Visible = false;
+                    pnlLockedOut.Visible = true;
+                }
+                else
+                {
+                    SendConfirmation( userLogin );
+
+                    lConfirmCaption.Text = GetAttributeValue( "ConfirmCaption" ).ResolveMergeFields( mergeFields );
+
+                    pnlLogin.Visible = false;
+                    pnlConfirmation.Visible = true;
+                }
+            }
         }
 
         /// <summary>
@@ -254,12 +271,12 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
         {
             if ( sender is LinkButton )
             {
-                LinkButton lb = (LinkButton)sender;
+                LinkButton lb = ( LinkButton ) sender;
 
                 foreach ( var serviceEntry in AuthenticationContainer.Instance.Components )
                 {
                     var component = serviceEntry.Value.Value;
-                    if (component.IsActive && component.RequiresRemoteAuthentication)
+                    if ( component.IsActive && component.RequiresRemoteAuthentication )
                     {
                         string loginTypeName = component.GetType().Name;
                         if ( lb.ID == "lb" + loginTypeName + "Login" )
@@ -273,7 +290,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
                             }
                             else
                             {
-                                DisplayError( string.Format("ERROR: {0} does not have a remote login URL", loginTypeName ));
+                                DisplayError( string.Format( "ERROR: {0} does not have a remote login URL", loginTypeName ) );
                             }
                         }
                     }
@@ -293,7 +310,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
             if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "NewAccountPage" ) ) )
             {
                 var parms = new Dictionary<string, string>();
-                
+
                 if ( !string.IsNullOrWhiteSpace( returnUrl ) )
                 {
                     parms.Add( "returnurl", returnUrl );
@@ -308,7 +325,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
                 if ( !string.IsNullOrWhiteSpace( returnUrl ) )
                 {
                     url += "?returnurl=" + returnUrl;
-                } 
+                }
 
                 Response.Redirect( url, false );
                 Context.ApplicationInstance.CompleteRequest();
@@ -360,17 +377,17 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
 
             UserLoginService.UpdateLastLogin( userName );
 
-            Rock.Security.Authorization.SetAuthCookie( userName, rememberMe, false );
+            Authorization.SetAuthCookie( userName, rememberMe, false );
 
-            if (!string.IsNullOrWhiteSpace(returnUrl))
+            if ( !string.IsNullOrWhiteSpace( returnUrl ) )
             {
                 string redirectUrl = Server.UrlDecode( returnUrl );
                 Response.Redirect( redirectUrl );
                 Context.ApplicationInstance.CompleteRequest();
             }
-            else if (!string.IsNullOrWhiteSpace(redirectUrlSetting))
+            else if ( !string.IsNullOrWhiteSpace( redirectUrlSetting ) )
             {
-                Response.Redirect(redirectUrlSetting);
+                Response.Redirect( redirectUrlSetting );
                 Context.ApplicationInstance.CompleteRequest();
             }
             else
@@ -391,8 +408,8 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
                 url = ResolveRockUrl( "~/ConfirmAccount" );
             }
 
-            var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
-            mergeFields.Add( "ConfirmAccountUrl", RootPath + url.TrimStart( new char[] { '/' } ) );
+            var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( RockPage, CurrentPerson );
+            mergeFields.Add( "ConfirmAccountUrl", RootPath + url.TrimStart('/') );
             mergeFields.Add( "Person", userLogin.Person );
             mergeFields.Add( "User", userLogin );
 


### PR DESCRIPTION
# Context
Fixes #2115 

# Goal
Change the Login block to check for locked and unconfirmed external accounts

# Strategy
I took the logic for checking for confirmation/locked accounts from the login method from the internal login button event and moved it to a separate method which is called by both the `lbLogin` and the `btnLogin`. The method signature and naming for that method are a bit weird because I'm bad at naming and I wanted to preserve the `UserLoginService` if it was an internal auth.

# Tests
Not sure this is testable but if it is I'll happily write a test.

# Possible Implications
If someone has locked an external auth account previously there would've been no consequences. After this change, they'd be locked out.


# Documentation
🤷‍♂️ 
