### PR TITLE
Add Connection Status as a possible Person Field when building Registration Templates

### DIFF
--- a/Rock/Model/Registration.cs
+++ b/Rock/Model/Registration.cs
@@ -1221,6 +1221,7 @@ Registration By: {0} Total Cost/Fees:{1}
                                 dvPhone = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_WORK );
                                 break;
                             }
+                        case RegistrationPersonFieldType.ConnectionStatus: return person.ConnectionStatusValueId;
                     }
 
                     if ( dvPhone != null )
@@ -1393,6 +1394,7 @@ Registration By: {0} Total Cost/Fees:{1}
                         case RegistrationPersonFieldType.Campus:
                         case RegistrationPersonFieldType.MaritalStatus:
                         case RegistrationPersonFieldType.Grade:
+                        case RegistrationPersonFieldType.ConnectionStatus:
                                 return typeof( int? );
 
                         case RegistrationPersonFieldType.Address:

--- a/Rock/Model/RegistrationTemplateFormField.cs
+++ b/Rock/Model/RegistrationTemplateFormField.cs
@@ -318,6 +318,11 @@ namespace Rock.Model
         /// The grade
         /// </summary>
         Grade = 11,
+
+        /// <summary>
+        /// The connection status
+        /// </summary>
+        ConnectionStatus = 12,
     }
 
     #endregion

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -2191,6 +2191,14 @@ namespace RockWeb.Blocks.Event
                                         SavePhone( fieldValue, person, Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_WORK.AsGuid(), personChanges );
                                         break;
                                     }
+
+                                case RegistrationPersonFieldType.ConnectionStatus:
+                                    {
+                                        var newConnectionStatusId = fieldValue.ToString().AsIntegerOrNull() ?? dvcConnectionStatus.Id;
+                                        History.EvaluateChange( personChanges, "Connection Status", DefinedValueCache.GetName( person.ConnectionStatusValueId ), DefinedValueCache.GetName( newConnectionStatusId ) );
+                                        person.ConnectionStatusValueId = newConnectionStatusId;
+                                        break;
+                                    }
                             }
                         }
                     }
@@ -4121,6 +4129,25 @@ namespace RockWeb.Blocks.Event
 
                         break;
                     }
+
+                case RegistrationPersonFieldType.ConnectionStatus:
+                    {
+                        var ddlConnectionStatus = new RockDropDownList();
+                        ddlConnectionStatus.ID = "ddlConnectionStatus";
+                        ddlConnectionStatus.Label = "Connection Status";
+                        ddlConnectionStatus.Required = field.IsRequired;
+                        ddlConnectionStatus.ValidationGroup = BlockValidationGroup;
+                        ddlConnectionStatus.BindToDefinedType( DefinedTypeCache.Read( new Guid( Rock.SystemGuid.DefinedType.PERSON_CONNECTION_STATUS ) ), true );
+
+                        phRegistrantControls.Controls.Add( ddlConnectionStatus );
+
+                        if ( setValue && fieldValue != null )
+                        {
+                            var value = fieldValue.ToString().AsInteger();
+                            ddlConnectionStatus.SetValue( value );
+                        }
+                        break;
+                    }
             }
         }
 
@@ -4441,6 +4468,12 @@ namespace RockWeb.Blocks.Event
                             return phoneNumber;
                         }
                         break;
+                    }
+
+                case RegistrationPersonFieldType.ConnectionStatus:
+                    {
+                        var ddlConnectionStatus = phRegistrantControls.FindControl( "ddlConnectionStatus" ) as RockDropDownList;
+                        return ddlConnectionStatus != null ? ddlConnectionStatus.SelectedValueAsInt() : null;
                     }
             }
 


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Lack of ability to allow registrants to update their connection status.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Grant ability to allow registrants to update their connection status.

## Strategy
_How have you implemented your solution?_

Duplicated the Marital Status person field code to handle the similar Connection Status.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
