### PR TITLE
Fixed spelling on github contributing & PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -168,9 +168,9 @@ If you want to read about using Rock or developing plugins for Rock, the [Rock D
 ### Pull Requests
 The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
 on your part and review time on ours, we have implemented the following guidelines for PRs:
-1. If you are submitting a PR for a logged Issue / Enchancement request please reference it in your commit (Fixes #1234 or Closes #2445)
-2. If your PR is for an enchancment that has not been discussed and approved by the core team please get that approval BEFORE submitting
-the request. In fact, this approval should be recieved before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.
+1. If you are submitting a PR for a logged Issue / Enhancement request please reference it in your commit (Fixes #1234 or Closes #2445)
+2. If your PR is for an enhancement that has not been discussed and approved by the core team please get that approval BEFORE submitting
+the request. In fact, this approval should be received before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.
 
 #### Keep In Mind The Following
 * When making changes keep the changes simple (i.e. don't refactor boldly) otherwise the git diff will obscure your change and make it difficult to quickly see the actual change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 # Rock PR Policy
 The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
 on your part and review time on ours, we have implemented the following guidelines for PRs:
-1. If you are submitting a PR for a logged Issue / Enchancement request please reference it in your commit
-2. If your PR is for an enchancment that has not been discussed and approved by the core team please get that approval BEFORE submitting
-the request. In fact, this approval should be recieved before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.
+1. If you are submitting a PR for a logged Issue / Enhancement request please reference it in your commit
+2. If your PR is for an enhancement that has not been discussed and approved by the core team please get that approval BEFORE submitting
+the request. In fact, this approval should be received before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.
 
 
 ## Contributor Agreement


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Fix spelling errors on contributing guide and pull request template.

## Goal
📝 👍 

## Strategy
N/A

## Tests
N/A

## Possible Implications
N/A

## Screenshots
N/A

## Documentation
N/A

## Migrations
N/A
