### PR TITLE
Add an optional maximum length to Text field types

### DIFF
--- a/Rock/Field/Types/TextFieldType.cs
+++ b/Rock/Field/Types/TextFieldType.cs
@@ -66,8 +66,8 @@ namespace Rock.Field.Types
 
             var maxLength = new RockTextBox();
             controls.Add( maxLength );
-            maxLength.Label = "Max Length";
-            maxLength.Help = "Enter the max length of this field (0 is unlimited).";
+            maxLength.Label = "Maximum Length";
+            maxLength.Help = "Enter the maximum length of this field (leave blank for unlimited).";
 
             return controls;
         }

--- a/Rock/Field/Types/TextFieldType.cs
+++ b/Rock/Field/Types/TextFieldType.cs
@@ -30,10 +30,10 @@ namespace Rock.Field.Types
     [Serializable]
     public class TextFieldType : FieldType
     {
-
         #region Configuration
 
         private const string IS_PASSWORD_KEY = "ispassword";
+        private const string MAX_LENGTH = "0";
 
         /// <summary>
         /// Returns a list of the configuration keys
@@ -43,6 +43,7 @@ namespace Rock.Field.Types
         {
             var configKeys = base.ConfigurationKeys();
             configKeys.Add( IS_PASSWORD_KEY );
+            configKeys.Add( MAX_LENGTH );
             return configKeys;
         }
 
@@ -62,6 +63,12 @@ namespace Rock.Field.Types
             cb.Label = "Password Field";
             cb.Text = "Yes";
             cb.Help = "When set, edit field will be masked.";
+
+            var maxLength = new RockTextBox();
+            controls.Add( maxLength );
+            maxLength.Label = "Max Length";
+            maxLength.Help = "Enter the max length of this field (0 is unlimited).";
+
             return controls;
         }
 
@@ -74,10 +81,19 @@ namespace Rock.Field.Types
         {
             Dictionary<string, ConfigurationValue> configurationValues = new Dictionary<string, ConfigurationValue>();
             configurationValues.Add( IS_PASSWORD_KEY, new ConfigurationValue( "Password Field", "When set, edit field will be masked.", "" ) );
+            configurationValues.Add( MAX_LENGTH, new ConfigurationValue( "Maximum Length", "Enter the maximum length of this field.", "" ) );
 
-            if ( controls != null && controls.Count > 0 && controls[0] != null && controls[0] is CheckBox )
-            { 
-                configurationValues[IS_PASSWORD_KEY].Value = ( (CheckBox)controls[0] ).Checked.ToString();
+            if ( controls != null && controls.Count > 0 )
+            {
+                if ( controls[0] != null && controls[0] is CheckBox )
+                {
+                    configurationValues[IS_PASSWORD_KEY].Value = ( (CheckBox)controls[0] ).Checked.ToString();
+                }
+
+                if ( controls[1] != null && controls[1] is TextBox )
+                {
+                    configurationValues[MAX_LENGTH].Value = ( (TextBox)controls[1] ).Text;
+                }
             }
 
             return configurationValues;
@@ -90,7 +106,7 @@ namespace Rock.Field.Types
         /// <returns></returns>
         public bool IsPassword( Dictionary<string, ConfigurationValue> configurationValues )
         {
-            if (configurationValues != null && configurationValues.ContainsKey( IS_PASSWORD_KEY ) )
+            if ( configurationValues != null && configurationValues.ContainsKey( IS_PASSWORD_KEY ) )
             {
                 return configurationValues[IS_PASSWORD_KEY].Value.AsBoolean();
             }
@@ -110,6 +126,11 @@ namespace Rock.Field.Types
                 if ( controls[0] != null && controls[0] is CheckBox && configurationValues.ContainsKey( IS_PASSWORD_KEY ) )
                 {
                     ( (CheckBox)controls[0] ).Checked = configurationValues[IS_PASSWORD_KEY].Value.AsBoolean();
+                }
+
+                if ( controls[1] != null && controls[1] is TextBox && configurationValues.ContainsKey( MAX_LENGTH ) )
+                {
+                    ( (TextBox)controls[1] ).Text = configurationValues[MAX_LENGTH].Value;
                 }
             }
         }
@@ -209,6 +230,13 @@ namespace Rock.Field.Types
                 configurationValues[IS_PASSWORD_KEY].Value.AsBoolean() )
             {
                 tb.TextMode = TextBoxMode.Password;
+            }
+
+            if ( configurationValues != null &&
+               configurationValues.ContainsKey( MAX_LENGTH ) &&
+               configurationValues[MAX_LENGTH].Value.AsInteger() > 0 )
+            {
+                tb.MaxLength = configurationValues[MAX_LENGTH].Value.AsInteger();
             }
 
             return tb;
@@ -315,6 +343,5 @@ namespace Rock.Field.Types
         }
 
         #endregion
-
     }
 }

--- a/Rock/Field/Types/TextFieldType.cs
+++ b/Rock/Field/Types/TextFieldType.cs
@@ -33,7 +33,7 @@ namespace Rock.Field.Types
         #region Configuration
 
         private const string IS_PASSWORD_KEY = "ispassword";
-        private const string MAX_LENGTH = "0";
+        private const string MAX_LENGTH = "maxlength";
 
         /// <summary>
         /// Returns a list of the configuration keys


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

✅

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Fix #2488.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Adds support for the pre-existing Textbox property of Max Length to the Rock Text fieldtype.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img width="862" alt="screenshot 2017-10-23 23 00 34" src="https://user-images.githubusercontent.com/1210933/31923102-eb2585ae-b846-11e7-8d12-57f99788886f.png">

<img width="627" alt="screenshot 2017-10-23 22 58 16" src="https://user-images.githubusercontent.com/1210933/31923107-ef40c626-b846-11e7-97c5-2234afb48c93.png">


## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

An attribute of type Text can now be set with a maximum input length.  Keep in mind that the user isn't prompted when they reach the end of the field; they just won't be able to type any more.

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

N/A
