### PR TITLE
Fixes #2412 Made Edit Properties Visible in Admin toolbar when User has Edit Role

### DIFF
--- a/Rock/Web/UI/RockPage.cs
+++ b/Rock/Web/UI/RockPage.cs
@@ -616,6 +616,7 @@ namespace Rock.Web.UI
             var stopwatchInitEvents = Stopwatch.StartNew();
             bool showDebugTimings = this.PageParameter( "ShowDebugTimings" ).AsBoolean();
             bool canAdministratePage = false;
+            bool canEditPage = false;
 
             if ( showDebugTimings )
             {
@@ -969,8 +970,9 @@ namespace Rock.Web.UI
 
                     Page.Trace.Warn( "Checking if user can administer" );
                     canAdministratePage = _pageCache.IsAuthorized( Authorization.ADMINISTRATE, CurrentPerson );
+                    canEditPage = _pageCache.IsAuthorized( Authorization.EDIT, CurrentPerson );
 
-                    if ( !canAdministratePage )
+                    if ( !canAdministratePage && !canEditPage )
                     {
                         // if the current user is impersonated by an Admin, then show the admin bar
                         var impersonatedByUser = Session["ImpersonatedByUser"] as UserLogin;
@@ -978,6 +980,7 @@ namespace Rock.Web.UI
                         if ( impersonatedByUser != null && currentUserIsImpersonated )
                         {
                             canAdministratePage = _pageCache.IsAuthorized( Authorization.ADMINISTRATE, impersonatedByUser.Person );
+                            canEditPage = _pageCache.IsAuthorized( Authorization.EDIT, impersonatedByUser.Person );
                         }
                     }
 
@@ -1203,7 +1206,7 @@ namespace Rock.Web.UI
                     }
 
                     // Add the page admin footer if the user is authorized to edit the page
-                    if ( _pageCache.IncludeAdminFooter && ( canAdministratePage || canAdministrateBlockOnPage ) )
+                    if ( _pageCache.IncludeAdminFooter && ( canAdministratePage || canAdministrateBlockOnPage || canEditPage ) )
                     {
                         // Add the page admin script
                         AddScriptLink( Page, "~/Scripts/Bundles/RockAdmin", false );
@@ -1222,7 +1225,7 @@ namespace Rock.Web.UI
                         var currentUserIsImpersonated = ( HttpContext.Current?.User?.Identity?.Name ?? string.Empty ).StartsWith( "rckipid=" );
                         if ( canAdministratePage && currentUserIsImpersonated && impersonatedByUser != null)
                         {
-                             HtmlGenericControl impersonatedByUserDiv = new HtmlGenericControl( "span" );
+                            HtmlGenericControl impersonatedByUserDiv = new HtmlGenericControl( "span" );
                             impersonatedByUserDiv.AddCssClass( "label label-default margin-l-md" );
                             _btnRestoreImpersonatedByUser = new LinkButton();
                             _btnRestoreImpersonatedByUser.ID = "_btnRestoreImpersonatedByUser";
@@ -1248,7 +1251,7 @@ namespace Rock.Web.UI
                         aBlockConfig.Controls.Add( iBlockConfig );
                         iBlockConfig.Attributes.Add( "class", "fa fa-th-large" );
 
-                        if ( canAdministratePage )
+                        if ( canEditPage || canAdministratePage)
                         {
                             // RockPage Properties
                             HtmlGenericControl aPageProperties = new HtmlGenericControl( "a" );
@@ -1262,7 +1265,10 @@ namespace Rock.Web.UI
                             HtmlGenericControl iPageProperties = new HtmlGenericControl( "i" );
                             aPageProperties.Controls.Add( iPageProperties );
                             iPageProperties.Attributes.Add( "class", "fa fa-cog" );
+                        }
 
+                        if ( canAdministratePage )
+                        {
                             // Child Pages
                             HtmlGenericControl aChildPages = new HtmlGenericControl( "a" );
                             buttonBar.Controls.Add( aChildPages );


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
Yes

## Context
Fixes #2412 Made Edit Properties Visible in Admin toolbar when User has Edit Role

## Strategy
Changed the dependency from Administrate to both Administrate as well as Edit at the time of displaying Edit Properties in Admin Bar.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.

N/A

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
