### PR TITLE
Modified Group Placements to Validate on Group Capacity if known.

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx
@@ -378,6 +378,7 @@
                         <h1 class="panel-title"><i class="fa fa-link"></i> Group Placement</h1>
                     </div>
                     <div class="panel-body">
+                        <Rock:NotificationBox ID="nbWarningNotificationBox" runat="server" NotificationBoxType="Danger" />
                         <div class="row">
                             <div class="col-md-6">
                                 <Rock:GroupPicker ID="gpGroupPlacementParentGroup" runat="server" Label="Parent Group"

--- a/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceDetail.ascx.cs
@@ -1871,7 +1871,7 @@ namespace RockWeb.Blocks.Event
                         int? groupId = gp.SelectedValueAsInt();
                         if ( groupId.HasValue )
                         {
-                            int registrantId = (int)gGroupPlacements.DataKeys[row.RowIndex].Value;
+                            int registrantId = ( int ) gGroupPlacements.DataKeys[row.RowIndex].Value;
                             placements.AddOrIgnore( groupId.Value, new List<int>() );
                             placements[groupId.Value].Add( registrantId );
                         }
@@ -1880,46 +1880,64 @@ namespace RockWeb.Blocks.Event
 
                 using ( var rockContext = new RockContext() )
                 {
-                    var groupMemberService = new GroupMemberService( rockContext );
-
-                    // Get all the registrants that were selected
-                    var registrantIds = placements.SelectMany( p => p.Value ).ToList();
-                    var registrants = new RegistrationRegistrantService( rockContext )
-                        .Queryable( "PersonAlias" ).AsNoTracking()
-                        .Where( r => registrantIds.Contains( r.Id ) )
-                        .ToList();
-
-                    // Get any groups that were selected
-                    var groupIds = placements.Keys.ToList();
-                    foreach ( var group in new GroupService( rockContext )
-                        .Queryable( "GroupType" ).AsNoTracking()
-                        .Where( g => groupIds.Contains( g.Id ) ) )
+                    try
                     {
-                        foreach ( int registrantId in placements[group.Id] )
+                        rockContext.WrapTransaction( () =>
                         {
-                            int? roleId = group.GroupType.DefaultGroupRoleId;
-                            if ( !roleId.HasValue )
+                            var groupMemberService = new GroupMemberService( rockContext );
+
+                            // Get all the registrants that were selected
+                            var registrantIds = placements.SelectMany( p => p.Value ).ToList();
+                            var registrants = new RegistrationRegistrantService( rockContext )
+                                .Queryable( "PersonAlias" ).AsNoTracking()
+                                .Where( r => registrantIds.Contains( r.Id ) )
+                                .ToList();
+
+                            // Get any groups that were selected
+                            var groupIds = placements.Keys.ToList();
+                            foreach ( var group in new GroupService( rockContext )
+                                .Queryable( "GroupType" ).AsNoTracking()
+                                .Where( g => groupIds.Contains( g.Id ) ) )
                             {
-                                roleId = group.GroupType.Roles
-                                    .OrderBy( r => r.Order )
-                                    .Select( r => r.Id )
-                                    .FirstOrDefault();
+                                foreach ( int registrantId in placements[group.Id] )
+                                {
+                                    int? roleId = group.GroupType.DefaultGroupRoleId;
+                                    if ( !roleId.HasValue )
+                                    {
+                                        roleId = group.GroupType.Roles
+                                            .OrderBy( r => r.Order )
+                                            .Select( r => r.Id )
+                                            .FirstOrDefault();
+                                    }
+
+                                    var registrant = registrants.FirstOrDefault( r => r.Id == registrantId );
+                                    if ( registrant != null && roleId.HasValue && roleId.Value > 0 )
+                                    {
+                                        var groupMember = new GroupMember();
+                                        groupMember.PersonId = registrant.PersonAlias.PersonId;
+                                        groupMember.GroupId = group.Id;
+                                        groupMember.GroupRoleId = roleId.Value;
+                                        groupMember.GroupMemberStatus = GroupMemberStatus.Active;
+
+                                        if ( !groupMember.IsValidGroupMember( rockContext ) )
+                                        {
+                                            throw new Exception( string.Format( "Placing '{0}' in the '{1}' group is not valid for the following reason: {2}",
+                                                registrant.Person.FullName, group.Name,
+                                                groupMember.ValidationResults.Select( a => a.ErrorMessage ).ToList().AsDelimited( "<br />" ) ) );
+                                        }
+                                        groupMemberService.Add( groupMember );
+                                        rockContext.SaveChanges();
+                                    }
+
+                                }
                             }
 
-                            var registrant = registrants.FirstOrDefault( r => r.Id == registrantId );
-                            if ( registrant != null && roleId.HasValue && roleId.Value > 0 )
-                            {
-                                var groupMember = new GroupMember();
-                                groupMember.PersonId = registrant.PersonAlias.PersonId;
-                                groupMember.GroupId = group.Id;
-                                groupMember.GroupRoleId = roleId.Value;
-                                groupMember.GroupMemberStatus = GroupMemberStatus.Active;
-                                groupMemberService.Add( groupMember );
-                            }
-                        }
+                        } );
                     }
-
-                    rockContext.SaveChanges();
+                    catch ( Exception ex )
+                    {
+                        nbWarningNotificationBox.Text = ex.Message;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?

**Yes**

## Context
What is the problem you encountered that lead to you creating this pull request?
Group Capacity was not taken into account at the time of Group Placement.

## Goal
What will this pull request achieve and how will this fix the problem?
Modified Group Placements to Validate on Group Capacity if it's known.

## Strategy
How have you implemented your solution?
I have called GroupMember IsValidGroupMember which was missing.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?
N/A

## Screenshots
Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
![image](https://user-images.githubusercontent.com/10127187/31143295-7f0ec292-a89a-11e7-8713-b6958cad60ef.png)


## Documentation
If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
N/A