### PR TITLE
- Added classes to email components to assist with media queries

### DIFF
--- a/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx
+++ b/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx
@@ -776,20 +776,20 @@
                                     <div class="component component-section" data-content="<div class='dropzone'></div>" data-state="template">
 					                    <i class="rk rk-one-column"></i> <br /> One
 				                    </div>
-                                    <div class="component component-section" data-content="<table width='100%'><tr><td width='50%' valign='top'><div class='dropzone'></div></td><td width='50%' valign='top'><div class='dropzone'></div></td></tr></table>" data-state="template">
+                                    <div class="component component-section" data-content="<table class='row'width='100%' ><tr><td class='dropzone columns large-6 small-6 first' width='50%' valign='top'></td><td class='dropzone columns large-6 small-6 last' width='50%' valign='top'></td></tr></table>" data-state="template">
 					                    <i class="rk rk-two-column"></i> <br /> Two
 				                    </div>
-                                    <div class="component component-section" data-content="<table width='100%'><tr><td width='33%' valign='top'><div class='dropzone'></div></td><td width='34%' valign='top'><div class='dropzone'></div></td><td width='33%' valign='top'><div class='dropzone'></div></td></tr></table>" data-state="template">
+                                    <div class="component component-section" data-content="<table class='row'width='100%' ><tr><td class='dropzone columns large-4 small-4 first' width='33%' valign='top'></td><td class='dropzone columns large-4 small-4' width='34%' valign='top'></td><td class='dropzone columns large-4 small-4 last' width='33%' valign='top'></td></tr></table>" data-state="template">
 					                    <i class="rk rk-three-column"></i> <br /> Three
 				                    </div>
                                     <!--
-                                    <div class="component component-section" data-content="<table width='100%'><tr><td width='25%' valign='top'><div class='dropzone'></div></td><td width='25%' valign='top'><div class='dropzone'></div></td><td width='25%' valign='top'><div class='dropzone'></div></td><td width='25%' valign='top'><div class='dropzone'></div></td></tr></table>" data-state="template">
+                                    <div class="component component-section" data-content="<table class='row' width='100%'><tr><td class='dropzone' width='25%' valign='top'></td><td class='dropzone columns large-3 small-3' width='25%' valign='top'></td><td class='dropzone columns large-3 small-3' width='25%' valign='top'></td><td class='dropzone columns large-3 small-3' width='25%' valign='top'></td></tr></table>" data-state="template">
 					                    <i class="rk rk-four-column"></i> <br /> Four
 				                    </div> -->
-                                    <div class="component component-section" data-content="<table width='100%'><tr><td width='33%' valign='top'><div class='dropzone'></div></td><td width='67%' valign='top'><div class='dropzone'></div></td></tr></table>" data-state="template">
+                                    <div class="component component-section" data-content="<table class='row'width='100%' ><tr><td class='dropzone columns large-4 small-4 first' width='33%' valign='top'></td><td class='dropzone columns large-8 small-8 last' width='67%' valign='top'></td></tr></table>" data-state="template">
 					                    <i class="rk rk-left-column"></i> <br /> Left
 				                    </div>
-                                    <div class="component component-section" data-content="<table width='100%'><tr><td width='67%' valign='top'><div class='dropzone'></div></td><td width='33%' valign='top'><div class='dropzone'></div></td></tr></table>" data-state="template">
+                                    <div class="component component-section" data-content="<table class='row'width='100%' ><tr><td class='dropzone columns large-8 small-8 first' width='67%' valign='top'></td><td class='dropzone columns large-4 small-4 last' width='33%' valign='top'></td></tr></table>" data-state="template">
 					                    <i class="rk rk-right-column"></i> <br /> Right
 				                    </div>
                                 </div>


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Fixes #2800

## Goal
Help with the ability to use css to target components added via the communication wizard, specifically the `component-section` block which adds column markup. 

## Strategy
Mostly keep existing markup, use `<td>`s as dropzones where possible, and add css classes that match what's found in Zurb Foundation. 

Please squash my commits before merging... messed up and forgot a space 🙃 

## Tests
N/A

## Possible Implications
None

## Screenshots
N/A

## Documentation
N/A

## Migrations
N//A
