### PR TITLE
Updated code editor blocks to prevent incorrect html errors

### DIFF
--- a/RockWeb/Blocks/Administration/PageProperties.ascx
+++ b/RockWeb/Blocks/Administration/PageProperties.ascx
@@ -122,7 +122,7 @@
                                 </div>
                                 <div class="row">
                                     <div class="col-md-12">
-                                        <Rock:CodeEditor ID="ceHeaderContent" runat="server" Label="Header Content" EditorMode="Html" EditorTheme="Rock" EditorHeight="400"
+                                        <Rock:CodeEditor ID="ceHeaderContent" runat="server" Label="Header Content" EditorMode="Lava" EditorTheme="Rock" EditorHeight="400"
                                             Help="Additional HTML content to include in the &amp;lt;head&amp;gt; section of the rendered page." />
                                     </div>
                                 </div>

--- a/RockWeb/Blocks/Cms/SiteDetail.ascx
+++ b/RockWeb/Blocks/Cms/SiteDetail.ascx
@@ -101,7 +101,7 @@
                         </div>
                         <div class="row">
                             <div class="col-md-12">
-                                <Rock:CodeEditor ID="cePageHeaderContent" runat="server" Label="Page Header Content" Help="The content provided here will be added to each page's head section." EditorMode="Html" EditorTheme="Rock" Height="300" />
+                                <Rock:CodeEditor ID="cePageHeaderContent" runat="server" Label="Page Header Content" Help="The content provided here will be added to each page's head section." EditorMode="Lava" EditorTheme="Rock" Height="300" />
                             </div>
                         </div>
                     </Rock:PanelWidget>

--- a/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx
+++ b/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx
@@ -586,7 +586,7 @@
                                     <!-- Code Properties -->
                                     <div class="propertypanel propertypanel-code" data-component="code" style="display: none;">
 						                <h4 class="propertypanel-title">HTML</h4>
-                                        <Rock:CodeEditor ID="codeEditor" CssClass="js-component-code-codeEditor" runat="server" Height="350" EditorTheme="Rock" EditorMode="Html" OnChangeScript="updateCodeComponent(this, contents);" />
+                                        <Rock:CodeEditor ID="codeEditor" CssClass="js-component-code-codeEditor" runat="server" Height="350" EditorTheme="Rock" EditorMode="Lava" OnChangeScript="updateCodeComponent(this, contents);" />
                                         <div class="alert alert-danger" id="component-code-codeEditor-error"  style="display:none"></div>
 						
 

--- a/RockWeb/Blocks/Core/BlockProperties.ascx
+++ b/RockWeb/Blocks/Core/BlockProperties.ascx
@@ -31,8 +31,8 @@
 
                     <asp:Panel ID="pnlAdvancedSettings" runat="server" Visible="false" >
                         <Rock:RockTextBox ID="tbCssClass" runat="server" Label="CSS Class" Help="An optional CSS class to include with this block's containing div" />
-                        <Rock:CodeEditor ID="cePreHtml" runat="server" Label="Pre-HTML" Help="HTML Content to render before the block <span class='tip tip-lava'></span>." EditorMode="Html" EditorTheme="Rock" EditorHeight="400" />
-                        <Rock:CodeEditor ID="cePostHtml" runat="server" Label="Post-HTML" Help="HTML Content to render after the block <span class='tip tip-lava'></span>." EditorMode="Html" EditorTheme="Rock" EditorHeight="400" />
+                        <Rock:CodeEditor ID="cePreHtml" runat="server" Label="Pre-HTML" Help="HTML Content to render before the block <span class='tip tip-lava'></span>." EditorMode="Lava" EditorTheme="Rock" EditorHeight="400" />
+                        <Rock:CodeEditor ID="cePostHtml" runat="server" Label="Post-HTML" Help="HTML Content to render after the block <span class='tip tip-lava'></span>." EditorMode="Lava" EditorTheme="Rock" EditorHeight="400" />
                         <Rock:RockTextBox ID="tbCacheDuration" runat="server"  Label="Output Cache Duration (seconds)" Help="Number of seconds to cache the output of this block.  If a value is entered here, this block will only process data when the cache expires." />
                         <asp:PlaceHolder ID="phAdvancedAttributes" runat="server"></asp:PlaceHolder>
                     </asp:Panel>

--- a/RockWeb/Blocks/Crm/PersonAttributeForms.ascx
+++ b/RockWeb/Blocks/Crm/PersonAttributeForms.ascx
@@ -110,9 +110,9 @@
                             Help="Should a value for this attribute be required?" />
                     </div>
                 </div>
-                <Rock:CodeEditor ID="ceAttributePreText" runat="server" Label="Pre-Text" EditorMode="Html" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field"
+                <Rock:CodeEditor ID="ceAttributePreText" runat="server" Label="Pre-Text" EditorMode="Lava" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field"
                     Help="Any HTML to display directly above this field <span class='tip tip-lava'></span>." />
-                <Rock:CodeEditor ID="ceAttributePostText" runat="server" Label="Post-Text" EditorMode="Html" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field"
+                <Rock:CodeEditor ID="ceAttributePostText" runat="server" Label="Post-Text" EditorMode="Lava" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field"
                     Help="Any HTML to display directly below this field <span class='tip tip-lava'></span>." />
             </Content>
         </Rock:ModalDialog>

--- a/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx
@@ -424,8 +424,8 @@
                     </div>
                 </div>
                 <Rock:AttributeEditor ID="edtRegistrationAttribute" runat="server" ShowActions="false" ValidationGroup="Field" Visible="false" />
-                <Rock:CodeEditor ID="ceAttributePreText" runat="server" Label="Pre-Text" EditorMode="Html" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field" />
-                <Rock:CodeEditor ID="ceAttributePostText" runat="server" Label="Post-Text" EditorMode="Html" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field" />
+                <Rock:CodeEditor ID="ceAttributePreText" runat="server" Label="Pre-Text" EditorMode="Lava" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field" />
+                <Rock:CodeEditor ID="ceAttributePostText" runat="server" Label="Post-Text" EditorMode="Lava" EditorTheme="Rock" EditorHeight="100" ValidationGroup="Field" />
            </Content>
         </Rock:ModalDialog>
 

--- a/RockWeb/Blocks/Finance/AccountDetail.ascx
+++ b/RockWeb/Blocks/Finance/AccountDetail.ascx
@@ -67,7 +67,7 @@
 
                     <div class="row">
                         <div class="col-md-12">
-                            <Rock:CodeEditor ID="cePublicDescription" runat="server" Label="Public description HTML" EditorMode="Html" EditorTheme="Rock" EditorHeight="250"
+                            <Rock:CodeEditor ID="cePublicDescription" runat="server" Label="Public description HTML" EditorMode="Lava" EditorTheme="Rock" EditorHeight="250"
                                 Help="Additional HTML content to include with the account." />
                         </div>
                     </div>


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
#2774, incorrect errors from Ace when editing valid code

## Goal
Replace `EditorMode="Html` with `EditorMode="Lava"` to prevent errors and provide relevant syntax highlighting

## Strategy
Change EditorMode

## Tests
N/A

## Possible Implications
N/A

## Screenshots
N/A

## Documentation
N/A

## Migrations
N//A
