### PR TITLE
Minor css fix related to display of a matrix Field in AttributeValues block

### DIFF
--- a/RockWeb/Blocks/Crm/PersonDetail/AttributeValues.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/AttributeValues.ascx.cs
@@ -392,7 +392,14 @@ namespace RockWeb.Blocks.Crm.PersonDetail
                             
                             if ( !string.IsNullOrWhiteSpace( formattedValue ) )
                             {
-                                fsAttributes.Controls.Add( new RockLiteral { Label = attribute.Name, Text = formattedValue } );
+                                if ( attribute.FieldType.Class == typeof( Rock.Field.Types.MatrixFieldType ).FullName )
+                                {
+                                    fsAttributes.Controls.Add( new RockLiteral { Label = attribute.Name, Text = formattedValue, CssClass= "matrix-attribute" } );
+                                    }
+                                else
+                                {
+                                    fsAttributes.Controls.Add( new RockLiteral { Label = attribute.Name, Text = formattedValue } );
+                                }
                             }
                         }
                     }

--- a/RockWeb/Styles/developer.css
+++ b/RockWeb/Styles/developer.css
@@ -135,3 +135,14 @@ span.data-view-filter-label {
 table th[align='right'] {
   text-align: right;
 }
+
+
+
+.panel-persondetails .panel-body .form-group.static-control.matrix-attribute label {
+    width: 100%;
+    text-align: left;
+}
+
+.panel-persondetails .panel-body .form-group.static-control.matrix-attribute .form-control-static{
+    display:none;
+}


### PR DESCRIPTION
## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
**Yes**

## Context
What is the problem you encountered that lead to you creating this pull request?
The display of a matrix type attribute is a little awkward since the 'data' portion spills over into the title area

## Goal
What will this pull request achieve and how will this fix the problem?
Minor css fix related to display of a matrix Field in AttributeValues block

## Strategy
How have you implemented your solution?
I have defined few custom css to align the grid and label to correct position.
Also done minor changes in AttributeValues  to call those CSS class in case of Matrix field type.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?
N/A

## Screenshots
Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
N/A

## Documentation
If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:
N/A

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
N/A