### PR TITLE
No longer removes field codes in Word merge templates

### DIFF
--- a/Rock/MergeTemplates/WordDocumentMergeTemplateType.cs
+++ b/Rock/MergeTemplates/WordDocumentMergeTemplateType.cs
@@ -466,7 +466,7 @@ namespace Rock.MergeTemplates
             RemoveComments = true,
             RemoveContentControls = true,
             RemoveEndAndFootNotes = true,
-            RemoveFieldCodes = true,
+            RemoveFieldCodes = false,
             RemoveLastRenderedPageBreak = true,
             RemovePermissions = true,
             RemoveProof = true,


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

## Context

We generate documents that have page number fields in them, and we needed these page number fields to work properly in the final generated file.

## Goal

To allow page number fields (and other field codes) to remain in generated Word documents.

## Strategy

Set RemoveFieldCodes = false in SimplifyMarkupSettings.

## Tests

## Possible Implications

Field codes will now remain in Word templates, so if anyone has fields in their templates that they don't want to be retained in the final document, this may be a problem. I'd this this is pretty unlikely.

## Screenshots


## Documentation

## Migrations

