### PR TITLE
Updated Ace Editor to wrap lines by default

### DIFF
--- a/Rock/Web/UI/Controls/CodeEditor.cs
+++ b/Rock/Web/UI/Controls/CodeEditor.cs
@@ -568,6 +568,7 @@ namespace Rock.Web.UI.Controls
                 var ce_{0} = ace.edit('codeeditor-div-{0}');
                 ce_{0}.setTheme('ace/theme/{1}');
                 ce_{0}.getSession().setMode('ace/mode/{2}');
+                ce_{0}.getSession().setUseWrapMode(true);
                 ce_{0}.setShowPrintMargin(false);
                 $('#codeeditor-div-{0}').data('aceEditor', ce_{0});
 


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Fixes #2806

## Goal
Increase usability of code editor by automatically wrapping lines

## Strategy
Add `ce_{0}.getSession().setUseWrapMode(true);` to CodeEditor control

## Tests
N/A

## Possible Implications
None

## Screenshots
N/A

## Documentation
N/A

## Migrations
N//A
