### PR TITLE
Relocate autocomplete _renderItem override to be per-instance

### DIFF
--- a/RockWeb/Scripts/Rock/Controls/personPicker.js
+++ b/RockWeb/Scripts/Rock/Controls/personPicker.js
@@ -60,7 +60,80 @@
                     noResults: function () { },
                     results: function () { }
                 }
-            });
+            }).data('ui-autocomplete')._renderItem = function ($ul, item) {
+                if (this.options.html) {
+                    // override jQueryUI autocomplete's _renderItem so that we can do Html for the listitems
+                    // derived from http://github.com/scottgonzalez/jquery-ui-extensions
+
+                    var inactiveWarning = "";
+
+                    if (!item.IsActive && item.RecordStatus) {
+                        inactiveWarning = " <small>(" + item.RecordStatus + ")</small>";
+                    }
+
+                    var quickSummaryInfo = "";
+                    if (item.FormattedAge || item.SpouseName) {
+                        quickSummaryInfo = " <small class='rollover-item text-muted'>";
+                        if (item.FormattedAge) {
+                            quickSummaryInfo += "Age: " + item.FormattedAge;
+                        }
+
+                        if (item.SpouseName) {
+                            if (item.FormattedAge) {
+                                quickSummaryInfo += "; ";
+                            }
+
+                            quickSummaryInfo += "Spouse: " + item.SpouseName;
+                        }
+
+                        quickSummaryInfo += "</small>";
+                    }
+
+                    var $div = $('<div/>').attr('class', 'radio'),
+
+                        $label = $('<label/>')
+                            .html(item.Name + inactiveWarning + quickSummaryInfo + ' <i class="fa fa-refresh fa-spin margin-l-md loading-notification" style="display: none; opacity: .4;"></i>')
+                            .addClass('rollover-container')
+                            .prependTo($div),
+
+                        $radio = $('<input type="radio" name="person-id" />')
+                            .attr('id', item.Id)
+                            .attr('value', item.Id)
+                            .prependTo($label),
+
+                        $li = $('<li/>')
+                            .addClass('picker-select-item')
+                            .attr('data-person-id', item.Id)
+                            .attr('data-person-name', item.Name)
+                            .html($div),
+
+                        $resultSection = $(this.options.appendTo);
+
+                    if (item.PickerItemDetailsHtml) {
+                        $(item.PickerItemDetailsHtml).appendTo($li);
+                    }
+                    else {
+                        var $itemDetailsDiv = $('<div/>')
+                            .addClass('picker-select-item-details clearfix')
+                            .attr('data-has-details', false)
+                            .hide();
+
+                        $itemDetailsDiv.appendTo($li);
+                    }
+
+                    if (!item.IsActive) {
+                        $li.addClass('is-inactive');
+                    }
+
+                    return $resultSection.append($li);
+                }
+                else {
+                    return $('<li></li>')
+                        .data('item.autocomplete', item)
+                        .append($('<a></a>').text(item.label))
+                        .appendTo($ul);
+                }
+            };
 
             $('#' + controlId + ' a.picker-label').click(function (e) {
                 e.preventDefault();
@@ -216,83 +289,6 @@
         }
 
         PersonPicker.prototype.initialize = function () {
-            $.extend($.ui.autocomplete.prototype, {
-                _renderItem: function ($ul, item) {
-                    if (this.options.html) {
-                        // override jQueryUI autocomplete's _renderItem so that we can do Html for the listitems
-                        // derived from http://github.com/scottgonzalez/jquery-ui-extensions
-
-                        var inactiveWarning = "";
-
-                        if (!item.IsActive && item.RecordStatus) {
-                            inactiveWarning = " <small>(" + item.RecordStatus + ")</small>";
-                        }
-
-                        var quickSummaryInfo = "";
-                        if (item.FormattedAge || item.SpouseName) {
-                            quickSummaryInfo = " <small class='rollover-item text-muted'>";
-                            if (item.FormattedAge) {
-                                quickSummaryInfo += "Age: " + item.FormattedAge;
-                            }
-
-                            if (item.SpouseName) {
-                                if (item.FormattedAge) {
-                                    quickSummaryInfo += "; ";
-                                }
-
-                                quickSummaryInfo += "Spouse: " + item.SpouseName;
-                            }
-
-                            quickSummaryInfo += "</small>";
-                        }
-
-                        var $div = $('<div/>').attr('class', 'radio'),
-
-                            $label = $('<label/>')
-                                .html(item.Name + inactiveWarning + quickSummaryInfo + ' <i class="fa fa-refresh fa-spin margin-l-md loading-notification" style="display: none; opacity: .4;"></i>')
-                                .addClass('rollover-container')
-                                .prependTo($div),
-
-                            $radio = $('<input type="radio" name="person-id" />')
-                                .attr('id', item.Id)
-                                .attr('value', item.Id)
-                                .prependTo($label),
-
-                            $li = $('<li/>')
-                                .addClass('picker-select-item')
-                                .attr('data-person-id', item.Id)
-                                .attr('data-person-name', item.Name)
-                                .html($div),
-
-                            $resultSection = $(this.options.appendTo);
-
-                        if (item.PickerItemDetailsHtml) {
-                            $(item.PickerItemDetailsHtml).appendTo($li);
-                        }
-                        else {
-                            var $itemDetailsDiv = $('<div/>')
-                                .addClass('picker-select-item-details clearfix')
-                                .attr('data-has-details', false)
-                                .hide();
-
-                            $itemDetailsDiv.appendTo($li);
-                        }
-
-                        if (!item.IsActive) {
-                            $li.addClass('is-inactive');
-                        }
-
-                        return $resultSection.append($li);
-                    }
-                    else {
-                        return $('<li></li>')
-                            .data('item.autocomplete', item)
-                            .append($('<a></a>').text(item.label))
-                            .appendTo($ul);
-                    }
-                }
-            });
-
             var $control = $('#' + this.controlId);
             $control.find('.scroll-container').tinyscrollbar({ size: 120, sizethumb: 20 });
 


### PR DESCRIPTION
<!-- # Rock PR Policy
The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
on your part and review time on ours, we have implemented the following guidelines for PRs:
1. If you are submitting a PR for a logged Issue / Enchancement request please reference it in your commit
2. If your PR is for an enchancment that has not been discussed and approved by the core team please get that approval BEFORE submitting
the request. In fact, this approval should be recieved before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.
-->

## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Issue #2518, conflicts with other autocomplete implementations.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Move the `_renderItem` function override so that it is defined per-instance instead of in the prototype for autocomplete.

## Strategy
_How have you implemented your solution?_

Copy & Paste

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Person Picker could break in theory, but all tests show solid so far.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a