### PR TITLE
Updated various field types to support reverting to default value.

### DIFF
--- a/Rock/Field/Types/DecimalRangeFieldType.cs
+++ b/Rock/Field/Types/DecimalRangeFieldType.cs
@@ -71,7 +71,7 @@ namespace Rock.Field.Types
         public override string GetEditValue( System.Web.UI.Control control, System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues )
         {
             NumberRangeEditor editor = control as NumberRangeEditor;
-            if ( editor != null )
+            if ( editor != null && ( editor.LowerValue.HasValue || editor.UpperValue.HasValue ) )
             {
                 return editor.DelimitedValues;
             }

--- a/Rock/Field/Types/DefinedValueRangeFieldType.cs
+++ b/Rock/Field/Types/DefinedValueRangeFieldType.cs
@@ -260,7 +260,11 @@ namespace Rock.Field.Types
             {
                 RockDropDownList lowerValueControl = pnlRange.Controls.OfType<RockDropDownList>().FirstOrDefault( a => a.ID.EndsWith( "_ddlLower" ) );
                 RockDropDownList upperValueControl = pnlRange.Controls.OfType<RockDropDownList>().FirstOrDefault( a => a.ID.EndsWith( "_ddlUpper" ) );
-                return string.Format( "{0},{1}", lowerValueControl.SelectedValue, upperValueControl.SelectedValue );
+
+                if ( !string.IsNullOrEmpty( lowerValueControl.SelectedValue ) || !string.IsNullOrEmpty( upperValueControl.SelectedValue ) )
+                {
+                    return string.Format( "{0},{1}", lowerValueControl.SelectedValue, upperValueControl.SelectedValue );
+                }
             }
 
             return null;

--- a/Rock/Field/Types/GroupAndRoleFieldType.cs
+++ b/Rock/Field/Types/GroupAndRoleFieldType.cs
@@ -234,7 +234,10 @@ namespace Rock.Field.Types
                     }
                 }
 
-                return string.Format( "{0}|{1}|{2}", groupTypeGuid, groupGuid, groupTypeRoleGuid );
+                if ( groupTypeGuid.HasValue || groupGuid.HasValue || groupTypeRoleGuid.HasValue )
+                {
+                    return string.Format( "{0}|{1}|{2}", groupTypeGuid, groupGuid, groupTypeRoleGuid );
+                }
             }
 
             return null;

--- a/Rock/Field/Types/GroupTypeGroupFieldType.cs
+++ b/Rock/Field/Types/GroupTypeGroupFieldType.cs
@@ -210,7 +210,10 @@ namespace Rock.Field.Types
                     }
                 }
 
-                return string.Format( "{0}|{1}", groupTypeGuid, groupGuid );
+                if ( groupTypeGuid.HasValue || groupGuid.HasValue )
+                {
+                    return string.Format( "{0}|{1}", groupTypeGuid, groupGuid );
+                }
             }
 
             return null;

--- a/Rock/Field/Types/IntegerRangeFieldType.cs
+++ b/Rock/Field/Types/IntegerRangeFieldType.cs
@@ -92,7 +92,7 @@ namespace Rock.Field.Types
         public override string GetEditValue( System.Web.UI.Control control, System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues )
         {
             NumberRangeEditor editor = control as NumberRangeEditor;
-            if ( editor != null )
+            if ( editor != null && ( editor.LowerValue.HasValue || editor.UpperValue.HasValue ) )
             {
                 return string.Format( "{0},{1}", editor.LowerValue, editor.UpperValue );
             }

--- a/Rock/Field/Types/SlidingDateRangeFieldType.cs
+++ b/Rock/Field/Types/SlidingDateRangeFieldType.cs
@@ -209,7 +209,7 @@ namespace Rock.Field.Types
         public override string GetEditValue( System.Web.UI.Control control, System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues )
         {
             SlidingDateRangePicker editor = control as SlidingDateRangePicker;
-            if ( editor != null )
+            if ( editor != null && editor.SlidingDateRangeMode != SlidingDateRangePicker.SlidingDateRangeType.All )
             {
                 return editor.DelimitedValues;
             }


### PR DESCRIPTION
## Contributor Agreement
_Have you filled out and sent your [Spark Contributor Agreement](http://www.rockrms.com/Content/RockExternal/Misc/Contributor%20Agreement.pdf) to secretary [at] sparkdevnetwork.org?_

**はい** (Yes)

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2596. Some field types, specifically ones that normal return a comma or pipe delimited value from the editor, would return a `,` value instead of null if no values were set. This prevented the default value from being used instead.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Update field types to allow returning null instead of `,` when empty.

## Strategy
_How have you implemented your solution?_

Check for blank values before returning the formatted string.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

n/a

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

It's remotely possible that people were using this "feature" to override a default value to be blank. While it may have displayed as blank in the UI it would not actually be blank in the database.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

n/a

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

n/a

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

n/a