### PR TITLE
WorkflowEntry block executes wrong Activity

### DIFF
--- a/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
@@ -382,7 +382,7 @@ namespace RockWeb.Blocks.WorkFlow
                 {
                     foreach ( var activity in _workflow.ActiveActivities )
                     {
-                        _action = activity.Actions.Where( a => a.ActionTypeId == ActionTypeId.Value ).FirstOrDefault();
+                        _action = activity.ActiveActions.Where( a => a.ActionTypeId == ActionTypeId.Value ).FirstOrDefault();
                         if ( _action != null )
                         {
                             _activity = activity;


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

This fixes two separate, but related issues (See #2567 for details of first issue):

1. If a User Entry Form exists on an activity, and that activity is activated multiple times, then the first activity is always processed even if the form-action is already marked as completed.
2. If two User Entry Forms exist on a single activity, the same issue can cause the first form to always be displayed instead of the second form.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the problem.

## Strategy
_How have you implemented your solution?_

Update WorkflowEntry to only look at Active actions when determining what form to display.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

> I tested a few quick workflows on my system and it worked correctly, but it's such a complex system it's possible this will somehow break existing workflows, but I think the change is sound...

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a