### PR TITLE
Fixes #2507 Removed "Remove all pending" from communications simple mode

### DIFF
--- a/RockWeb/Blocks/Communication/CommunicationEntry.ascx.cs
+++ b/RockWeb/Blocks/Communication/CommunicationEntry.ascx.cs
@@ -218,6 +218,7 @@ namespace RockWeb.Blocks.Communication
             string mode = GetAttributeValue( "Mode" );
             _fullMode = string.IsNullOrWhiteSpace( mode ) || mode != "Simple";
             ppAddPerson.Visible = _fullMode;
+            lbRemoveAllRecipients.Visible = _fullMode;
             cbBulk.Visible = _fullMode;
             ddlTemplate.Visible = _fullMode;
             dtpFutureSend.Visible = _fullMode;
@@ -938,7 +939,7 @@ namespace RockWeb.Blocks.Communication
                 lbShowAllRecipients.Visible = false;
             }
 
-            lbRemoveAllRecipients.Visible = Recipients.Where( r => r.Status == CommunicationRecipientStatus.Pending ).Any();
+            lbRemoveAllRecipients.Visible = Recipients.Where( r => r.Status == CommunicationRecipientStatus.Pending ).Any() && _fullMode;
 
             rptRecipients.DataBind();
 


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
**Yes**

## Context
What is the problem you encountered that lead to you creating this pull request?
#2507 Remove "Remove all pending" in simple communications editor

## Goal
What will this pull request achieve and how will this fix the problem?
Goal is to remove 'Remove all pending' button in simple mode.

## Strategy
How have you implemented your solution?
I marked Visible=false for 'remove all pending' when there is no recipients or when mode is simple. 

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?
N/A

## Screenshots
Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
![image](https://user-images.githubusercontent.com/10127187/31584159-838f892a-b1c6-11e7-9141-f763f394e9ce.png)


## Documentation
If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:
N/A

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
N/A