### PR TITLE
Allowed multiple enum attributes to be added to a single block

### DIFF
--- a/Rock/Attribute/EnumFieldAttribute.cs
+++ b/Rock/Attribute/EnumFieldAttribute.cs
@@ -26,7 +26,7 @@ namespace Rock.Attribute
     /// <summary>
     /// Field Attribute for selecting radio button options from an enum.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage( AttributeTargets.Class, AllowMultiple = true, Inherited = true )]
     public class EnumFieldAttribute : FieldAttribute
     {
         /// <summary>

--- a/Rock/Attribute/EnumsFieldAttribute.cs
+++ b/Rock/Attribute/EnumsFieldAttribute.cs
@@ -24,7 +24,7 @@ namespace Rock.Attribute
     /// <summary>
     /// Field Attribute for selecting checkbox options from an enum.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage( AttributeTargets.Class, AllowMultiple = true, Inherited = true )]
     public class EnumsFieldAttribute : FieldAttribute
     {
         /// <summary>


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

## Context
_What is the problem you encountered that lead to you creating this pull request?_

I needed to add two different Enum block settings to a single block.

## Goal
_What will this pull request achieve and how will this fix the problem?_

This will allow more than one Enum attribute to be added to a single block.

## Strategy
_How have you implemented your solution?_

I set AllowMultiple to True on EnumFieldAttribute (and also EnumsFieldAttribute merely for consistency).

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
