### PR TITLE
- Added the ability to view unlisted phone numbers in person merge block

### DIFF
--- a/RockWeb/Blocks/Crm/PersonMerge.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonMerge.ascx.cs
@@ -981,7 +981,14 @@ validity of the request before completing this merge." :
                     var phoneNumber = person.PhoneNumbers.Where( p => p.NumberTypeValueId == phoneType.Id ).FirstOrDefault();
                     if ( phoneNumber != null )
                     {
-                        AddProperty( key, phoneType.Value, person.Id, phoneNumber.Number, phoneNumber.ToString() );
+                        if (phoneNumber.IsUnlisted)
+                        {
+                            AddProperty(key, phoneType.Value, person.Id, phoneNumber.Number, phoneNumber.NumberFormatted + " <em>(Unlisted)</em>");
+                        }
+                        else
+                        {
+                            AddProperty(key, phoneType.Value, person.Id, phoneNumber.Number, phoneNumber.NumberFormatted);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Issue #2174, when merging a listed and unlisted phone number the unlisted number always shows `Unlisted`. Making it difficult to determine the winning record.

## Goal
When a number is unlisted, use number formatted and _(Unlisted)_ i.e. `(559) 555-5555 <em>(Unlisted)</em>`

## Strategy
If statement that looks for unlisted.

## Tests
N/A

## Possible Implications
N/A

## Screenshots
<img width="1280" alt="screen shot 2018-01-23 at 2 50 55 pm" src="https://user-images.githubusercontent.com/374209/35305670-0751eac4-004f-11e8-8048-43a9fae5065a.png">
_Ignore the { typo, fixed in commit 🙃 _

## Documentation
N/A

## Migrations
N/A
