### PR TITLE
+ Updated scheduled transaction list lava to include card number

### DIFF
--- a/RockWeb/Blocks/Finance/ScheduledTransactionListLiquid.ascx.cs
+++ b/RockWeb/Blocks/Finance/ScheduledTransactionListLiquid.ascx.cs
@@ -161,6 +161,7 @@ namespace RockWeb.Blocks.Finance
                 scheduleSummary.Add( "PersonName", transactionSchedule.AuthorizedPersonAlias != null && transactionSchedule.AuthorizedPersonAlias.Person != null ? transactionSchedule.AuthorizedPersonAlias.Person.FullName : "" );
                 scheduleSummary.Add( "CurrencyType", ( transactionSchedule.FinancialPaymentDetail != null && transactionSchedule.FinancialPaymentDetail.CurrencyTypeValue != null ) ? transactionSchedule.FinancialPaymentDetail.CurrencyTypeValue.Value : ""  );
                 scheduleSummary.Add( "CreditCardType", ( transactionSchedule.FinancialPaymentDetail != null && transactionSchedule.FinancialPaymentDetail.CreditCardTypeValue != null) ? transactionSchedule.FinancialPaymentDetail.CreditCardTypeValue.Value : "" );
+                scheduleSummary.Add( "AccountNumberMasked", ( transactionSchedule.FinancialPaymentDetail != null && transactionSchedule.FinancialPaymentDetail.AccountNumberMaskedValue != null) ? transactionSchedule.FinancialPaymentDetail.AccountNumberMaskedValue.Value : "" );
                 scheduleSummary.Add( "UrlEncryptedKey", transactionSchedule.UrlEncodedKey );
                 scheduleSummary.Add( "Frequency", transactionSchedule.TransactionFrequencyValue.Value );
                 scheduleSummary.Add( "FrequencyDescription", transactionSchedule.TransactionFrequencyValue.Description );

--- a/RockWeb/Themes/Flat/Assets/Lava/ScheduledTransactionListLiquid.lava
+++ b/RockWeb/Themes/Flat/Assets/Lava/ScheduledTransactionListLiquid.lava
@@ -1,8 +1,13 @@
 <div class="scheduledtransaction-summary">
-    ${{ ScheduledTransaction.ScheduledAmount }} on {{ ScheduledTransaction.CurrencyType }}
-    {{ ScheduledTransaction.FrequencyDescription | downcase }}. 
-     
-    {% if ScheduledTransaction.NextPaymentDate != null %}
-        Next gift will be on {{ ScheduledTransaction.NextPaymentDate | Date:"MMMM d, yyyy" }}.
-    {% endif %}
+  {{ ScheduledTransaction.ScheduledAmount | FormatAsCurrency }} on 
+  {% if ScheduledTransaction.CurrencyType != "Credit Card" %}
+  {{ ScheduledTransaction.CurrencyType }}
+  {% else %}
+  {{ ScheduledTransaction.CreditCardType }} {{ ScheduledTransaction.AccountNumberMasked }}
+  {% endif %}<br>
+  {{ ScheduledTransaction.FrequencyDescription | downcase }}.
+
+  {% if ScheduledTransaction.NextPaymentDate != null %}
+  Next gift will be on {{ ScheduledTransaction.NextPaymentDate | Date:"MMMM d, yyyy" }}.
+  {% endif %}
 </div>

--- a/RockWeb/Themes/Stark/Assets/Lava/ScheduledTransactionListLiquid.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/ScheduledTransactionListLiquid.lava
@@ -1,6 +1,11 @@
 <div class="scheduledtransaction-summary">
   <strong>{{ ScheduledTransaction.PersonName }}</strong><br/>
-  ${{ ScheduledTransaction.ScheduledAmount }} on {{ ScheduledTransaction.CurrencyType }}
+  {{ ScheduledTransaction.ScheduledAmount | FormatAsCurrency }} on 
+  {% if ScheduledTransaction.CurrencyType != "Credit Card" %}
+  {{ ScheduledTransaction.CurrencyType }}
+  {% else %}
+  {{ ScheduledTransaction.CreditCardType }} {{ ScheduledTransaction.AccountNumberMasked }}
+  {% endif %}<br>
   {{ ScheduledTransaction.FrequencyDescription | downcase }}.
 
   {% if ScheduledTransaction.NextPaymentDate != null %}


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
People are confused about what card is being used for a scheduled transaction. If the transaction uses a credit card renders a descriptive: `{{ ScheduledTransaction.CreditCardType }} {{ ScheduledTransaction.AccountNumberMasked }}` instead of `Credit Card`

## Goal
Provide a liquid tag inside the scheduled transaction list lava block. Also change the currency tag to be internationalized. (Templates previously used `$`)

## Strategy
_How have you implemented your solution?_

## Tests
N/A

## Possible Implications
The `AccountNumberMasked` could show unmasked account numbers if the migration masking NMI cards never ran.

## Screenshots
N/A

## Documentation
N/A

## Migrations
N//A
