### PR TITLE
Show big fat warning on PMM configuration page when using a non-SSL URL

### DIFF
--- a/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx
+++ b/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx
@@ -53,6 +53,14 @@
                             <Rock:RockLiteral ID="lPackages" runat="server" Label="Enabled Background Check Types" />
                         </div>
                     </div>
+
+                    <Rock:NotificationBox ID="nbSSLWarning" runat="server" CssClass="clearfix" NotificationBoxType="Danger">
+                        <i class="fa fa-2x fa-exclamation-triangle pull-left margin-t-sm"></i>
+                        Your current configuration will cause Protect My Ministry to send results to your server over an
+                        insecure connection. Please use a <code>https://</code> URL to ensure the data remains secure
+                        during transmission before using in production.
+                    </Rock:NotificationBox>
+
                     <div class="actions">
                         <asp:LinkButton ID="lbEdit" runat="server" Text="Edit" CssClass="btn btn-primary" OnClick="lbEdit_Click" />
                     </div>

--- a/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx
+++ b/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx
@@ -57,8 +57,8 @@
                     <Rock:NotificationBox ID="nbSSLWarning" runat="server" CssClass="clearfix" NotificationBoxType="Danger">
                         <i class="fa fa-2x fa-exclamation-triangle pull-left margin-t-sm"></i>
                         Your current configuration will cause Protect My Ministry to send results to your server over an
-                        insecure connection. Please use a <code>https://</code> URL to ensure the data remains secure
-                        during transmission before using in production.
+                        insecure connection. Please ensure that your server is configured for SSL and use a <code>https://</code>
+                        URL to protect the data during transmission before using in production.
                     </Rock:NotificationBox>
 
                     <div class="actions">

--- a/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx.cs
+++ b/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx.cs
@@ -418,6 +418,9 @@ namespace RockWeb.Blocks.Security.BackgroundCheck
                 lPackages.Text = packages.AsDelimited( "<br/>" );
             }
 
+            nbSSLWarning.Visible = !GetSettingValue( settings, "ReturnURL" ).StartsWith( "https://" );
+            nbSSLWarning.NotificationBoxType = GetSettingValue( settings, "TestMode" ).AsBoolean() ? NotificationBoxType.Warning : NotificationBoxType.Danger;
+
             pnlNew.Visible = false;
             pnlViewDetails.Visible = true;
             pnlEditDetails.Visible = false;
@@ -684,5 +687,5 @@ namespace RockWeb.Blocks.Security.BackgroundCheck
 
         #endregion
 
-}
+    }
 }


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

<img width="200px" alt="32471079-5bd51dae-c310-11e7-9bc6-195af085a5ab.png" src="https://user-images.githubusercontent.com/1119863/32471079-5bd51dae-c310-11e7-9bc6-195af085a5ab.png">

## Context
_What is the problem you encountered that lead to you creating this pull request?_

PMM will send results over non-SSL connection. Make sure admin sees big fat warning when configuring as such. See #2578.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Ensure the admin is informed that they are using a non-SSL connection to get results from PMM.

## Strategy
_How have you implemented your solution?_

Since HTML5 killed the `blink` tag I had to resort to a Bootstrap alert div.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img alt="2017-11-06 16_27_19-virtualbox" src="https://user-images.githubusercontent.com/1119863/32471015-10862e74-c310-11e7-982a-5899b9cf5bda.png">

<img alt="2017-11-06 16_28_19-virtualbox" src="https://user-images.githubusercontent.com/1119863/32471019-150bf1ea-c310-11e7-8314-157a9d040bf2.png">

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a