### PR TITLE
Added 'Days To Anniversary' to person report fields

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -1238,6 +1238,39 @@ namespace Rock.Model
                 return null;
             }
         }
+        
+        /// <summary>
+        /// Gets the number of days until the Person's anniversary.
+        /// </summary>
+        /// <value>
+        /// A <see cref="System.Int32"/> representing the number of days until the Person's anniversary. If the person's anniversary is not available returns Int.MaxValue
+        /// </value>
+        [DataMember]
+        [NotMapped]
+        public virtual int DaysToAnniversary
+        {
+            get
+            {
+                if ( AnniversaryDate.HasValue )
+                {
+                    var today = RockDateTime.Today;
+                    var nextAnniversary = RockDateTime.New( today.Year, AnniversaryDate.Value.Month, AnniversaryDate.Value.Day );
+                    if ( nextAnniversary.HasValue && nextAnniversary.Value.CompareTo( today ) < 0 )
+                    {
+                        nextAnniversary = RockDateTime.New( today.Year + 1, AnniversaryDate.Value.Month, AnniversaryDate.Value.Day );
+                    }
+                    
+                    return Convert.ToInt32( nextAnniversary.Subtract( today ).TotalDays );
+                }
+
+                return Int.MaxValue;
+            }
+            private set
+            {
+                // intentionally blank
+            }
+
+        }
 
         /// <summary>
         /// Gets the next anniversary.


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Issue #662. Chose against adding lava hooks since date differences can be calculated in lava and are less likely to be used.

## Goal
Replicate `DaysToBirthday` for anniversary

## Strategy
Mash up `DaysToBirthday` and `NextAnniversary` code

## Tests
N/A

## Possible Implications
N/A

## Screenshots
N/A

## Documentation
Might want to mention anywhere `Days To Birthday` is.

## Migrations
N/A
