### PR TITLE
Fix #2647, don't adjust DateTime.MaxValue

### DIFF
--- a/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
+++ b/RockWeb/Blocks/Finance/ContributionStatementLava.ascx.cs
@@ -390,17 +390,22 @@ namespace RockWeb.Blocks.Finance
             // add detailed pledge information
             foreach ( var pledge in pledges )
             {
-                var adjustedPedgeEndDate = pledge.PledgeEndDate.Value.Date.AddDays( 1 );
+                var adjustedPledgeEndDate = pledge.PledgeEndDate.Value.Date;
                 var statementYearEnd = new DateTime( statementYear + 1, 1, 1 );
-
-                if ( adjustedPedgeEndDate > statementYearEnd )
+                
+                if ( adjustedPledgeEndDate != DateTime.MaxValue.Date )
                 {
-                    adjustedPedgeEndDate = statementYearEnd;
+                    adjustedPledgeEndDate = adjustedPledgeEndDate.AddDays( 1 );
                 }
 
-                if ( adjustedPedgeEndDate > RockDateTime.Now )
+                if ( adjustedPledgeEndDate > statementYearEnd )
                 {
-                    adjustedPedgeEndDate = RockDateTime.Now;
+                    adjustedPledgeEndDate = statementYearEnd;
+                }
+
+                if ( adjustedPledgeEndDate > RockDateTime.Now )
+                {
+                    adjustedPledgeEndDate = RockDateTime.Now;
                 }
 
                 pledge.AmountGiven = new FinancialTransactionDetailService( rockContext ).Queryable()
@@ -408,7 +413,7 @@ namespace RockWeb.Blocks.Finance
                                                  t.AccountId == pledge.AccountId
                                                  && t.Transaction.AuthorizedPersonAliasId.HasValue && personAliasIds.Contains( t.Transaction.AuthorizedPersonAliasId.Value )
                                                  && t.Transaction.TransactionDateTime >= pledge.PledgeStartDate
-                                                 && t.Transaction.TransactionDateTime < adjustedPedgeEndDate )
+                                                 && t.Transaction.TransactionDateTime < adjustedPledgeEndDate )
                                             .Sum( t => ( decimal? ) t.Amount ) ?? 0;
 
                 pledge.AmountRemaining = ( pledge.AmountGiven > pledge.AmountPledged ) ? 0 : ( pledge.AmountPledged - pledge.AmountGiven );


### PR DESCRIPTION
Also fixed spelling of `adjustedPledgeEndDate`

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2647

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the exception-causing code.

## Strategy
_How have you implemented your solution?_

Verified that the date is not the maximum allowed value before adjusting it.

