### PR TITLE
Added JS to date picker to prevent selecting past dates

### DIFF
--- a/Rock/Web/UI/Controls/NewFamily/MembersRow.cs
+++ b/Rock/Web/UI/Controls/NewFamily/MembersRow.cs
@@ -492,6 +492,7 @@ namespace Rock.Web.UI.Controls
 
             _dpBirthdate.StartView = DatePicker.StartViewOption.decade;
             _dpBirthdate.ForceParse = false;
+            _dpBirthdate.AllowFutureDateSelection = false;
             _dpBirthdate.RequiredErrorMessage = "Birthdate is required for all group members";
             _dpBirthdate.Required = false;
 

--- a/Rock/Web/UI/Controls/Pickers/DatePicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/DatePicker.cs
@@ -119,6 +119,25 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
+        /// Controls whether or not the DatePicker allows for past dates to be selected (default true). If set to false, all past dates will be disabled.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> (default); otherwise, <c>false</c>.
+        /// </value>
+        public bool AllowPastDateSelection
+        {
+            get
+            {
+                return ViewState["AllowPastDateSelection"] as bool? ?? true;
+            }
+
+            set
+            {
+                ViewState["AllowPastDateSelection"] = value;
+            }
+        }
+
+        /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
         /// </summary>
         /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
@@ -168,13 +187,14 @@ namespace Rock.Web.UI.Controls
             dateFormat = dateFormat.Replace( "M", "m" ).Replace( "m", "mm" ).Replace( "mmmm", "mm" );
             dateFormat = dateFormat.Replace( "d", "dd" ).Replace( "dddd", "dd" );
 
-            var script = string.Format( @"Rock.controls.datePicker.initialize({{ id: '{0}', startView: {1}, format: '{2}', todayHighlight: {3}, forceParse: {4}, {5} }});", 
+            var script = string.Format( @"Rock.controls.datePicker.initialize({{ id: '{0}', startView: {1}, format: '{2}', todayHighlight: {3}, forceParse: {4}, {5} {6} }});", 
                 this.ClientID,                                  // {0}
                 this.StartView.ConvertToInt(),                  // {1}
                 dateFormat,                                     // {2}
                 this.HighlightToday.ToString().ToLower(),       // {3}
                 this.ForceParse.ToString().ToLower(),           // {4}
-                (this.AllowFutureDateSelection ) ? "" : "endDate: '" + RockDateTime.Today.ToString("o") + "',"  // {5}
+                ( this.AllowFutureDateSelection ) ? "" : "endDate: '" + RockDateTime.Today.ToString("o") + "',",  // {5}
+                ( this.AllowPastDateSelection ) ? "" : "startDate: '" + RockDateTime.Today.ToString("o") + "',"  // {6}
             );
             ScriptManager.RegisterStartupScript( this, this.GetType(), "date_picker-" + this.ClientID, script, true );
         }

--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx
@@ -120,7 +120,7 @@
                         </div>
                         <div class="col-md-4 col-md-offset-2">
                             <Rock:RockRadioButtonList ID="rblState" runat="server" Label="State" RepeatDirection="Horizontal" OnSelectedIndexChanged="rblState_SelectedIndexChanged" AutoPostBack="true" />
-                            <Rock:DatePicker ID="dpFollowUp" runat="server" Label="Follow-up Date" Visible="false" />
+                            <Rock:DatePicker ID="dpFollowUp" runat="server" Label="Follow-up Date" AllowPastDateSelection="false" Visible="false" />
                         </div>
                     </div>
 

--- a/RockWeb/Blocks/Crm/PersonUpdate.Kiosk.ascx
+++ b/RockWeb/Blocks/Crm/PersonUpdate.Kiosk.ascx
@@ -150,7 +150,7 @@
                                 <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" />
                             </div>
                             <div class="col-md-4">
-                                <Rock:DatePicker ID="dpBirthdate" runat="server" Label="Birthdate" />
+                                <Rock:DatePicker ID="dpBirthdate" runat="server" AllowFutureDateSelection="false"  Label="Birthdate" />
                             </div>
                         </div>
 

--- a/RockWeb/Blocks/Finance/TransactionEntry.ascx
+++ b/RockWeb/Blocks/Finance/TransactionEntry.ascx
@@ -50,7 +50,7 @@
                                             <Rock:RockLiteral ID="txtFrequency" runat="server" Label="Frequency" Visible="false" />
                                             <Rock:ButtonDropDownList ID="btnFrequency" runat="server" Label="Frequency"
                                                 DataTextField="Value" DataValueField="Id" AutoPostBack="true" OnSelectionChanged="btnFrequency_SelectionChanged" />
-                                            <Rock:DatePicker ID="dtpStartDate" runat="server" Label="First Gift" AutoPostBack="true" OnTextChanged="btnFrequency_SelectionChanged" />
+                                            <Rock:DatePicker ID="dtpStartDate" runat="server" Label="First Gift" AutoPostBack="true" AllowPastDateSelection="false" OnTextChanged="btnFrequency_SelectionChanged" />
                                         </div>
 
                                         <Rock:RockTextBox ID="txtCommentEntry" runat="server" Required="true" Label="Comment" />

--- a/RockWeb/Blocks/Groups/GroupAttendanceDetail.ascx
+++ b/RockWeb/Blocks/Groups/GroupAttendanceDetail.ascx
@@ -27,7 +27,7 @@
                     <div class="row">
                         <div class="col-sm-3">
                             <Rock:RockLiteral ID="lOccurrenceDate" runat="server" Label="Attendance For" />
-                            <Rock:DatePicker ID="dpOccurrenceDate" runat="server" Label="Attendance For" Required="true" />
+                            <Rock:DatePicker ID="dpOccurrenceDate" runat="server" Label="Attendance For" AllowFutureDateSelection="false"  Required="true" />
                         </div>
                         <div class="col-sm-3">
                             <Rock:RockLiteral ID="lLocation" runat="server" Label="Location" />

--- a/RockWeb/Scripts/Rock/Controls/datePicker.js
+++ b/RockWeb/Scripts/Rock/Controls/datePicker.js
@@ -25,6 +25,7 @@
                     autoclose: true,
                     todayBtn: true,
                     forceParse: options.forceParse,
+                    startDate: options.startDate,
                     endDate: options.endDate || new Date(8640000000000000),
                     startView: options.startView,
                     todayHighlight: options.todayHighlight


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_ Yes

## Context
Credit card transaction entry selection allows you to select dates in the past. Preventing the ability to select invalid dates improves UX.

## Goal
Add `AllowPastDateSelection` method that matches `AllowFutureDateSelection`

## Strategy
Added `AllowFutureDateSelection` to New Family and past to ConnectionRequestDetail.ascx, PersonUpdate.Kiosk.ascx, GroupAttendanceDetail and `AllowPastDateSelection` to TransactionEntry

## Tests
None 😞 

## Possible Implications
Prevents frustration? Implications are minimal because it's still possible to force a invalid selection, the date picker just won't display the date.

## Screenshots

<img width="387" alt="screen shot 2017-10-15 at 10 07 46 pm" src="https://user-images.githubusercontent.com/374209/31596134-57c66988-b1f5-11e7-8d4b-d257ad63da64.png">
From the transaction entry block. (The disabled dates could use a little less contrast to make it clear they cannot be selected)

## Documentation
N/A

## Migrations
N/A
