### PR TITLE
Fixed #2476 Modified Notes or Tooltip in case of Child in Family Attendance

### DIFF
--- a/Rock/PersonProfile/Badge/FamilyAttendance.cs
+++ b/Rock/PersonProfile/Badge/FamilyAttendance.cs
@@ -61,7 +61,18 @@ namespace Rock.PersonProfile.Badge
                 animateClass = " animate";
             }
 
-            writer.Write(String.Format( "<div class='badge badge-attendance{0} badge-id-{1}' data-toggle='tooltip' data-original-title='Family attendance for the last 24 months. Each bar is a month.'>", animateClass, badge.Id));
+            string tooltip = string.Empty;
+            var groupTypeRole = Person.GetFamilyRole();
+            if ( groupTypeRole != null && groupTypeRole.Guid == SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD.AsGuid() )
+            {
+                tooltip = string.Format( "{0}&apos;s attendance for the last 24 months. Each bar is a month.", Person.NickName );
+            }
+            else
+            {
+                tooltip = "Family attendance for the last 24 months. Each bar is a month.";
+            }
+
+            writer.Write( String.Format( "<div class='badge badge-attendance{0} badge-id-{1}' data-toggle='tooltip' data-original-title='{2}'>", animateClass, badge.Id, tooltip ) );
 
             writer.Write("</div>");
 


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
**Yes**

## Context
What is the problem you encountered that lead to you creating this pull request?
#2476 Help text/Tooltip and functionality was not in sync with each other in case of Child in Family attendance bar graph.

## Goal
What will this pull request achieve and how will this fix the problem?
Modified Notes or Tooltip in case of Child in Family Attendance

## Strategy
How have you implemented your solution?
Yes i changed the notes for child.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?
N/A

## Screenshots
Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
N/A

## Documentation
If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:
N/A

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
N/A