### PR TITLE
Fixed available spelling on Set Available Schedules workflow

### DIFF
--- a/Rock/Workflow/Action/CheckIn/SetAvailableSchedules.cs
+++ b/Rock/Workflow/Action/CheckIn/SetAvailableSchedules.cs
@@ -30,7 +30,7 @@ namespace Rock.Workflow.Action.CheckIn
     /// Removes (or excludes) any locations that are not active
     /// </summary>
     [ActionCategory( "Check-In" )]
-    [Description( "Sets the avialable schedules for each grouptype, group, and location" )]
+    [Description( "Sets the available schedules for each grouptype, group, and location" )]
     [Export( typeof( ActionComponent ) )]
     [ExportMetadata( "ComponentName", "Set Available Schedules" )]
 


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Fix spelling on Set Available Schedules workflow description. To `Sets the available schedules for each grouptype, group, and location`

## Goal
Fix

## Strategy
N/A

## Tests
N/A

## Possible Implications
N/A

## Screenshots
N/A

## Documentation
N/A

## Migrations
N/A