### PR TITLE
Fixed #2157 Funds in Giving block are populated with 0.00

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionEntry.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionEntry.ascx.cs
@@ -527,7 +527,7 @@ TransactionAccountDetails: [
             }
 
             // Update the total amount
-            lblTotalAmount.Text = SelectedAccounts.Sum( f => f.Amount ).ToString( "F2" );
+            lblTotalAmount.Text = GlobalAttributesCache.Value("CurrencySymbol") + SelectedAccounts.Sum( f => f.Amount ).ToString( "F2" );
 
             // Set the frequency date label based on if 'One Time' is selected or not
             if ( btnFrequency.Items.Count > 0 )
@@ -3321,7 +3321,10 @@ TransactionAccountDetails: [
                 mergeFields.Add( "Account", account );
                 txtAccountAmount.Label = accountHeaderTemplate.ResolveMergeFields( mergeFields );
 
-                txtAccountAmount.Text = accountItem.Amount.ToString( "N2" );
+                if ( accountItem.Amount != 0 )
+                {
+                    txtAccountAmount.Text = accountItem.Amount.ToString( "N2" );
+                }
 
                 if ( !accountItem.Enabled )
                 {


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

## Context
Issue #2157 ... Ran into issue while completing #2337

## Goal
Prevents field from populating when value is 0, also adds currency symbol on `lblTotalAmount` initial load. (Current behavior is `0.00` on initial load, currency sign `$0.00` is added after adding a value to an account).

## Strategy
Checked for 0

## Tests
N/A

## Possible Implications
N/A

## Screenshots
N/A

## Documentation
N/A

## Migrations
N/A
