### PR TITLE
Fixed bug in Registration List Lava block with multiple Linkages

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationListLava.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationListLava.ascx.cs
@@ -115,19 +115,37 @@ namespace RockWeb.Blocks.Event
             
             List<Registration> hasDates = registrationList.Where(a => a.RegistrationInstance.Linkages.Any(x => x.EventItemOccurrenceId.HasValue && x.EventItemOccurrence.NextStartDateTime.HasValue)).ToList();
             List<Registration> noDates = registrationList.Where( a => !hasDates.Any( d => d.Id == a.Id ) ).OrderBy( x => x.RegistrationInstance.Name ).ToList();
-            
-            hasDates = hasDates.OrderBy(a => a.RegistrationInstance.Linkages.OrderBy(b => b.EventItemOccurrence.NextStartDateTime).FirstOrDefault().EventItemOccurrence.NextStartDateTime).ToList();
+
+            hasDates = hasDates
+                .OrderBy( a => a.RegistrationInstance.Linkages
+                     .Where( x => x.EventItemOccurrenceId.HasValue && x.EventItemOccurrence.NextStartDateTime.HasValue )
+                     .OrderBy( b => b.EventItemOccurrence.NextStartDateTime )
+                     .FirstOrDefault()
+                     .EventItemOccurrence.NextStartDateTime )
+                .ToList();
 
             // filter by date range
             var requestDateRange = SlidingDateRangePicker.CalculateDateRangeFromDelimitedValues( GetAttributeValue( "DateRange" ) ?? "-1||" );
             if ( requestDateRange.Start.HasValue )
             {
-                hasDates = hasDates.Where( a => a.RegistrationInstance.Linkages.OrderBy( b => b.EventItemOccurrence.NextStartDateTime ).FirstOrDefault().EventItemOccurrence.NextStartDateTime >= requestDateRange.Start ).ToList();
+                hasDates = hasDates
+                    .Where( a => a.RegistrationInstance.Linkages
+                        .Where( x => x.EventItemOccurrenceId.HasValue && x.EventItemOccurrence.NextStartDateTime.HasValue )
+                        .OrderBy( b => b.EventItemOccurrence.NextStartDateTime )
+                        .FirstOrDefault()
+                        .EventItemOccurrence.NextStartDateTime >= requestDateRange.Start )
+                    .ToList();
             }
 
             if ( requestDateRange.End.HasValue )
             {
-                hasDates = hasDates.Where( a => a.RegistrationInstance.Linkages.OrderBy( b => b.EventItemOccurrence.NextStartDateTime ).FirstOrDefault().EventItemOccurrence.NextStartDateTime < requestDateRange.End ).ToList();
+                hasDates = hasDates
+                    .Where( a => a.RegistrationInstance.Linkages
+                        .Where( x => x.EventItemOccurrenceId.HasValue && x.EventItemOccurrence.NextStartDateTime.HasValue )
+                        .OrderBy( b => b.EventItemOccurrence.NextStartDateTime )
+                        .FirstOrDefault()
+                        .EventItemOccurrence.NextStartDateTime < requestDateRange.End )
+                    .ToList();
             }
             
             registrationList = hasDates;


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

If a registration instance had multiple linkages, one of which did not have an EventItemOccurrenceId, then the block caused an Oops error on the My Account page, preventing people from seeing the page. Error caused by the `hasDates` variable containing a list of any registrations that had _any_ Linkages with a valid `EventItemOccurrenceId`. Then later it being assumed that _all_ Linkages had a valid `EventItemOccurrenceId`.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Update the query filters.

## Strategy
_How have you implemented your solution?_

When enumerating the Linkages, check for valid EventItemOccurrenceId before accessing.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a