### PR TITLE
- Added missing access key shortcuts on save and cancel buttons

### DIFF
--- a/RockWeb/Blocks/Administration/Pages.ascx
+++ b/RockWeb/Blocks/Administration/Pages.ascx
@@ -41,8 +41,8 @@
             </fieldset>
 
             <div class="actions">
-                <asp:LinkButton ID="lbSave" runat="server" Text="Add" CssClass="btn btn-primary" onclick="lbSave_Click" />
-                <asp:LinkButton id="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" OnClick="lbCancel_Click" CausesValidation="false" />
+                <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Add" CssClass="btn btn-primary" onclick="lbSave_Click" />
+                <asp:LinkButton id="lbCancel" runat="server"  AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" OnClick="lbCancel_Click" CausesValidation="false" />
             </div>
 
         </asp:Panel>

--- a/RockWeb/Blocks/Cms/ContentChannelDetail.ascx
+++ b/RockWeb/Blocks/Cms/ContentChannelDetail.ascx
@@ -112,8 +112,8 @@
                     </Rock:PanelWidget>
 
                     <div class="actions">
-                        <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                        <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                        <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                        <asp:LinkButton ID="lbCancel" runat="server"  AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
                     </div>
 
                 </div>

--- a/RockWeb/Blocks/Cms/ContentChannelTypeDetail.ascx
+++ b/RockWeb/Blocks/Cms/ContentChannelTypeDetail.ascx
@@ -97,8 +97,8 @@
                 </Rock:PanelWidget>
 
                 <div class="actions">
-                    <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                    <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                    <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                    <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
                 </div>
 
             </div>

--- a/RockWeb/Blocks/Finance/BatchDetail.ascx
+++ b/RockWeb/Blocks/Finance/BatchDetail.ascx
@@ -53,8 +53,8 @@
                     </div>
 
                     <div class="actions">
-                        <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                        <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                        <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                        <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
                     </div>
                 </div>
 

--- a/RockWeb/Blocks/Finance/BenevolenceRequestDetail.ascx
+++ b/RockWeb/Blocks/Finance/BenevolenceRequestDetail.ascx
@@ -116,8 +116,8 @@
                     </Rock:Grid>
                 </Rock:PanelWidget>
 
-                <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
                 <asp:LinkButton ID="lbPrint" runat="server" Text="<i class='fa fa-print'></i>" CssClass="btn btn-sm btn-default pull-right" OnClick="lbPrint_Click" />
             </div>
 

--- a/RockWeb/Blocks/Prayer/PrayerCommentDetail.ascx
+++ b/RockWeb/Blocks/Prayer/PrayerCommentDetail.ascx
@@ -45,8 +45,8 @@
                                     </div>
                                 </div>
                                 <div class="actions">
-                                    <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                                    <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-default" CausesValidation="false" OnClick="lbCancel_Click" />
+                                    <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                                    <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-default" CausesValidation="false" OnClick="lbCancel_Click" />
                                 </div>
                         </div>
 

--- a/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx
+++ b/RockWeb/Blocks/Security/BackgroundCheck/ProtectMyMinistrySettings.ascx
@@ -72,8 +72,8 @@
                         </div>
                     </div>
                     <div class="actions">
-                        <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                        <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                        <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                        <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
                     </div>
                 </div>
 

--- a/RockWeb/Blocks/Security/RestKeyDetail.ascx
+++ b/RockWeb/Blocks/Security/RestKeyDetail.ascx
@@ -52,8 +52,8 @@
                         <div class="col-md-12"></div>
                     </div>
                     <div class="actions">
-                        <asp:LinkButton ID="lbSave" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
-                        <asp:LinkButton ID="lbCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                        <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
+                        <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
                     </div>
                 </div>
 


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
#2708, the batch detail block and a few other blocks were missing access key shortcuts on the save and cancel buttons

## Goal
Add access keys to save and cancel buttons.

## Strategy
`Alt+s & Alt+c`

## Tests
N/A

## Possible Implications
N/A

## Screenshots
N/A

## Documentation
N/A

## Migrations
N/A
