### PR TITLE
Reworked SMS Response Code generate to prevent infinite loops.

### DIFF
--- a/Rock/Communication/Medium/Sms.cs
+++ b/Rock/Communication/Medium/Sms.cs
@@ -230,8 +230,7 @@ namespace Rock.Communication.Medium
 
                 if ( availableCodes.Any() )
                 {
-                    availableCodes.OrderBy( c => Guid.NewGuid() ).ToList();
-                    return availableCodes;
+                    return availableCodes.OrderBy( c => Guid.NewGuid() ).ToList();
                 }
             }
 

--- a/Rock/Communication/Medium/Sms.cs
+++ b/Rock/Communication/Medium/Sms.cs
@@ -15,6 +15,7 @@
 // </copyright>
 //
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -38,6 +39,23 @@ namespace Rock.Communication.Medium
     public class Sms : MediumComponent
     {
         const int TOKEN_REUSE_DURATION = 30; // number of days between token reuse
+
+        /// <summary>
+        /// The highest value an SMS Response Code can contain. If you change this above 5 digits
+        /// then you must also change the regular expression in the ProcessResponse method.
+        /// </summary>
+        private const int RESPONSE_CODE_MAX = 90000;
+
+        /// <summary>
+        /// Define a key to use in the cache for storing our available response code list.
+        /// </summary>
+        private const string RESPONSE_CODE_CACHE_KEY = "Rock:Communication:Sms:ResponseCodeCache";
+
+        /// <summary>
+        /// Used by the GenerateResponseCode method to ensure exclusive access to the cached
+        /// available response code list.
+        /// </summary>
+        private static readonly object _responseCodesLock = new object();
 
         /// <summary>
         /// Gets the type of the communication.
@@ -102,7 +120,7 @@ namespace Rock.Communication.Medium
                     if ( toPerson.Id == fromPerson.Id ) // message from the medium recipient
                     {
                         // look for response code in the message
-                        Match match = Regex.Match( message, @"@\d{3}" );
+                        Match match = Regex.Match( message, @"@\d{3,5}" );
                         if ( match.Success )
                         {
                             string responseCode = match.ToString();
@@ -180,37 +198,91 @@ namespace Rock.Communication.Medium
         }
 
         /// <summary>
+        /// Generate a randomized list of available response codes that can be used for SMS tracking.
+        /// </summary>
+        /// <param name="rockContext">A context to use for database calls.</param>
+        /// <returns>A randomized <see cref="List{T}"/> of strings that are available for use.</returns>
+        static private List<string> GenerateAvailableResponseCodeList( Rock.Data.RockContext rockContext )
+        {
+            DateTime tokenStartDate = RockDateTime.Now.Subtract( new TimeSpan( TOKEN_REUSE_DURATION, 0, 0, 0 ) );
+            int[] blacklist = new int[] { 666, 911 };
+            int chunkSize = 100;
+
+            //
+            // Generate a list of codes that are currently active in the database.
+            //
+            var activeCodes = new CommunicationRecipientService( rockContext ).Queryable()
+                                    .Where( c => c.ResponseCode.StartsWith( "@" ) && c.CreatedDateTime > tokenStartDate )
+                                    .Select( c => c.ResponseCode )
+                                    .ToList();
+
+            //
+            // Starting at code 100, try to generate a list of available codes in small chunks until
+            // we have a list with atleast 1 available code.
+            //
+            for ( int startValue = 100; startValue < RESPONSE_CODE_MAX - chunkSize; startValue += chunkSize )
+            {
+                var availableCodes = Enumerable.Range( startValue, chunkSize )
+                    .Where( i => !blacklist.Contains( i ) )
+                    .Select( i => string.Format( "@{0}", i ) )
+                    .Where( c => !activeCodes.Contains( c ) )
+                    .ToList();
+
+                if ( availableCodes.Any() )
+                {
+                    availableCodes.OrderBy( c => Guid.NewGuid() ).ToList();
+                    return availableCodes;
+                }
+            }
+
+            throw new Exception( "No available response codes." );
+        }
+
+        /// <summary>
         /// Creates a recipient token to help track conversations.
         /// </summary>
         /// <param name="rockContext">A context to use for database calls.</param>
         /// <returns>String token</returns>
         private string GenerateResponseCode( Rock.Data.RockContext rockContext )
         {
-            bool isUnique = false;
-            int randomNumber = -1;
             DateTime tokenStartDate = RockDateTime.Now.Subtract( new TimeSpan( TOKEN_REUSE_DURATION, 0, 0, 0 ) );
+            var communicationRecipientService = new CommunicationRecipientService( rockContext );
+            var cache = RockMemoryCache.Default;
 
-            Random rnd = new Random();
-
-            while ( isUnique == false )
+            lock ( _responseCodesLock )
             {
-                randomNumber = rnd.Next( 100, 1000 );
+                var availableResponseCodes = cache[RESPONSE_CODE_CACHE_KEY] as List<string>;
 
-                if ( randomNumber != 666 ) // just because
+                //
+                // Try up to 1,000 times to find a code. This really should never go past the first
+                // loop but we will give the benefit of the doubt in case a code is issued via SQL.
+                //
+                for ( int attempts = 0; attempts < 1000; attempts++ )
                 {
-
-                    // check if token has been used recently
-                    var communication = new CommunicationRecipientService( rockContext ).Queryable()
-                                            .Where( c => c.ResponseCode == "@" + randomNumber.ToString() && c.CreatedDateTime > tokenStartDate )
-                                            .FirstOrDefault();
-                    if ( communication == null )
+                    if ( availableResponseCodes == null || !availableResponseCodes.Any() )
                     {
-                        isUnique = true;
+                        availableResponseCodes = GenerateAvailableResponseCodeList( rockContext );
+                    }
+
+                    var code = availableResponseCodes[0];
+                    availableResponseCodes.RemoveAt( 0 );
+
+                    //
+                    // Verify that the code is still unused.
+                    //
+                    var isUsed = communicationRecipientService.Queryable()
+                            .Where( c => c.ResponseCode == code && c.CreatedDateTime > tokenStartDate )
+                            .Any();
+
+                    if ( !isUsed )
+                    {
+                        cache[RESPONSE_CODE_CACHE_KEY] = availableResponseCodes;
+                        return code;
                     }
                 }
             }
 
-            return "@" + randomNumber.ToString();
+            throw new Exception( "Could not find an available response code." );
         }
 
         /// <summary>


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Issue #2552, when all 899 available response codes had been used in the past 30 days the system would loop forever trying to generate a new code.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Increase number of available codes, decrease window for a code being considered "used" and rework the loop to have a final escape.

## Strategy
_How have you implemented your solution?_

System now supports up to 5-digit response codes. It generates them in a "bucket system" of 100 at a time, between 100 and 90,000 (skipping `666` and `911`). These chunks are generated using the "smallest number available" logic. Once the chunk list is generated it is randomized. Because of this "bucket system" the randomized list will be at most 100 sequential numbers, so we may want to increase the bucket size if we find there is not enough entropy.

This randomized list is then stored in the cache and re-used until the list has been depleted, at which time a new list is generated.

When trying to find the next single available code, it will try 1,000 times to find a code before giving up. An exception is now thrown if that 1,000 limit is reached or no codes are found to be available when generating the cached list.

## Performance

For testing performance, I pre-generated codes 100 - 3,927 as recently used response codes to determine how much time would be used by the system to process incoming SMS messages.

* Took 5,673ms to find recently used codes (3,827 database rows).
* Took 51ms to find first available chunk of codes (i.e. 3,928 - 3,999).
* Took 0ms to randomize list.

These timings only applied on the first (simulated) incoming SMS message. Subsequent messages took <2ms to pull from the cache and check the database to ensure that one single code was still available.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a