### PR TITLE
Update Workflow Trigger actions and logic

### DIFF
--- a/Rock/Model/WorkflowTrigger.cs
+++ b/Rock/Model/WorkflowTrigger.cs
@@ -219,7 +219,12 @@ namespace Rock.Model
         /// <summary>
         /// Immediate Post Save
         /// </summary>
-        ImmediatePostSave = 4
+        ImmediatePostSave = 4,
+
+        /// <summary>
+        /// Post Add
+        /// </summary>
+        PostAdd = 5,
     }
 
     #endregion

--- a/Rock/Workflow/TriggerCache.cs
+++ b/Rock/Workflow/TriggerCache.cs
@@ -77,7 +77,30 @@ namespace Rock.Workflow
         }
 
         /// <summary>
-        /// Triggerses the specified entity type name.
+        /// Gets a collection of Workflow Triggers for the specified criteria.
+        /// </summary>
+        /// <param name="entityTypeName">Name of the entity type.</param>
+        /// <returns></returns>
+        public static List<WorkflowTrigger> Triggers( string entityTypeName )
+        {
+            var triggers = new List<WorkflowTrigger>();
+
+            lock ( obj )
+            {
+                if ( EntityTriggers != null && EntityTriggers.ContainsKey( entityTypeName ) )
+                {
+                    foreach ( var trigger in EntityTriggers[entityTypeName] )
+                    {
+                        triggers.Add( trigger );
+                    }
+                }
+            }
+
+            return triggers;
+        }
+
+        /// <summary>
+        /// Gets a collection of Workflow Triggers for the specified criteria.
         /// </summary>
         /// <param name="entityTypeName">Name of the entity type.</param>
         /// <param name="triggerType">Type of the trigger.</param>

--- a/RockWeb/Blocks/WorkFlow/WorkflowTriggerDetail.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowTriggerDetail.ascx.cs
@@ -209,6 +209,7 @@ namespace RockWeb.Blocks.WorkFlow
             var rockContext = new RockContext();
             WorkflowTriggerService WorkflowTriggerService = new WorkflowTriggerService( rockContext );
             AttributeService attributeService = new AttributeService( rockContext );
+            bool usePreviousValue = false;
 
             int WorkflowTriggerId = int.Parse( hfWorkflowTriggerId.Value );
 
@@ -228,9 +229,20 @@ namespace RockWeb.Blocks.WorkFlow
             workflowTrigger.EntityTypeId = ddlEntityType.SelectedValueAsInt().Value;
             workflowTrigger.EntityTypeQualifierColumn = ddlQualifierColumn.SelectedValue;
 
+            //
+            // If the trigger type is PreSave, PostSave or ImmediatePostSave then we have
+            // a previous value option.
+            //
+            if ( workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PreSave ||
+                workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PostSave ||
+                workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.ImmediatePostSave )
+            {
+                usePreviousValue = true;
+            }
+
             // If the trigger type is PreSave and the tbQualifierValue does not exist,
             // use the previous and alt qualifier value
-            if ( workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PreSave ) 
+            if ( usePreviousValue ) 
             {
                 if ( !string.IsNullOrEmpty( tbQualifierValue.Text ) )
                 {
@@ -305,13 +317,20 @@ namespace RockWeb.Blocks.WorkFlow
         /// <param name="workflowTrigger">The workflow trigger.</param>
         private void ShowQualifierValues( WorkflowTrigger workflowTrigger )
         {
-            bool showPreSave = false;
+            bool usePreviousValue = false;
+            bool showPreviousField = false;
+
             if ( workflowTrigger != null )
             {
-                showPreSave = ( workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PreSave );
-                if ( showPreSave
-                    && ! string.IsNullOrEmpty( workflowTrigger.EntityTypeQualifierValue )
-                    && workflowTrigger.EntityTypeQualifierValue != workflowTrigger.EntityTypeQualifierValuePrevious )
+                if ( workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PreSave ||
+                    workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PostSave ||
+                    workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.ImmediatePostSave )
+                {
+                    usePreviousValue = true;
+                }
+
+                if ( usePreviousValue
+                    && ( !string.IsNullOrEmpty( workflowTrigger.EntityTypeQualifierValue ) || !string.IsNullOrEmpty( workflowTrigger.EntityTypeQualifierValuePrevious ) ) )
                 {
                     tbQualifierValueAlt.Text = workflowTrigger.EntityTypeQualifierValue;
                     tbPreviousQualifierValue.Text = workflowTrigger.EntityTypeQualifierValuePrevious;
@@ -322,7 +341,14 @@ namespace RockWeb.Blocks.WorkFlow
                 }
             }
 
-            if ( rblTriggerType.SelectedValue == ( (int)WorkflowTriggerType.PreSave ).ToStringSafe() || showPreSave )
+            if ( rblTriggerType.SelectedValue == ( ( int ) WorkflowTriggerType.PreSave ).ToStringSafe() ||
+                rblTriggerType.SelectedValue == ( ( int ) WorkflowTriggerType.PostSave ).ToStringSafe() ||
+                rblTriggerType.SelectedValue == ( ( int ) WorkflowTriggerType.ImmediatePostSave ).ToStringSafe() )
+            {
+                showPreviousField = true;
+            }
+
+            if ( showPreviousField || usePreviousValue )
             {
                 tbQualifierValue.Label = "Or value is";
                 tbPreviousQualifierValue.Visible = true;

--- a/RockWeb/Blocks/WorkFlow/WorkflowTriggerList.ascx
+++ b/RockWeb/Blocks/WorkFlow/WorkflowTriggerList.ascx
@@ -18,7 +18,7 @@
                             <Rock:RockBoundField DataField="EntityTypeFriendlyName" HeaderText="Entity" />
                             <Rock:EnumField DataField="WorkflowTriggerType" HeaderText="Type" />
                             <Rock:RockBoundField DataField="EntityTypeQualifierColumn" HeaderText="Qualifier Column" />
-                            <Rock:RockBoundField DataField="EntityTypeQualifierValue" HeaderText="Qualifier Value"  />
+                            <Rock:RockBoundField DataField="EntityTypeQualifierValueFormatted" HeaderText="Qualifier Value" HtmlEncode="false" />
                             <Rock:RockBoundField DataField="WorkflowTypeName" HeaderText="Workflow"  />
                             <Rock:BoolField DataField="IsSystem" HeaderText="System" SortExpression="IsSystem" />
                             <Rock:BoolField DataField="IsActive" HeaderText="Active" SortExpression="IsActive" />

--- a/RockWeb/Blocks/WorkFlow/WorkflowTriggerList.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowTriggerList.ascx.cs
@@ -167,6 +167,7 @@ namespace RockWeb.Blocks.WorkFlow
             }
 
             gWorkflowTrigger.DataSource = triggers
+                .ToList()
                 .OrderBy( w => w.EntityType.Name )
                 .ThenBy( w => w.EntityTypeQualifierColumn )
                 .ThenBy( w => w.EntityTypeQualifierValue ).Select( a =>
@@ -177,12 +178,62 @@ namespace RockWeb.Blocks.WorkFlow
                             a.WorkflowTriggerType,
                             a.EntityTypeQualifierColumn,
                             a.EntityTypeQualifierValue,
+                            a.EntityTypeQualifierValuePrevious,
+                            EntityTypeQualifierValueFormatted = GetFormattedQualifierValue( a ),
                             WorkflowTypeName = a.WorkflowType.Name,
                             a.IsSystem,
                             a.IsActive
                         } ).ToList();
             
             gWorkflowTrigger.DataBind();
+        }
+
+        /// <summary>
+        /// Get a formatted string that represents the qualifier value of the workflow trigger.
+        /// </summary>
+        /// <param name="workflowTrigger">The workflow trigger object.</param>
+        /// <returns>A formatted string that represents the qualifier value of the workflow trigger.</returns>
+        private string GetFormattedQualifierValue( WorkflowTrigger workflowTrigger )
+        {
+            bool usePreviousValue = false;
+            string value;
+
+            if ( workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PreSave ||
+                workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.PostSave ||
+                workflowTrigger.WorkflowTriggerType == WorkflowTriggerType.ImmediatePostSave )
+            {
+                usePreviousValue = true;
+            }
+
+            if ( usePreviousValue
+                && (!string.IsNullOrEmpty( workflowTrigger.EntityTypeQualifierValue ) || !string.IsNullOrEmpty( workflowTrigger.EntityTypeQualifierValuePrevious ) ) )
+            {
+                if ( !string.IsNullOrWhiteSpace( workflowTrigger.EntityTypeQualifierValuePrevious ) )
+                {
+                    value = workflowTrigger.EntityTypeQualifierValuePrevious.EncodeHtml();
+                }
+                else
+                {
+                    value = "<i>Any value</i>";
+                }
+
+                value += " <i class='fa fa-angle-double-right'></i> ";
+
+                if ( !string.IsNullOrWhiteSpace( workflowTrigger.EntityTypeQualifierValue ) )
+                {
+                    value += workflowTrigger.EntityTypeQualifierValue.EncodeHtml();
+                }
+                else
+                {
+                    value += "<i>Any value</i>";
+                }
+            }
+            else
+            {
+                value = workflowTrigger.EntityTypeQualifierValue.EncodeHtml();
+            }
+
+            return value;
         }
 
         #endregion


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2369, #2667, #2671.

1. Inability to use "did value change in any way" logic on pre-save actions.
2. Inability to use "did value change" logic on post-save actions.
3. Inability to have a trigger only run when an entity is added (as opposed to anytime it is saved).
4. Qualifier check logic not consistent between pre-save and post-save.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Resolve those items.

## Strategy
_How have you implemented your solution?_

1. If no previous value or current value are specified in the trigger configuration it is treated as a "did it change in any way" check.
2. Temporarily store the previous values during a Modified entity save operation to be used with the post-save action for comparing the values. This code has been benchmarked and adds <1ms extra processing time to a Save operation.
3. Add new Post-Add trigger type.
4. Synchronize the logic between the pre-save and post-save. This changes the post-save logic to now only trigger when the qualified value has actually changed, whereas before it would trigger on each save even if it didn't change.

Also updated the UI of the "Workflow Trigger List" block to indicate when  "changed from to" value is in effect as that was previously hidden information. (See screenshot below)

Possible "changed from to" value formats are
* _Any value_ >> **NewValue**
* **OldValue** >> **NewValue**
* **OldValue** >> _Any value_

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

Workflow triggers setup as Post-Save or Immediate-Post-Save with a qualifier column and value specified that were **intentionally** setup to run every time even if the value did not change will no longer run on every save. Now they will only run if the value actually changed.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![screen shot 2018-01-17 at 5 43 06 pm](https://user-images.githubusercontent.com/1119863/35111486-3c9be8ce-fc30-11e7-8131-1bbc051af860.png)

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.