### PR TITLE
Fixed Event Template Details from showing duplicate forms in certain situations.

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx.cs
@@ -2238,6 +2238,7 @@ namespace RockWeb.Blocks.Event
             lWorkflowType.Visible = !string.IsNullOrWhiteSpace( lWorkflowType.Text );
 
             rcwForms.Label = string.Format( "<strong>Forms</strong> ({0}) <i class='fa fa-caret-down'></i>", RegistrationTemplate.Forms.Count() );
+            lFormsReadonly.Text = string.Empty;
             if ( RegistrationTemplate.Forms.Any() )
             {
                 foreach ( var form in RegistrationTemplate.Forms.OrderBy( a => a.Order ) )


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

In certain PostBack situations, such as clicking Edit and then clicking Cancel, the read-only list of forms would duplicate and show multiple copies of the same form(s). See #2152.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the problem.

## Strategy
_How have you implemented your solution?_

Clear existing text data before appending new data to the Literal control.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a