### PR TITLE
Fixes #2516 Used earliest Created Date Time on People Merge

### DIFF
--- a/RockWeb/Blocks/Crm/PersonMerge.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonMerge.ascx.cs
@@ -410,9 +410,7 @@ validity of the request before completing this merge." :
                         primaryPerson.SystemNote = GetNewStringValue( "InactiveReasonNote", changes );
                         primaryPerson.SystemNote = GetNewStringValue( "SystemNote", changes );
 
-                        var peopleIds = MergeData.People.Select( a => a.Id ).ToList();
-                        primaryPerson.CreatedDateTime = personService.Queryable()
-                                                        .Where( p => peopleIds.Contains( p.Id ) )
+                        primaryPerson.CreatedDateTime = MergeData.People
                                                         .Min( a => a.CreatedDateTime );
 
                         // Update phone numbers
@@ -1302,6 +1300,7 @@ validity of the request before completing this merge." :
         public int Id { get; set; }
         public string FullName { get; set; }
         public DateTime? ModifiedDateTime { get; set; }
+        public DateTime? CreatedDateTime { get; set; }
         public string ModifiedBy { get; set; }
         public string Email { get; set; }
         public bool HasLogins { get; set; }
@@ -1312,6 +1311,7 @@ validity of the request before completing this merge." :
             Id = person.Id;
             FullName = person.FullName;
             ModifiedDateTime = person.ModifiedDateTime;
+            CreatedDateTime = person.CreatedDateTime;
             Email = person.Email;
             HasLogins = person.Users.Any();
             Guid = person.Guid;

--- a/RockWeb/Blocks/Crm/PersonMerge.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonMerge.ascx.cs
@@ -410,6 +410,11 @@ validity of the request before completing this merge." :
                         primaryPerson.SystemNote = GetNewStringValue( "InactiveReasonNote", changes );
                         primaryPerson.SystemNote = GetNewStringValue( "SystemNote", changes );
 
+                        var peopleIds = MergeData.People.Select( a => a.Id ).ToList();
+                        primaryPerson.CreatedDateTime = personService.Queryable()
+                                                        .Where( p => peopleIds.Contains( p.Id ) )
+                                                        .Min( a => a.CreatedDateTime );
+
                         // Update phone numbers
                         var phoneTypes = DefinedTypeCache.Read( Rock.SystemGuid.DefinedType.PERSON_PHONE_TYPE.AsGuid() ).DefinedValues;
                         foreach ( var phoneType in phoneTypes )


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
**Yes**

## Context
What is the problem you encountered that lead to you creating this pull request?
Created Date Time is always set in respect to person selected.

## Goal
What will this pull request achieve and how will this fix the problem?
To Use earliest Created Date Time on People Merge

## Strategy
How have you implemented your solution?
Queried minimum date time on all the person at the time of merge.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?
N/A

## Screenshots
Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
N/A

## Documentation
If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:
N/A

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
N/A