### PR TITLE
- Added link to Report Detail Data View link instead of OnClick JS

### DIFF
--- a/RockWeb/Blocks/Reporting/ReportDetail.ascx
+++ b/RockWeb/Blocks/Reporting/ReportDetail.ascx
@@ -99,7 +99,7 @@
                                 <Rock:ModalAlert ID="mdDeleteWarning" runat="server" />
                                 <asp:LinkButton ID="btnDelete" runat="server" Text="Delete" CssClass="btn btn-link" OnClick="btnDelete_Click" />
                                 <div class="pull-right">
-                                    <asp:LinkButton ID="lbDataView" runat="server" Text="Data View" CssClass="btn btn-link" OnClick="lbDataView_Click" />
+                                    <asp:HyperLink ID="lbDataView" runat="server" Text="Data View" CssClass="btn btn-link" />
                                     <asp:LinkButton ID="btnCopy" runat="server" Tooltip="Copy Report" CssClass="btn btn-default btn-sm fa fa-clone" OnClick="btnCopy_Click" />
                                     <Rock:SecurityButton ID="btnSecurity" runat="server" class="btn btn-sm btn-security" />
                                 </div>

--- a/RockWeb/Blocks/Reporting/ReportDetail.ascx.cs
+++ b/RockWeb/Blocks/Reporting/ReportDetail.ascx.cs
@@ -368,18 +368,6 @@ namespace RockWeb.Blocks.Reporting
             this.ShowResults = !this.ShowResults;
         }
 
-        protected void lbDataView_Click( object sender, EventArgs e )
-        {
-            var rockContext = new RockContext();
-            var reportService = new ReportService( rockContext );
-            var report = reportService.Get( hfReportId.Value.AsInteger() );
-
-            if ( report != null && report.DataViewId.HasValue )
-            {
-                NavigateToLinkedPage( "DataViewPage", "DataViewId", report.DataViewId.Value );
-            }
-        }
-
         #region Edit Events
 
         /// <summary>
@@ -1123,6 +1111,11 @@ namespace RockWeb.Blocks.Reporting
             if ( report.DataView != null )
             {
                 lbDataView.Visible = UserCanEdit;
+
+                var queryParams = new Dictionary<string, string>();
+                queryParams.Add("DataViewId", report.DataViewId.ToString());
+                lbDataView.NavigateUrl = LinkedPageUrl("DataViewPage", queryParams);
+
                 lbDataView.ToolTip = report.DataView.Name;
             }
             else


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Not being able to right hand click a link or open a link in a new tab is a bummer. This PR takes the Data View link contained on the Report Detail block and allows right clicking by moving the link from a `OnClick` JS event to a href.

## Goal
Fully functional, right clickable link.

## Strategy
Remove `OnClick` change `asp:LinkButton` to `asp:HyperLink`

## Tests
N/A

## Possible Implications
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/374209/35303042-7b591870-0045-11e8-96da-5bad85f485a7.png)
Changes `Data View` link on lower right side

## Documentation
N/A

## Migrations
N/A
