### PR TITLE
- Fix grades not working outside of en-US culture

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -2293,12 +2293,7 @@ namespace Rock.Model
         {
             if (gradeOffset.HasValue && gradeOffset.Value >= 0)
             {
-                var globalAttributes = GlobalAttributesCache.Read();
-                var transitionDate = globalAttributes.GetValue("GradeTransitionDate").AsDateTime() ?? new DateTime( RockDateTime.Today.Year, 6, 1 );
-                transitionDate = new DateTime( RockDateTime.Today.Year, transitionDate.Month, transitionDate.Day );
-
-                int gradeOffsetAdjustment = (RockDateTime.Now.Date < transitionDate) ? gradeOffset.Value : gradeOffset.Value + 1;
-                return transitionDate.Year + gradeOffsetAdjustment;
+                return GlobalAttributesCache.Read().CurrentGraduationYear + gradeOffset.Value;
             }
 
             return null;

--- a/Rock/Reporting/DataFilter/Person/GradeFilter.cs
+++ b/Rock/Reporting/DataFilter/Person/GradeFilter.cs
@@ -260,7 +260,9 @@ function() {{
         /// <returns></returns>
         public override Expression GetExpression( Type entityType, IService serviceInstance, ParameterExpression parameterExpression, string selection )
         {
-            // GradeTransitionDate is stored as just MM/DD so it'll resolve to the current year
+            /* GradeTransitionDate is stored as just MM/DD and as such .AsDateTime() will resolve differently depending on culture.
+             * To do this accurately we should use DateTime.TryParseExact but for this case we only care about if there is a date or not
+             */
             DateTime? gradeTransitionDate = GlobalAttributesCache.Read().GetValue( "GradeTransitionDate" ).AsDateTime();
 
             var values = selection.Split( '|' );
@@ -272,14 +274,7 @@ function() {{
 
             var personGradeQuery = new PersonService( (RockContext)serviceInstance.Context ).Queryable();
 
-            // if the next MM/DD of a graduation isn't until next year, treat next year as the current school year
-            int currentYearAdjustor = 0;
-            if ( gradeTransitionDate.HasValue && !( RockDateTime.Now < gradeTransitionDate ) )
-            {
-                currentYearAdjustor = 1;
-            }
-
-            int currentSchoolYear = RockDateTime.Now.AddYears( currentYearAdjustor ).Year;
+            int currentSchoolYear = GlobalAttributesCache.Read().CurrentGraduationYear;
 
             if ( gradeTransitionDate.HasValue && gradeOffset.HasValue )
             {

--- a/Rock/Web/Cache/GlobalAttributesCache.cs
+++ b/Rock/Web/Cache/GlobalAttributesCache.cs
@@ -465,6 +465,26 @@ namespace Rock.Web.Cache
         }
 
         /// <summary>
+        /// Parses the grade transition date to return a culture independent representation
+        /// </summary>
+        /// <value>
+        /// Returns a date comprised of: the grade transition month, the grade transition day, and the current year
+        /// </value>
+        private DateTime ParseFormattedTransitionDate()
+        {
+            var formattedTransitionDate = GetValue( "GradeTransitionDate" ) + "/" + RockDateTime.Today.Year;
+            DateTime transitionDate;
+
+            // Check Date Validity
+            if ( !DateTime.TryParseExact( formattedTransitionDate, new[] { "MM/dd/yyyy", "M/dd/yyyy", "M/d/yyyy", "MM/d/yyyy" }, CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces, out transitionDate ) )
+            {
+                transitionDate = new DateTime( RockDateTime.Today.Year, 6, 1 );
+            }
+            return transitionDate;
+        }
+
+        /// <summary>
         /// Gets the current graduation year based on grade transition date
         /// </summary>
         /// <value>
@@ -474,18 +494,26 @@ namespace Rock.Web.Cache
         {
             get
             {
-                var formattedTransitionDate = GetValue( "GradeTransitionDate" ) + "/" + RockDateTime.Today.Year;
-                DateTime transitionDate;
-
-                // Check Date Validity
-                if ( !DateTime.TryParseExact( formattedTransitionDate, new[] { "MM/dd/yyyy", "M/dd/yyyy", "M/d/yyyy", "MM/d/yyyy" }, CultureInfo.InvariantCulture,
-                    DateTimeStyles.AllowWhiteSpaces, out transitionDate ) )
-                {
-                    transitionDate = new DateTime( RockDateTime.Today.Year, 6, 1 );
-                }
+                DateTime transitionDate = ParseFormattedTransitionDate();
                 return RockDateTime.Now.Date < transitionDate ? transitionDate.Year : transitionDate.Year + 1;
             }
         }
+
+        /// <summary>
+        /// Gets the current graduation date based on grade transition date
+        /// </summary>
+        /// <value>
+        /// Returns a date with the grade transition day and month as well as the current year if transition month/day has not passed, else next year
+        /// </value>
+        public DateTime CurrentGraduationDate
+        {
+            get
+            {
+                DateTime transitionDate = ParseFormattedTransitionDate();
+                return new DateTime( RockDateTime.Now.Date < transitionDate ? transitionDate.Year : transitionDate.Year + 1, transitionDate.Month, transitionDate.Day );
+            }
+        }
+
         /// <summary>
         /// Gets the organization location (OrganizationAddress)
         /// </summary>

--- a/Rock/Web/UI/Controls/Pickers/GradePicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/GradePicker.cs
@@ -143,7 +143,8 @@ namespace Rock.Web.UI.Controls
         /// <returns></returns>
         public string GetJavascriptForYearPicker( YearPicker ypGraduationYear)
         {
-            DateTime gradeTransitionDate = GlobalAttributesCache.Read().GetValue( "GradeTransitionDate" ).AsDateTime() ?? new DateTime( RockDateTime.Now.Year, 6, 1 );
+            DateTime currentTransitionDate = GlobalAttributesCache.Read().CurrentGraduationDate;
+            DateTime gradeTransitionDate = new DateTime(RockDateTime.Now.Year, currentTransitionDate.Month, currentTransitionDate.Day);
 
             // add a year if the next graduation mm/dd won't happen until next year
             int gradeOffsetRefactor = ( RockDateTime.Now < gradeTransitionDate ) ? 0 : 1;


### PR DESCRIPTION
Separate ParsingGradeTransition logic
Add GlobalAttributeCache property "CurrentGraduationDate", replace all uses of GlobalAttributeCache.GetValue("GradeTransitionDate") with a GlobalAttributeCache property

## Context
Rock has historically not displayed grades correctly in client cultures that have a different format different from `MM/dd/yyyy` such as en-GB. In #2317 I fixed the `GlobalAttributeCache.CurrentGraduationDate ` to parse the `GradeTransitionDate` correctly however there are other places that manually read the `GradeTransitionDate` to calculate grade offsets - i.e. the GradeFilter, GradePicker, and a PersonProperty. This behaviour became apparent as the year rolled over.

## Goal
 This PR ensures that the grade offset is calculated independent of client culture in places I missed in #2317. 

## Strategy
Much of the code that was affected seemed to be repeating the pattern of calculating whether the transition date is this year or next year so I've added a  `CurrentGraduationDate` property to the GlobalAttributesCache which represents the date of the next graduation date. This simplifies the code elsewhere by a fairly significant margin.

## Areas In Need of Refactor
`GradePicker.GetJavascriptForYearPicker()` can be simplified as a result of the `CurrentGraduationDate` property.

## Possible Implications
This PR is compatible with the v6 branch.
