### PR TITLE
Updates ExceptionLogService to always log to file during startup.

### DIFF
--- a/Rock/Model/ExceptionLogService.Partial.cs
+++ b/Rock/Model/ExceptionLogService.Partial.cs
@@ -29,6 +29,15 @@ namespace Rock.Model
     /// </summary>
     public partial class ExceptionLogService 
     {
+        #region Fields
+
+        /// <summary>
+        /// When true, indicates that exceptions should always be logged to file in addition to the database.
+        /// </summary>
+        public static bool AlwaysLogToFile = false;
+
+        #endregion
+
         /// <summary>
         /// Gets a collection of <see cref="Rock.Model.ExceptionLog"/> entities by the Id of their Parent exceptionId. 
         /// Under most instances, only one child <see cref="Rock.Model.ExceptionLog"/> entity will be returned in the collection.
@@ -111,6 +120,8 @@ namespace Rock.Model
         /// </param>
         private static void LogExceptions( Exception ex, ExceptionLog log, bool isParent )
         {
+            bool logToFile = AlwaysLogToFile;
+
             // First, attempt to log exception to the database.
             try
             {
@@ -180,6 +191,11 @@ namespace Rock.Model
             catch ( Exception )
             {
                 // If logging the exception fails, write the exceptions to a file
+                logToFile = true;
+            }
+
+            if ( logToFile )
+            {
                 try
                 {
                     string directory = AppDomain.CurrentDomain.BaseDirectory;

--- a/RockWeb/App_Code/Global.asax.cs
+++ b/RockWeb/App_Code/Global.asax.cs
@@ -138,6 +138,9 @@ namespace RockWeb
                     System.Diagnostics.Debug.WriteLine( string.Format( "Application_Start: {0}", RockDateTime.Now.ToString( "hh:mm:ss.FFF" ) ) );
                 }
 
+                // Indicate to always log to file during initialization.
+                ExceptionLogService.AlwaysLogToFile = true;
+
                 // Clear all cache
                 RockMemoryCache.Clear();
 
@@ -315,6 +318,8 @@ namespace RockWeb
                 {
                     System.Diagnostics.Debug.WriteLine( string.Format( "Application_Started_Successfully: {0}", RockDateTime.Now.ToString( "hh:mm:ss.FFF" ) ) );
                 }
+
+                ExceptionLogService.AlwaysLogToFile = false;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

When an error occurs during initialization of Rock, it can be near impossible - or at least very difficult - for users to find out the exception if the error is logged to the database but Rock failed to start. This is because the UI is not available.

See #2733 

## Goal
_What will this pull request achieve and how will this fix the problem?_

Make ExceptionLogService always log to the RockExceptions.csv file during startup.

## Strategy
_How have you implemented your solution?_

Added a static property to ExceptionLogService to indicate that it should always log to file. Would have liked to make this internal, but couldn't figure out a way to do that since Global.asax is not in the same assembly.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
