### PR TITLE
Support importing of Lava Fields from the HTML code in Communication Templates

### DIFF
--- a/RockWeb/Blocks/Communication/TemplateDetail.ascx
+++ b/RockWeb/Blocks/Communication/TemplateDetail.ascx
@@ -109,6 +109,8 @@
                             <div class="col-md-4">
                                 <Rock:RockCheckBox ID="cbCssInliningEnabled" runat="server" Text="CSS Inlining Enabled" Help="Enable CSS Inlining to move styles to inline attributes. This can help maximize compatibility with email clients." />
                                 <Rock:KeyValueList ID="kvlMergeFields" runat="server" Label="Lava Fields" KeyPrompt="Key" Help="Add any fields and their default values that can be used as lava merge fields within the template html. Any fields with a 'Color' suffix will use a Color Picker as the value editor." ValuePrompt="Default Value" />
+                                
+                                <asp:LinkButton ID="lbUpdateLavaFields" runat="server" Text="Update Lava Fields" CssClass="btn btn-xs btn-action" OnClick="lbUpdateLavaFields_Click" CausesValidation="false" />
                             </div>
                         </div>
                     </asp:Panel>
@@ -145,7 +147,7 @@
 
                                             <asp:HiddenField ID="hfLavaFieldsState" runat="server" />
                                             <asp:PlaceHolder ID="phLavaFieldsControls" runat="server" />
-                                            <asp:LinkButton ID="btnUpdateTemplatePreview" runat="server" CssClass="btn btn-xs btn-action" Text="Update" OnClick="btnUpdateTemplatePreview_Click" />
+                                            <asp:LinkButton ID="btnUpdateTemplatePreview" runat="server" CssClass="btn btn-xs btn-action" Text="Update" OnClick="btnUpdateTemplatePreview_Click" CausesValidation="false" />
                                         </div>
                                     </div>
                                 </asp:Panel>


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2795 for full discussion. When "importing" a communication template by creating a new one and pasting in the code for it, the lava fields were not imported.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Provide functionality to import the lava fields.

## Strategy
_How have you implemented your solution?_

New button on the "Advanced" view to update lava fields from what is in the HTML. This replaces the existing Lava Fields with whatever is found in HTML.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
