### PR TITLE
Added Subtitle (Attribute Id) To Modal Dialog from Attribute Editor

### DIFF
--- a/Rock/Web/UI/Controls/AttributeEditor.cs
+++ b/Rock/Web/UI/Controls/AttributeEditor.cs
@@ -1367,6 +1367,8 @@ namespace Rock.Web.UI.Controls
 
                 this.Qualifiers = qualifiers;
                 this.DefaultValue = attribute.DefaultValue;
+
+                SetSubTitleOnModal( attribute );
             }
 
             if ( objectType != null )
@@ -1482,6 +1484,24 @@ namespace Rock.Web.UI.Controls
 
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Set the Subtitle of modal dialog
+        /// </summary>
+        /// <param name="attribute">The attribute.</param>
+        protected void SetSubTitleOnModal( Model.Attribute attribute )
+        {
+            Control parent = this.Parent;
+            while ( parent.GetType() != typeof( ModalDialog ) )
+            {
+                parent = parent.Parent;
+            }
+            if ( parent.GetType() == typeof( ModalDialog ) )
+            {
+                ModalDialog modalDialog = ( ModalDialog ) parent;
+                modalDialog.SubTitle = string.Format( "Id: {0}", attribute.Id );
             }
         }
 

--- a/Rock/Web/UI/Controls/AttributeEditor.cs
+++ b/Rock/Web/UI/Controls/AttributeEditor.cs
@@ -1113,7 +1113,7 @@ namespace Rock.Web.UI.Controls
                 if ( entityType != null )
                 {
                     _cbIsAnalytic.Visible = entityType.IsAnalyticAttributesSupported( this.AttributeEntityTypeQualifierColumn, this.AttributeEntityTypeQualifierValue );
-                    _cbIsAnalyticHistory.Visible = entityType.IsAnalyticsHistoricalSupported( this.AttributeEntityTypeQualifierColumn, this.AttributeEntityTypeQualifierValue ) ;
+                    _cbIsAnalyticHistory.Visible = entityType.IsAnalyticsHistoricalSupported( this.AttributeEntityTypeQualifierColumn, this.AttributeEntityTypeQualifierValue );
                 }
             }
 
@@ -1231,7 +1231,7 @@ namespace Rock.Web.UI.Controls
             writer.RenderEndTag();
 
             writer.RenderEndTag();
-            
+
             writer.RenderEndTag();
 
             // row 3 col 2
@@ -1284,7 +1284,7 @@ namespace Rock.Web.UI.Controls
         /// <param name="args">The <see cref="ServerValidateEventArgs"/> instance containing the event data.</param>
         protected void cvKey_ServerValidate( object source, ServerValidateEventArgs args )
         {
-            args.IsValid = 
+            args.IsValid =
                 !ReservedKeyNames.Contains( _tbKey.Text.Trim(), StringComparer.CurrentCultureIgnoreCase ) &&
                 !ObjectPropertyNames.Contains( _tbKey.Text.Trim(), StringComparer.CurrentCultureIgnoreCase );
         }
@@ -1325,7 +1325,7 @@ namespace Rock.Web.UI.Controls
                 CancelClick( sender, e );
             }
         }
-        
+
         #endregion
 
         #region Public Methods
@@ -1494,13 +1494,9 @@ namespace Rock.Web.UI.Controls
         protected void SetSubTitleOnModal( Model.Attribute attribute )
         {
             Control parent = this.Parent;
-            while ( parent.GetType() != typeof( ModalDialog ) )
+            ModalDialog modalDialog = this.FirstParentControlOfType<ModalDialog>();
+            if ( modalDialog != null && string.IsNullOrEmpty(modalDialog.SubTitle) )
             {
-                parent = parent.Parent;
-            }
-            if ( parent.GetType() == typeof( ModalDialog ) )
-            {
-                ModalDialog modalDialog = ( ModalDialog ) parent;
                 modalDialog.SubTitle = string.Format( "Id: {0}", attribute.Id );
             }
         }


### PR DESCRIPTION
# Rock PR Policy
The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
on your part and review time on ours, we have implemented the following guidelines for PRs:
1. If you are submitting a PR for a logged Issue / Enchancement request please reference it in your commit
2. If your PR is for an enchancment that has not been discussed and approved by the core team please get that approval BEFORE submitting
the request. In fact, this approval should be recieved before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.


## Contributor Agreement
Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?
**Yes**

## Context
What is the problem you encountered that lead to you creating this pull request?

## Goal
What will this pull request achieve and how will this fix the problem?
Goal is to put the Attribute Id in Modal Dialog containing attribute editor for convenience.

## Strategy
How have you implemented your solution?
Looked for parent Modal dialog inside Attribute editor control and added subtitle to control if found.

## Tests
If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request.
N/A

## Possible Implications
What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?
N/A

## Screenshots
Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
N/A

## Documentation
If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:
N/A

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
N/A