### PR TITLE
- Updated Rock Store to only show Icon Safe area of plugin image

### DIFF
--- a/RockWeb/Styles/_store.less
+++ b/RockWeb/Styles/_store.less
@@ -54,6 +54,9 @@
   cursor: pointer;
   background-color: #fff;
   border: 1px solid #ccc;
+  max-width: 282px;
+  margin-left: auto;
+  margin-right: auto;
 
   .packagesummary-image-hover {
     width: 100%;


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yes**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

While "Icon Safe Area" is not exactly a correct statement, I believe it conveys the idea. Basically we are recommending developers put an icon in the "red section" of the package banner (420x210 centered) and other information, such as possible text, outside of that "safe area". However on wider monitors, such as 1920x1080, the browser window is wide enough that the package icon displays outside this "safe area" and will display text.

While we don't have a good way yet to have a dedicated icon, this at least provides a way to ensure that the area outside the shaded red will not be displayed in "icon list" view modes without changing the height of the icon itself.

I'm perfectly okay to have this PR rejected since I didn't go through the normal issue-post first for discussion. But since it only ended up being 3 lines of CSS code it felt like it would be faster/easier to just post this with screenshot samples.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Make the package icons display a little bit cleaner on wide browser windows.

## Strategy
_How have you implemented your solution?_

Apply a max-width to the package summary div and auto margins so it will be centered in the column.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

Screenshots were taken on a 1920x1080 monitor with browser window maximized.

Before:

![screenshot-2017-12-21 rock shop rock rms](https://user-images.githubusercontent.com/1119863/34271547-89033bc2-e641-11e7-9cb1-01da7be75719.png)

After:

![screenshot-2017-12-21 rock shop rock rms 1](https://user-images.githubusercontent.com/1119863/34271551-8be47be4-e641-11e7-912a-213b5cc046f2.png)

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a