### PR TITLE
Removed Extra blank Line Height on email wizard

### DIFF
--- a/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx
+++ b/RockWeb/Blocks/Communication/CommunicationEntryWizard.ascx
@@ -250,7 +250,6 @@
                                                     <asp:ListItem Text="Slight" Value="125%" />
                                                     <asp:ListItem Text="1 &frac12; spacing" Value="150%" />
                                                     <asp:ListItem Text="Double space" Value="200%" />
-                                                    <asp:ListItem />
                                                 </Rock:RockDropDownList>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
There's an extra blank line height on the email editor. This PR removes it.

<img width="244" alt="screen shot 2018-02-22 at 5 06 11 pm" src="https://user-images.githubusercontent.com/374209/36572858-d4ca176e-17f2-11e8-8aaf-e194f0b906cf.png">

## Goal
Remove the extra blank line.

## Strategy
Delete `<asp:ListItem />` 

## Tests
N/A

## Possible Implications
None

## Screenshots
N/A

## Documentation
N/A

## Migrations
N//A
