### PR TITLE
Initialize ace.js later in CodeEditor initialization

### DIFF
--- a/Rock/Web/UI/Controls/CodeEditor.cs
+++ b/Rock/Web/UI/Controls/CodeEditor.cs
@@ -473,12 +473,6 @@ namespace Rock.Web.UI.Controls
         {
             base.OnInit( e );
             this.TextMode = TextBoxMode.MultiLine;
-
-            if ( this.Visible && !ScriptManager.GetCurrent( this.Page ).IsInAsyncPostBack )
-            {
-                // if the codeeditor is .Visible and this isn't an Async, add ace.js to the page (If the codeeditor is made visible during an Async Post, RenderBaseControl will take care of adding ace.js)
-                RockPage.AddScriptLink( Page, ResolveUrl( "~/Scripts/ace/ace.js" ) );
-            }
         }
 
         /// <summary>
@@ -494,6 +488,22 @@ namespace Rock.Web.UI.Controls
             _mfpMergeFields.ID = string.Format( "mfpMergeFields_{0}", this.ID );
             _mfpMergeFields.SelectItem += MergeFields_SelectItem;
             Controls.Add( _mfpMergeFields );
+        }
+
+        /// <summary>
+        /// Called by the ASP.NET page framework after event processing has finished but
+        /// just before rendering begins.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnPreRender( EventArgs e )
+        {
+            base.OnPreRender( e );
+
+            if ( this.Visible && !ScriptManager.GetCurrent( this.Page ).IsInAsyncPostBack )
+            {
+                // if the codeeditor is .Visible and this isn't an Async, add ace.js to the page (If the codeeditor is made visible during an Async Post, RenderBaseControl will take care of adding ace.js)
+                RockPage.AddScriptLink( Page, ResolveUrl( "~/Scripts/ace/ace.js" ) );
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**Yupz**

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See issue #2557 for full discussion.

If the `CodeEditor` control is not visible in the .ascx file, but then made visible in the OnLoad method of the block (i.e. not a postback, but not visible by default as we want to decide based on query string parameters or something), the ace.js does not get included.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Make sure ace.js gets included properly.

## Strategy
_How have you implemented your solution?_

Move the ace.js inclusion into the OnPreRender event method.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

n/a

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a