### PR TITLE
Improved Baptism Following Event to support N years after date anniversary reminders

### DIFF
--- a/Rock/Follow/Event/PersonBaptized.cs
+++ b/Rock/Follow/Event/PersonBaptized.cs
@@ -34,6 +34,7 @@ namespace Rock.Follow.Event
     [ExportMetadata( "ComponentName", "PersonBaptized" )]
 
     [IntegerField( "Max Days Back", "Maximum number of days back to consider", false, 30, "", 0)]
+    [IntegerField( "Anniversary Count", "The anniversary number that this event will trigger on. If you want to catch the 5th anniversary of the person being baptized set this to 5.", false, 0, order: 1 )]
     public class PersonBaptized : EventComponent
     {
         #region Event Component Implementation
@@ -79,13 +80,15 @@ namespace Rock.Follow.Event
                     if ( baptismDate.HasValue )
                     {
                         int daysBack = GetAttributeValue( followingEvent, "MaxDaysBack" ).AsInteger();
-                        var processDate = RockDateTime.Today;
+                        int anniversaryCount = GetAttributeValue( followingEvent, "AnniversaryCount" ).AsIntegerOrNull() ?? 0;
+                        var processDate = RockDateTime.Today.AddYears( -anniversaryCount );
                         if ( !followingEvent.SendOnWeekends && RockDateTime.Today.DayOfWeek == DayOfWeek.Friday )
                         {
                             daysBack += 2;
                         }
 
-                        if ( processDate.Subtract( baptismDate.Value ).Days < daysBack )
+                        var daysSince = processDate.Subtract( baptismDate.Value ).Days;
+                        if ( daysSince >= 0 && daysSince < daysBack )
                         {
                             return true;
                         }


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2612. Desired to have the ability to receive following reminders when somebody was baptized N years ago, such as a 5th anniversary.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Add support to the Following job for this feature.

## Strategy
_How have you implemented your solution?_

Added new "anniversary count" configuration field to indicate how many years after the event to trigger on.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
