### PR TITLE
Fixed ability to link Registration Instance to existing Calendar Item.

### DIFF
--- a/Rock/Web/UI/Controls/ModalDialog.cs
+++ b/Rock/Web/UI/Controls/ModalDialog.cs
@@ -402,6 +402,10 @@ namespace Rock.Web.UI.Controls
             {
                 _cancelLink.InnerText = "OK";
             }
+            else
+            {
+                _cancelLink.InnerText = "Cancel";
+            }
 
             base.OnPreRender( e );
         }

--- a/RockWeb/Blocks/Event/RegistrationInstanceLinkageDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationInstanceLinkageDetail.ascx
@@ -78,7 +78,7 @@
                             DataTextField="Name" DataValueField="Id" AutoPostBack="true" OnSelectedIndexChanged="ddlCalendarItem_SelectedIndexChanged" EnhanceForLongLists="true" />
                     </div>
                     <div class="col-md-6">
-                        <Rock:RockDropDownList ID="ddlCalendarItemOccurrence" runat="server" Label="Campus" Required="true" ValidationGroup="DlgPage3"
+                        <Rock:RockDropDownList ID="ddlCalendarItemOccurrence" runat="server" Label="Occurrence" Required="true" ValidationGroup="DlgPage3"
                             DataTextField="Name" DataValueField="Id"  />
                     </div>
                 </div>

--- a/RockWeb/Blocks/Event/RegistrationInstanceLinkageDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceLinkageDetail.ascx.cs
@@ -359,20 +359,31 @@ namespace RockWeb.Blocks.Event
                     ddlCalendarItemOccurrence.DataSource = new EventItemOccurrenceService( rockContext )
                         .Queryable().AsNoTracking()
                         .Where( c => c.EventItemId == eventItemId.Value )
+                        .ToList()
                         .Select( c => new
                         {
-                            Id = c.Id,
-                            Name = c.Campus != null ? c.Campus.Name : "All Campuses",
+                            c.Id,
+                            c.NextStartDateTime,
+                            Campus = c.Campus != null ? c.Campus.Name : "All Campuses",
                             Order = c.CampusId.HasValue ? 1 : 0
                         } )
+                        .Select( c => new
+                        {
+                            c.Id,
+                            c.NextStartDateTime,
+                            c.Campus,
+                            Name = c.NextStartDateTime.HasValue ? string.Format( "{0} - {1}", c.Campus, c.NextStartDateTime.Value.ToShortDateTimeString() ) : c.Campus,
+                            c.Order
+                        } )
                         .OrderBy( c => c.Order )
-                        .ThenBy( c => c.Name )
+                        .ThenBy( c => c.Campus )
+                        .ThenBy( c => c.NextStartDateTime ?? DateTime.MinValue )
                         .ToList();
                     ddlCalendarItemOccurrence.DataBind();
 
-                    if ( ddlCalendarItem.Items.Count > 0 )
+                    if ( ddlCalendarItemOccurrence.Items.Count > 0 )
                     {
-                        ddlCalendarItem.SelectedIndex = 0;
+                        ddlCalendarItemOccurrence.SelectedIndex = 0;
                     }
                 }
             }


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2624. The dialog on the Registration Instance screen to link to an existing Calendar Item was broken and did not work.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Make it work as one might expect.

## Strategy
_How have you implemented your solution?_

1. Fix the Calendar Item drop down to not reset itself.
2. Updated the display and sorting on the Occurrence drop down to be more useful and show the campus name and the next start datetime of the occurrence. Sorting is now done by "All Campuses" first, then by Campus Name, then by NextStartDateTime.
3. Fixed a bug in Modal Dialog in that it would not reset the Cancel button text after changing it to OK. This would come up in this context when the dialog is first displayed with no Save button, which causes the cancel button text to be come "OK". Then if the dialog is displayed again during the same pageview session WITH a Save button, the cancel button still contained the "OK" text.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

Second screenshot is for comparison and shows the related event item occurrences.

<img alt="2018-01-19 14_04_39-virtualbox" src="https://user-images.githubusercontent.com/1119863/35174064-d4b06052-fd22-11e7-8b72-8a72776d0a45.png">

<img alt="2018-01-19 14_05_09-virtualbox" src="https://user-
images.githubusercontent.com/1119863/35174065-d4cc6086-fd22-11e7-8b57-aa508ebca313.png">

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
