### PR TITLE
Fixed bug that would throw an error if an email subject was too long to be stored in the database.

### DIFF
--- a/Rock/Model/CommunicationService.Partial.cs
+++ b/Rock/Model/CommunicationService.Partial.cs
@@ -16,6 +16,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Rock.Communication;
 using Rock.Data;
@@ -101,7 +102,7 @@ namespace Rock.Model
                 communication.FromName = fromName;
                 communication.FromEmail = fromAddress;
                 communication.ReplyToEmail = replyTo;
-                communication.Subject = subject;
+                communication.Subject = string.IsNullOrEmpty( subject ) ? string.Empty : subject.Left( communication.GetAttributeFrom<MaxLengthAttribute>( "Subject" ).Length );
                 communication.Message = message;
                 communication.IsBulkCommunication = bulkCommunication;
                 communication.FutureSendDateTime = null;

--- a/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx.cs
+++ b/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx.cs
@@ -26,6 +26,7 @@ using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using System.ComponentModel.DataAnnotations;
 
 using Rock;
 using Rock.Attribute;
@@ -2423,7 +2424,8 @@ sendCountTerm.PluralizeIf( sendCount != 1 ) );
                 communication.Attachments.Add( new CommunicationAttachment { BinaryFileId = attachmentBinaryFileId, CommunicationType = CommunicationType.SMS } );
             }
 
-            communication.Subject = tbEmailSubject.Text;
+            var subjectMaxLength = communication.GetAttributeFrom<MaxLengthAttribute>( "Subject" ).Length;
+            communication.Subject = string.IsNullOrEmpty( tbEmailSubject.Text ) ? string.Empty : tbEmailSubject.Text.Left( subjectMaxLength );
             communication.Message = hfEmailEditorHtml.Value;
 
             communication.SMSFromDefinedValueId = ddlSMSFrom.SelectedValue.AsIntegerOrNull();


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

Yes

## Context

Users can enter email subjects of any length, but if the subject is longer than the database column max (currently 100), Rock will throw an error when trying to send.

## Goal

To prevent throwing an error.

## Strategy

Get the value of the MaxLength attribute on the database column and only take that many characters for the subject.

## Tests
## Possible Implications

A more ideal solution would be for the UI to prevent the too-long subject and give the user the chance to edit the subject to fit within the length limit. But since I don't know how to do that, and 100+ character subjects should be quite rare, this is what we have implemented for now.

## Screenshots
## Documentation
## Migrations
