### PR TITLE
Fixes #2481 Display only active groups in Fundraising Matching

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionEntityMatching.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionEntityMatching.ascx.cs
@@ -144,7 +144,7 @@ namespace RockWeb.Blocks.Finance
                 if ( _transactionEntityType.Id == EntityTypeCache.GetId<GroupMember>() )
                 {
                     int? groupTypeId = entityTypeQualifierValue;
-                    List<Group> groupsWithMembersList = new GroupService( new RockContext() ).Queryable().Where( a => a.GroupTypeId == groupTypeId.Value && a.Members.Any() ).OrderBy( a => a.Order ).ThenBy( a => a.Name ).AsNoTracking().ToList();
+                    List<Group> groupsWithMembersList = new GroupService( new RockContext() ).Queryable().Where( a => a.GroupTypeId == groupTypeId.Value && a.Members.Any() && a.IsActive ).OrderBy( a => a.Order ).ThenBy( a => a.Name ).AsNoTracking().ToList();
 
                     foreach ( var ddlGroup in phTableRows.ControlsOfTypeRecursive<RockDropDownList>().Where( a => a.ID.StartsWith( "ddlGroup_" ) ) )
                     {
@@ -176,7 +176,7 @@ namespace RockWeb.Blocks.Finance
                 else if ( _transactionEntityType.Id == EntityTypeCache.GetId<Group>() )
                 {
                     int? groupTypeId = entityTypeQualifierValue;
-                    List<Group> groupList = new GroupService( new RockContext() ).Queryable().Where( a => a.GroupTypeId == groupTypeId.Value ).OrderBy( a => a.Order ).ThenBy( a => a.Name ).AsNoTracking().ToList();
+                    List<Group> groupList = new GroupService( new RockContext() ).Queryable().Where( a => a.GroupTypeId == groupTypeId.Value && a.IsActive ).OrderBy( a => a.Order ).ThenBy( a => a.Name ).AsNoTracking().ToList();
 
                     foreach ( var ddlGroup in phTableRows.ControlsOfTypeRecursive<RockDropDownList>().Where( a => a.ID.StartsWith( "ddlGroup_" ) ) )
                     {


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
Yes

## Context
#2481 Fundraising Matching - Displays inactive groups

## Strategy
How have you implemented your solution?
minor tweak in TransactionEntityMatching to only list active group in the dropdown list.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
