### PR TITLE
Slingshot: Fix EF error on location import

### DIFF
--- a/Rock.Slingshot/BulkImport/BulkImportHelper.cs
+++ b/Rock.Slingshot/BulkImport/BulkImportHelper.cs
@@ -1146,8 +1146,8 @@ WHERE gta.GroupTypeId IS NULL" );
 
                     Location location = new Location();
 
-                    location.Street1 = address.Street1;
-                    location.Street2 = address.Street2;
+                    location.Street1 = address.Street1.Truncate( 50 );
+                    location.Street2 = address.Street2.Truncate( 50 );
                     location.City = address.City;
                     location.County = address.County;
                     location.State = address.State;

--- a/Rock.Slingshot/BulkImport/BulkImportHelper.cs
+++ b/Rock.Slingshot/BulkImport/BulkImportHelper.cs
@@ -17,7 +17,7 @@ using Rock.Web.Cache;
 namespace Rock.Slingshot
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class BulkImporter
     {
@@ -53,7 +53,7 @@ namespace Rock.Slingshot
         public OnProgressEvent OnProgress;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public enum ImportUpdateType
         {
@@ -261,7 +261,6 @@ namespace Rock.Slingshot
                 tableList.Add( "Campus" );
             }
 
-
             if ( new FinancialAccountService( rockContext ).Queryable().Any( a => a.ForeignId.HasValue && a.ForeignKey == foreignSystemKey ) )
             {
                 tableList.Add( "Financial Account" );
@@ -313,7 +312,6 @@ namespace Rock.Slingshot
             {
                 tableList.Add( "Location" );
             }
-
 
             if ( new NoteService( rockContext ).Queryable().Any( a => a.ForeignId.HasValue && a.ForeignKey == foreignSystemKey ) )
             {
@@ -415,9 +413,11 @@ namespace Rock.Slingshot
                     case FinancialBatchImport.BatchStatus.Closed:
                         financialBatch.Status = BatchStatus.Closed;
                         break;
+
                     case FinancialBatchImport.BatchStatus.Open:
                         financialBatch.Status = BatchStatus.Open;
                         break;
+
                     case FinancialBatchImport.BatchStatus.Pending:
                         financialBatch.Status = BatchStatus.Pending;
                         break;
@@ -690,7 +690,7 @@ namespace Rock.Slingshot
 
                 foreach ( var groupMemberImport in groupWithMembers.GroupMemberImports )
                 {
-                    var groupRoleId = groupTypeRoleLookup.GetValueOrNull(groupMemberImport.RoleName);
+                    var groupRoleId = groupTypeRoleLookup.GetValueOrNull( groupMemberImport.RoleName );
                     var personId = personIdLookup.GetValueOrNull( groupMemberImport.PersonForeignId );
                     if ( groupId.HasValue && groupRoleId.HasValue && personId.HasValue )
                     {
@@ -1219,22 +1219,22 @@ WHERE gta.GroupTypeId IS NULL" );
             {
                 // manually update ValueAsDateTime since the tgrAttributeValue_InsertUpdate trigger won't fire during when using BulkInsert
                 var rowsUpdated = rockContext.Database.ExecuteSqlCommand( @"
-UPDATE [AttributeValue] SET ValueAsDateTime = 
-		CASE WHEN 
-			LEN(value) < 50 and 
-			ISNULL(value,'') != '' and 
+UPDATE [AttributeValue] SET ValueAsDateTime =
+		CASE WHEN
+			LEN(value) < 50 and
+			ISNULL(value,'') != '' and
 			ISNUMERIC([value]) = 0 THEN
-				CASE WHEN [value] LIKE '____-__-__T%__:__:%' THEN 
+				CASE WHEN [value] LIKE '____-__-__T%__:__:%' THEN
 					ISNULL( TRY_CAST( TRY_CAST( LEFT([value],19) AS datetimeoffset ) as datetime) , TRY_CAST( value as datetime ))
 				ELSE
 					TRY_CAST( [value] as datetime )
 				END
 		END
-        where (CASE WHEN 
-			LEN(value) < 50 and 
-			ISNULL(value,'') != '' and 
+        where (CASE WHEN
+			LEN(value) < 50 and
+			ISNULL(value,'') != '' and
 			ISNUMERIC([value]) = 0 THEN
-				CASE WHEN [value] LIKE '____-__-__T%__:__:%' THEN 
+				CASE WHEN [value] LIKE '____-__-__T%__:__:%' THEN
 					ISNULL( TRY_CAST( TRY_CAST( LEFT([value],19) AS datetimeoffset ) as datetime) , TRY_CAST( value as datetime ))
 				ELSE
 					TRY_CAST( [value] as datetime )
@@ -1296,7 +1296,7 @@ UPDATE [AttributeValue] SET ValueAsDateTime =
             person.BirthDay = personImport.BirthDay;
             person.BirthMonth = personImport.BirthMonth;
             person.BirthYear = personImport.BirthYear;
-            person.Gender = ( Gender ) personImport.Gender;
+            person.Gender = (Gender)personImport.Gender;
             person.MaritalStatusValueId = personImport.MaritalStatusValueId;
             person.AnniversaryDate = personImport.AnniversaryDate;
             person.GraduationYear = personImport.GraduationYear;
@@ -1309,7 +1309,7 @@ UPDATE [AttributeValue] SET ValueAsDateTime =
 
             person.IsEmailActive = personImport.IsEmailActive;
             person.EmailNote = personImport.EmailNote;
-            person.EmailPreference = ( EmailPreference ) personImport.EmailPreference;
+            person.EmailPreference = (EmailPreference)personImport.EmailPreference;
             person.InactiveReasonNote = personImport.InactiveReasonNote;
             person.CreatedDateTime = personImport.CreatedDateTime;
             person.ModifiedDateTime = personImport.ModifiedDateTime;
@@ -1494,11 +1494,11 @@ UPDATE [AttributeValue] SET ValueAsDateTime =
 
             List<BinaryFile> binaryFilesToInsert = new List<BinaryFile>();
             Dictionary<PhotoImport.PhotoImportType, Dictionary<int, Guid>> photoTypeForeignIdBinaryFileGuidDictionary = new Dictionary<PhotoImport.PhotoImportType, Dictionary<int, Guid>>();
-            foreach( var photoImportType in Enum.GetValues(typeof(PhotoImport.PhotoImportType)).OfType<PhotoImport.PhotoImportType>() )
+            foreach ( var photoImportType in Enum.GetValues( typeof( PhotoImport.PhotoImportType ) ).OfType<PhotoImport.PhotoImportType>() )
             {
                 photoTypeForeignIdBinaryFileGuidDictionary.Add( photoImportType, new Dictionary<int, Guid>() );
             }
-            
+
             var binaryFileService = new BinaryFileService( rockContext );
 
             HashSet<string> alreadyExists = new HashSet<string>( binaryFileService.Queryable().Where( a => a.ForeignKey != null && a.ForeignKey != "" ).Select( a => a.ForeignKey ).Distinct().ToList() );
@@ -1624,7 +1624,7 @@ WHERE (
 		)
 	AND AttributeId = @AttributeId
 
--- set the Photo for the Families 
+-- set the Photo for the Families
 INSERT INTO AttributeValue (
 	IsSystem
 	,AttributeId

--- a/Rock.Slingshot/SlingshotImport/SlingshotImporter.cs
+++ b/Rock.Slingshot/SlingshotImport/SlingshotImporter.cs
@@ -84,7 +84,7 @@ namespace Rock.Slingshot
                      }
                      catch ( Exception ex )
                      {
-                         System.Diagnostics.Debug.WriteLine( $"Unable to extract {a.FullName} from imageZipFile: {ex.Message}");
+                         System.Diagnostics.Debug.WriteLine( $"Unable to extract {a.FullName} from imageZipFile: {ex.Message}" );
                      }
                  } );
 
@@ -159,7 +159,7 @@ namespace Rock.Slingshot
             }
         }
 
-        List<string> _samplePhotoLocalUrls = null;
+        private List<string> _samplePhotoLocalUrls = null;
 
         /* Person Related */
         private Dictionary<Guid, DefinedValueCache> PersonRecordTypeValues { get; set; }
@@ -382,9 +382,9 @@ namespace Rock.Slingshot
         /// </summary>
         public void DoImportPhotos()
         {
-            // NOTE: Images can either be a URL or FileName specified in Person or Family import, 
+            // NOTE: Images can either be a URL or FileName specified in Person or Family import,
             // or in *.images.slingshot folders in the following format:
-            /*  
+            /*
                 exportfilename.slingshot
                 exportfilename_1.images.slingshot( max size 100MB )
                   - FinancialTransaction_{ Id}[_{ImageNum}].jpg/dif
@@ -483,7 +483,6 @@ namespace Rock.Slingshot
                 if ( photoImport.FileName.StartsWith( "FinancialTransaction_" ) )
                 {
                     photoImport.PhotoType = Slingshot.Model.PhotoImport.PhotoImportType.FinancialTransaction;
-
                 }
                 else if ( photoImport.FileName.StartsWith( "Person_" ) )
                 {
@@ -632,8 +631,8 @@ namespace Rock.Slingshot
             {
                 try
                 {
-                    HttpWebRequest imageRequest = ( HttpWebRequest ) HttpWebRequest.Create( photoUri );
-                    HttpWebResponse imageResponse = ( HttpWebResponse ) imageRequest.GetResponse();
+                    HttpWebRequest imageRequest = (HttpWebRequest)HttpWebRequest.Create( photoUri );
+                    HttpWebResponse imageResponse = (HttpWebResponse)imageRequest.GetResponse();
                     var imageStream = imageResponse.GetResponseStream();
                     using ( MemoryStream ms = new MemoryStream() )
                     {
@@ -672,7 +671,6 @@ namespace Rock.Slingshot
 
             return true;
         }
-
 
         #region Person and Family Notes
 
@@ -785,24 +783,31 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.PledgeFrequency.OneTime:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_ONE_TIME )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.Weekly:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_WEEKLY )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.BiWeekly:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_BIWEEKLY )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.TwiceAMonth:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_TWICEMONTHLY )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.Monthly:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_MONTHLY )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.Quarterly:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_QUARTERLY )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.TwiceAYear:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_TWICEYEARLY )?.Id;
                         break;
+
                     case SlingshotCore.Model.PledgeFrequency.Yearly:
                         financialPledgeImport.PledgeFrequencyValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.TRANSACTION_FREQUENCY_YEARLY )?.Id;
                         break;
@@ -849,7 +854,7 @@ namespace Rock.Slingshot
                     financialAccountImport.CampusId = this.CampusLookupByForeignId[slingshotFinancialAccount.CampusId.Value]?.Id;
                 }
 
-                financialAccountImport.ParentFinancialAccountForeignId = slingshotFinancialAccount.ParentAccountId == 0 ? ( int? ) null : slingshotFinancialAccount.ParentAccountId;
+                financialAccountImport.ParentFinancialAccountForeignId = slingshotFinancialAccount.ParentAccountId == 0 ? (int?)null : slingshotFinancialAccount.ParentAccountId;
 
                 financialAccountImportList.Add( financialAccountImport );
             }
@@ -890,15 +895,17 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.BatchStatus.Closed:
                         financialBatchImport.Status = Rock.Slingshot.Model.FinancialBatchImport.BatchStatus.Closed;
                         break;
+
                     case SlingshotCore.Model.BatchStatus.Open:
                         financialBatchImport.Status = Rock.Slingshot.Model.FinancialBatchImport.BatchStatus.Open;
                         break;
+
                     case SlingshotCore.Model.BatchStatus.Pending:
                         financialBatchImport.Status = Rock.Slingshot.Model.FinancialBatchImport.BatchStatus.Pending;
                         break;
                 }
 
-                financialBatchImport.CampusId = slingshotFinancialBatch.CampusId.HasValue ? this.CampusLookupByForeignId[slingshotFinancialBatch.CampusId.Value]?.Id : ( int? ) null;
+                financialBatchImport.CampusId = slingshotFinancialBatch.CampusId.HasValue ? this.CampusLookupByForeignId[slingshotFinancialBatch.CampusId.Value]?.Id : (int?)null;
 
                 financialBatchImportList.Add( financialBatchImport );
             }
@@ -928,21 +935,27 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.CurrencyType.ACH:
                         financialTransactionImport.CurrencyTypeValueId = this.CurrencyTypeValues[Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_ACH.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.CurrencyType.Cash:
                         financialTransactionImport.CurrencyTypeValueId = this.CurrencyTypeValues[Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_CASH.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.CurrencyType.Check:
                         financialTransactionImport.CurrencyTypeValueId = this.CurrencyTypeValues[Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_CHECK.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.CurrencyType.CreditCard:
                         financialTransactionImport.CurrencyTypeValueId = this.CurrencyTypeValues[Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_CREDIT_CARD.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.CurrencyType.NonCash:
                         financialTransactionImport.CurrencyTypeValueId = this.CurrencyTypeValues[Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_NONCASH.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.CurrencyType.Unknown:
                         financialTransactionImport.CurrencyTypeValueId = this.CurrencyTypeValues[Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_UNKNOWN.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.CurrencyType.Other:
                         // TODO: Do we need to support this?
                         break;
@@ -953,15 +966,19 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.TransactionSource.BankChecks:
                         financialTransactionImport.TransactionSourceValueId = this.TransactionSourceTypeValues[Rock.SystemGuid.DefinedValue.FINANCIAL_SOURCE_TYPE_BANK_CHECK.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.TransactionSource.Kiosk:
                         financialTransactionImport.TransactionSourceValueId = this.TransactionSourceTypeValues[Rock.SystemGuid.DefinedValue.FINANCIAL_SOURCE_TYPE_KIOSK.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.TransactionSource.MobileApplication:
                         financialTransactionImport.TransactionSourceValueId = this.TransactionSourceTypeValues[Rock.SystemGuid.DefinedValue.FINANCIAL_SOURCE_TYPE_MOBILE_APPLICATION.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.TransactionSource.OnsiteCollection:
                         financialTransactionImport.TransactionSourceValueId = this.TransactionSourceTypeValues[Rock.SystemGuid.DefinedValue.FINANCIAL_SOURCE_TYPE_ONSITE_COLLECTION.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.TransactionSource.Website:
                         financialTransactionImport.TransactionSourceValueId = this.TransactionSourceTypeValues[Rock.SystemGuid.DefinedValue.FINANCIAL_SOURCE_TYPE_WEBSITE.AsGuid()].Id;
                         break;
@@ -972,6 +989,7 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.TransactionType.Contribution:
                         financialTransactionImport.TransactionTypeValueId = this.TransactionTypeValues[Rock.SystemGuid.DefinedValue.TRANSACTION_TYPE_CONTRIBUTION.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.TransactionType.EventRegistration:
                         financialTransactionImport.TransactionTypeValueId = this.TransactionTypeValues[Rock.SystemGuid.DefinedValue.TRANSACTION_TYPE_EVENT_REGISTRATION.AsGuid()].Id;
                         break;
@@ -1176,7 +1194,7 @@ namespace Rock.Slingshot
                     groupImport.CampusId = this.CampusLookupByForeignId[slingshotGroup.CampusId.Value]?.Id;
                 }
 
-                groupImport.ParentGroupForeignId = slingshotGroup.ParentGroupId == 0 ? ( int? ) null : slingshotGroup.ParentGroupId;
+                groupImport.ParentGroupForeignId = slingshotGroup.ParentGroupId == 0 ? (int?)null : slingshotGroup.ParentGroupId;
                 groupImport.GroupMemberImports = new List<Rock.Slingshot.Model.GroupMemberImport>();
 
                 foreach ( var groupMember in slingshotGroup.GroupMembers )
@@ -1266,6 +1284,7 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.FamilyRole.Adult:
                         personImport.GroupRoleId = familyRolesLookup[Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.FamilyRole.Child:
                         personImport.GroupRoleId = familyRolesLookup[Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD.AsGuid()].Id;
                         break;
@@ -1281,9 +1300,11 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.RecordStatus.Active:
                         personImport.RecordStatusValueId = this.PersonRecordStatusValues[Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_ACTIVE.AsGuid()]?.Id;
                         break;
+
                     case SlingshotCore.Model.RecordStatus.Inactive:
                         personImport.RecordStatusValueId = this.PersonRecordStatusValues[Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_INACTIVE.AsGuid()]?.Id;
                         break;
+
                     case SlingshotCore.Model.RecordStatus.Pending:
                         personImport.RecordStatusValueId = this.PersonRecordStatusValues[Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_PENDING.AsGuid()]?.Id;
                         break;
@@ -1317,19 +1338,21 @@ namespace Rock.Slingshot
                 {
                     personImport.BirthMonth = slingshotPerson.Birthdate.Value.Month;
                     personImport.BirthDay = slingshotPerson.Birthdate.Value.Day;
-                    personImport.BirthYear = slingshotPerson.Birthdate.Value.Year == slingshotPerson.BirthdateNoYearMagicYear ? ( int? ) null : slingshotPerson.Birthdate.Value.Year;
+                    personImport.BirthYear = slingshotPerson.Birthdate.Value.Year == slingshotPerson.BirthdateNoYearMagicYear ? (int?)null : slingshotPerson.Birthdate.Value.Year;
                 }
 
                 switch ( slingshotPerson.Gender )
                 {
                     case SlingshotCore.Model.Gender.Male:
-                        personImport.Gender = ( int ) Rock.Model.Gender.Male;
+                        personImport.Gender = (int)Rock.Model.Gender.Male;
                         break;
+
                     case SlingshotCore.Model.Gender.Female:
-                        personImport.Gender = ( int ) Rock.Model.Gender.Female;
+                        personImport.Gender = (int)Rock.Model.Gender.Female;
                         break;
+
                     case SlingshotCore.Model.Gender.Unknown:
-                        personImport.Gender = ( int ) Rock.Model.Gender.Unknown;
+                        personImport.Gender = (int)Rock.Model.Gender.Unknown;
                         break;
                 }
 
@@ -1338,12 +1361,15 @@ namespace Rock.Slingshot
                     case SlingshotCore.Model.MaritalStatus.Married:
                         personImport.MaritalStatusValueId = this.PersonMaritalStatusValues[Rock.SystemGuid.DefinedValue.PERSON_MARITAL_STATUS_MARRIED.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.MaritalStatus.Single:
                         personImport.MaritalStatusValueId = this.PersonMaritalStatusValues[Rock.SystemGuid.DefinedValue.PERSON_MARITAL_STATUS_SINGLE.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.MaritalStatus.Divorced:
                         personImport.MaritalStatusValueId = this.PersonMaritalStatusValues[Rock.SystemGuid.DefinedValue.PERSON_MARITAL_STATUS_DIVORCED.AsGuid()].Id;
                         break;
+
                     case SlingshotCore.Model.MaritalStatus.Unknown:
                         personImport.MaritalStatusValueId = null;
                         break;
@@ -1360,13 +1386,15 @@ namespace Rock.Slingshot
                 switch ( slingshotPerson.EmailPreference )
                 {
                     case SlingshotCore.Model.EmailPreference.EmailAllowed:
-                        personImport.EmailPreference = ( int ) Rock.Model.EmailPreference.EmailAllowed;
+                        personImport.EmailPreference = (int)Rock.Model.EmailPreference.EmailAllowed;
                         break;
+
                     case SlingshotCore.Model.EmailPreference.DoNotEmail:
-                        personImport.EmailPreference = ( int ) Rock.Model.EmailPreference.DoNotEmail;
+                        personImport.EmailPreference = (int)Rock.Model.EmailPreference.DoNotEmail;
                         break;
+
                     case SlingshotCore.Model.EmailPreference.NoMassEmails:
-                        personImport.EmailPreference = ( int ) Rock.Model.EmailPreference.NoMassEmails;
+                        personImport.EmailPreference = (int)Rock.Model.EmailPreference.NoMassEmails;
                         break;
                 }
 
@@ -1400,9 +1428,11 @@ namespace Rock.Slingshot
                             case SlingshotCore.Model.AddressType.Home:
                                 groupLocationTypeValueId = this.GroupLocationTypeValues[Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME.AsGuid()].Id;
                                 break;
+
                             case SlingshotCore.Model.AddressType.Previous:
                                 groupLocationTypeValueId = this.GroupLocationTypeValues[Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_PREVIOUS.AsGuid()].Id;
                                 break;
+
                             case SlingshotCore.Model.AddressType.Work:
                                 groupLocationTypeValueId = this.GroupLocationTypeValues[Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_WORK.AsGuid()].Id;
                                 break;
@@ -1724,7 +1754,6 @@ namespace Rock.Slingshot
 
             // Family Attributes
             this.SlingshotFamilyAttributes = LoadSlingshotListFromFile<SlingshotCore.Model.FamilyAttribute>();
-
 
             /* Attendance */
             this.SlingshotAttendanceList = LoadSlingshotListFromFile<SlingshotCore.Model.Attendance>( false );


### PR DESCRIPTION
## Context
_What is the problem you encountered that lead to you creating this pull request?_

See https://github.com/SparkDevNetwork/Slingshot/issues/9.  The code between `LocationImport` and `PersonAddressImport` wasn't consistent with truncating Street1 and Street2 to 100 characters.  This change makes that consistent.

Ideally the LocationImport and PersonAddressImport should use the same logic, but refactoring doesn't fit in my timeline 😸 
