### PR TITLE
New block type for converting Person records to and from Businesses

### DIFF
--- a/Rock/SystemGuid/BlockType.cs
+++ b/Rock/SystemGuid/BlockType.cs
@@ -62,5 +62,14 @@ namespace Rock.SystemGuid
         /// The PowerBI Account Registration Block Type Guid
         /// </summary>
         public const string POWERBI_ACCOUNT_REGISTRATION = "EA20D87E-ED46-3DAA-4C4D-4156C399B1C2";
+
+        #region Finance Block Types
+
+        /// <summary>
+        /// The Convert Business Block Type Guid
+        /// </summary>
+        public const string CONVERT_BUSINESS = "115A7725-6760-4E86-8171-57F4A3CF6909";
+
+        #endregion
     }
 }

--- a/RockWeb/Blocks/Finance/ConvertBusiness.ascx
+++ b/RockWeb/Blocks/Finance/ConvertBusiness.ascx
@@ -1,0 +1,59 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="ConvertBusiness.ascx.cs" Inherits="RockWeb.Blocks.Finance.ConvertBusiness" %>
+
+<asp:UpdatePanel ID="upnlContent" runat="server">
+    <ContentTemplate>
+        <div class="panel panel-block">
+            <div class="panel-heading">
+                <h1 class="panel-title"><i class="fa fa-building"></i> Convert Business</h1>
+            </div>
+
+            <div class="panel-body">
+                <Rock:NotificationBox ID="nbSuccess" runat="server" NotificationBoxType="Success" />
+                <Rock:NotificationBox ID="nbWarning" runat="server" NotificationBoxType="Warning" />
+                <Rock:NotificationBox ID="nbError" runat="server" NotificationBoxType="Danger" />
+
+                <Rock:PersonPicker ID="ppSource" runat="server" IncludeBusinesses="true" Label="Person or Business" Help="Select the person or business that you want to convert." OnSelectPerson="ppSource_SelectPerson" />
+
+                <asp:Panel ID="pnlToPerson" runat="server" Visible="false">
+                    <asp:ValidationSummary ID="vsToPerson" runat="server" CssClass="alert alert-danger" ValidationGroup="ConvertToPerson" />
+
+                    <Rock:NotificationBox ID="nbToPerson" runat="server" NotificationBoxType="Warning">The selected record will be converted to a Person with the values entered below.</Rock:NotificationBox>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <Rock:RockTextBox ID="tbPersonFirstName" runat="server" Label="First Name" Required="true" ValidationGroup="ConvertToPerson" />
+                            <Rock:RockTextBox ID="tbPersonLastName" runat="server" Label="Last Name" Required="true" ValidationGroup="ConvertToPerson" />
+                            <Rock:DefinedValuePicker ID="dvpPersonConnectionStatus" runat="server" Label="Connection Status" Required="true" ValidationGroup="ConvertToPerson" />
+                        </div>
+                        <div class="col-md-6">
+                            <Rock:DefinedValuePicker ID="dvpMaritalStatus" runat="server" Label="Marital Status" Required="false" ValidationGroup="ConvertToPerson" />
+                            <Rock:RockRadioButtonList ID="rblGender" runat="server" Label="Gender" RepeatDirection="Horizontal" Required="true" ValidationGroup="ConvertToPerson" />
+                        </div>
+                    </div>
+                    
+                    <div class="actions">
+                        <asp:LinkButton ID="lbPersonSave" runat="server" Text="Save" CssClass="btn btn-primary" ValidationGroup="ConvertToPerson" OnClick="lbToPersonSave_Click" />
+                        <asp:LinkButton ID="lbPersonCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbPersonCancel_Click" />
+                    </div>
+                </asp:Panel>
+
+                <asp:Panel ID="pnlToBusiness" runat="server" Visible="false">
+                    <asp:ValidationSummary ID="vsToBusiness" runat="server" CssClass="alert alert-danger" ValidationGroup="ConvertToBusiness" />
+
+                    <Rock:NotificationBox ID="nbToBusiness" runat="server" NotificationBoxType="Warning">The selected record will be converted to a Business with the values entered below.</Rock:NotificationBox>
+
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <Rock:RockTextBox ID="tbBusinessName" runat="server" Label="Name" Required="true" ValidationGroup="ConvertToBusiness" />
+                        </div>
+                    </div>
+
+                    <div class="actions">
+                        <asp:LinkButton ID="lbBusinessSave" runat="server" Text="Save" CssClass="btn btn-primary" ValidationGroup="ConvertToBusiness" OnClick="lbToBusinessSave_Click" />
+                        <asp:LinkButton ID="lbBusinessCancel" runat="server" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbBusinessCancel_Click" />
+                    </div>
+                </asp:Panel>
+            </div>
+        </div>
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/RockWeb/Blocks/Finance/ConvertBusiness.ascx.cs
+++ b/RockWeb/Blocks/Finance/ConvertBusiness.ascx.cs
@@ -1,0 +1,348 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+
+namespace RockWeb.Blocks.Finance
+{
+    [DisplayName( "Convert Business" )]
+    [Category( "Finance" )]
+    [Description( "Allows you to convert a Person record into a Business and vice-versa." )]
+
+    [DefinedValueField( Rock.SystemGuid.DefinedType.PERSON_CONNECTION_STATUS, "Default Connection Status", "The default connection status to use when converting a business to a person.", false, order: 0 )]
+    public partial class ConvertBusiness : RockBlock
+    {
+        #region Base Method Overrides
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            // this event gets fired after block settings are updated. it's nice to repaint the screen if these settings would alter it
+            this.BlockUpdated += Block_BlockUpdated;
+            this.AddConfigurationUpdateTrigger( upnlContent );
+        }
+
+        /// <summary>
+        /// Initialize basic information about the page structure and setup the default content.
+        /// </summary>
+        /// <param name="sender">Object that is generating this event.</param>
+        /// <param name="e">Arguments that describe this event.</param>
+        protected void Page_Load( object sender, EventArgs e )
+        {
+            if ( !IsPostBack )
+            {
+            }
+        }
+
+        #endregion
+
+        #region Core Methods
+
+        #endregion
+
+        #region Event Handlers
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            pnlToBusiness.Visible = false;
+            pnlToPerson.Visible = false;
+            ppSource.SetValue( null );
+        }
+
+        /// <summary>
+        /// Handles the SelectPerson event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ppSource_SelectPerson( object sender, EventArgs e )
+        {
+            nbSuccess.Text = string.Empty;
+            nbWarning.Text = string.Empty;
+            nbError.Text = string.Empty;
+            pnlToBusiness.Visible = false;
+            pnlToPerson.Visible = false;
+            
+            if ( ppSource.PersonId.HasValue )
+            {
+                var person = new PersonService( new RockContext() ).Get( ppSource.PersonId.Value );
+
+                if ( person.RecordTypeValue.Guid == Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_BUSINESS.AsGuid() )
+                {
+                    pnlToPerson.Visible = true;
+                    tbPersonFirstName.Text = string.Empty;
+                    tbPersonLastName.Text = person.LastName;
+                    dvpPersonConnectionStatus.DefinedTypeId = DefinedTypeCache.Read( Rock.SystemGuid.DefinedType.PERSON_CONNECTION_STATUS.AsGuid() ).Id;
+                    dvpMaritalStatus.DefinedTypeId = DefinedTypeCache.Read( Rock.SystemGuid.DefinedType.PERSON_MARITAL_STATUS.AsGuid() ).Id;
+                    rblGender.BindToEnum<Gender>();
+
+                    rblGender.SetValue( Gender.Unknown.ConvertToInt() );
+
+                    if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "DefaultConnectionStatus" ) ) )
+                    {
+                        var dv = DefinedValueCache.Read( GetAttributeValue( "DefaultConnectionStatus" ).AsGuid() );
+                        if ( dv != null )
+                        {
+                            dvpPersonConnectionStatus.SetValue( dv.Id );
+                        }
+                    }
+                }
+                else
+                {
+                    //
+                    // Ensure person record is a member of only one family.
+                    //
+                    var families = person.GetFamilies();
+                    if ( families.Count() != 1 )
+                    {
+                        nbError.Text = "Cannot convert person record to a business. Please adjust the family membership of the selected person so they are only a member of a single family and then try again.";
+                        return;
+                    }
+
+                    //
+                    // Ensure person record is only record in family.
+                    //
+                    var family = families.First();
+                    if ( family.Members.Count != 1 )
+                    {
+                        nbError.Text = "Cannot convert person record to a business. Please remove extra family members before trying to convert this person to a business.";
+                        return;
+                    }
+
+                    //
+                    // Ensure giving group is correct.
+                    //
+                    if ( person.GivingGroup == null || person.GivingGroup.Members.Count != 1 || person.GivingLeaderId != person.Id )
+                    {
+                        nbError.Text = "Cannot convert person record to a business. Please fix the giving group and then try again.";
+                        return;
+                    }
+
+                    pnlToBusiness.Visible = true;
+                    tbBusinessName.Text = string.Format( "{0} {1}", person.FirstName, person.LastName ).Trim();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbToPersonSave_Click( object sender, EventArgs e )
+        {
+            var context = new RockContext();
+            var person = new PersonService( context ).Get( ppSource.PersonId.Value );
+            var changes = new List<string>();
+
+            person.RecordTypeValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_PERSON ).Id;
+
+            History.EvaluateChange( changes, "Connection Status", DefinedValueCache.GetName( person.ConnectionStatusValueId ), DefinedValueCache.GetName( dvpPersonConnectionStatus.SelectedValueAsInt() ) );
+            person.ConnectionStatusValueId = dvpPersonConnectionStatus.SelectedValueAsInt();
+
+            History.EvaluateChange( changes, "First Name", person.FirstName, tbPersonFirstName.Text.Trim() );
+            person.FirstName = tbPersonFirstName.Text.Trim();
+
+            History.EvaluateChange( changes, "Nick Name", person.NickName, tbPersonFirstName.Text.Trim() );
+            person.NickName = tbPersonFirstName.Text.Trim();
+
+            History.EvaluateChange( changes, "Last Name", person.LastName, tbPersonLastName.Text.Trim() );
+            person.LastName = tbPersonLastName.Text.Trim();
+
+            History.EvaluateChange( changes, "Gender", person.Gender, rblGender.SelectedValueAsEnum<Gender>() );
+            person.Gender = rblGender.SelectedValueAsEnum<Gender>();
+
+            History.EvaluateChange( changes, "Marital Status", DefinedValueCache.GetName( person.MaritalStatusValueId ), DefinedValueCache.GetName( dvpMaritalStatus.SelectedValueAsId() ) );
+            person.MaritalStatusValueId = dvpMaritalStatus.SelectedValueAsId();
+
+            context.SaveChanges();
+            if ( changes.Count > 0 )
+            {
+                HistoryService.SaveChanges( context, typeof( Person ), Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(), person.Id, changes );
+            }
+
+            ppSource.SetValue( null );
+
+            var parameters = new Dictionary<string, string>
+            {
+                { "PersonId", person.Id.ToString() }
+            };
+            var pageRef = new Rock.Web.PageReference( Rock.SystemGuid.Page.PERSON_PROFILE_PERSON_PAGES, parameters );
+            nbSuccess.Text = string.Format( "<a href='{1}'>{0}</a> has been converted to a person.", person.FullName, pageRef.BuildUrl() );
+            
+            pnlToPerson.Visible = false;
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbToBusinessSave_Click( object sender, EventArgs e )
+        {
+            var context = new RockContext();
+            var person = new PersonService( context ).Get( ppSource.PersonId.Value );
+            var changes = new List<string>();
+
+            person.RecordTypeValueId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_BUSINESS ).Id;
+
+            History.EvaluateChange( changes, "Connection Status", DefinedValueCache.GetName( person.ConnectionStatusValueId ), DefinedValueCache.GetName( null ) );
+            person.ConnectionStatusValueId = null;
+
+            History.EvaluateChange( changes, "Title", DefinedValueCache.GetName( person.TitleValueId ), DefinedValueCache.GetName( null ) );
+            person.TitleValueId = null;
+
+            History.EvaluateChange( changes, "First Name", person.FirstName, null );
+            person.FirstName = null;
+
+            History.EvaluateChange( changes, "Nick Name", person.NickName, null );
+            person.NickName = null;
+
+            History.EvaluateChange( changes, "Middle Name", person.MiddleName, null );
+            person.MiddleName = null;
+
+            History.EvaluateChange( changes, "Last Name", person.LastName, tbBusinessName.Text.Trim() );
+            person.LastName = tbBusinessName.Text.Trim();
+
+            History.EvaluateChange( changes, "Suffix", DefinedValueCache.GetName( person.SuffixValueId ), DefinedValueCache.GetName( null ) );
+            person.SuffixValueId = null;
+
+            History.EvaluateChange( changes, "Birth Month", person.BirthMonth, null );
+            History.EvaluateChange( changes, "Birth Day", person.BirthDay, null );
+            History.EvaluateChange( changes, "Birth Year", person.BirthYear, null );
+            person.SetBirthDate( null );
+
+            History.EvaluateChange( changes, "Gender", person.Gender, Gender.Unknown );
+            person.Gender = Gender.Unknown;
+
+            History.EvaluateChange( changes, "Marital Status", DefinedValueCache.GetName( person.MaritalStatusValueId ), DefinedValueCache.GetName( null ) );
+            person.MaritalStatusValueId = null;
+
+            History.EvaluateChange( changes, "Anniversary Date", person.AnniversaryDate, null );
+            person.AnniversaryDate = null;
+
+            History.EvaluateChange( changes, "Graduation Year", person.GraduationYear, null );
+            person.GraduationYear = null;
+
+            //
+            // Check address(es) and make sure one is of type Work.
+            //
+            var family = person.GetFamily( context );
+            if ( family.GroupLocations.Count > 0 )
+            {
+                var workLocationTypeId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_WORK ).Id;
+                var homeLocationTypeId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME ).Id;
+
+                var workLocation = family.GroupLocations.Where( gl => gl.GroupLocationTypeValueId == workLocationTypeId ).FirstOrDefault();
+                if ( workLocation == null )
+                {
+                    var homeLocation = family.GroupLocations.Where( gl => gl.GroupLocationTypeValueId == homeLocationTypeId ).FirstOrDefault();
+                    if ( homeLocation != null )
+                    {
+                        homeLocation.GroupLocationTypeValueId = workLocationTypeId;
+                    }
+                }
+            }
+
+            //
+            // Check phone(es) and make sure one is of type Work.
+            //
+            if ( person.PhoneNumbers.Count > 0 )
+            {
+                var workPhoneTypeId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_WORK ).Id;
+                var homePhoneTypeId = DefinedValueCache.Read( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_HOME ).Id;
+
+                var workPhone = person.PhoneNumbers.Where( pn => pn.NumberTypeValueId == workPhoneTypeId ).FirstOrDefault();
+                if ( workPhone == null )
+                {
+                    var homePhone = person.PhoneNumbers.Where( pn => pn.NumberTypeValueId == homePhoneTypeId ).FirstOrDefault();
+                    if ( homePhone != null )
+                    {
+                        homePhone.NumberTypeValueId = workPhoneTypeId;
+                    }
+                }
+            }
+
+            //
+            // Make sure member status in family is set to Adult.
+            //
+            var adultRoleId = GroupTypeCache.GetFamilyGroupType().Roles
+                .Where( a => a.Guid == Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() )
+                .Select( a => a.Id ).First();
+            family.Members.Where( m => m.PersonId == person.Id ).First().GroupRoleId = adultRoleId;
+
+            context.SaveChanges();
+            if ( changes.Count > 0 )
+            {
+                HistoryService.SaveChanges( context, typeof( Person ), Rock.SystemGuid.Category.HISTORY_PERSON_DEMOGRAPHIC_CHANGES.AsGuid(), person.Id, changes );
+            }
+
+            ppSource.SetValue( null );
+
+            var parameters = new Dictionary<string, string>
+            {
+                { "BusinessId", person.Id.ToString() }
+            };
+            var pageRef = new Rock.Web.PageReference( Rock.SystemGuid.Page.BUSINESS_DETAIL, parameters );
+            nbSuccess.Text = string.Format( "<a href='{1}'>{0}</a> has been converted to a business.", person.LastName, pageRef.BuildUrl() );
+
+            pnlToBusiness.Visible = false;
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbPersonCancel_Click( object sender, EventArgs e )
+        {
+            pnlToPerson.Visible = false;
+            ppSource.SetValue( null );
+        }
+
+        /// <summary>
+        /// Handles the Click event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbBusinessCancel_Click( object sender, EventArgs e )
+        {
+            pnlToBusiness.Visible = false;
+            ppSource.SetValue( null );
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2832. There is no UI method for converting a Person record to a Business, or vice-versa. This required the user to go into SQL to make the changes, but this often made it difficult to get history information recorded properly. Also made it easy to mess up.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Provide a UI block to do the conversion.

## Strategy
_How have you implemented your solution?_

New Block Type in the Finance category called Convert Business. Allows you to select either a person or a business record and it will be converted to the opposite type.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

See issue referenced for screenshots.

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

I did not include a migration to add the block to the system. However, I did add a new SystemGuid for it as a placeholder.