### PR TITLE
Show Inactive Groups in GroupListPersonalizedLava block

### DIFF
--- a/RockWeb/Themes/Rock/Assets/Lava/GroupListSidebar.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/GroupListSidebar.lava
@@ -1,37 +1,59 @@
+<style>
+    .list-group > a.disabled, .list-group-item > a.disabled {
+        color: #999999;
+    }
+
+        .list-group > a.disabled:hover,
+        .list-group > a.disabled:focus,
+        .list-group-item > a.disabled:hover,
+        .list-group-item > a.disabled:focus {
+            color: #999999;
+            text-decoration: none;
+            background-color: transparent;
+            cursor: not-allowed;
+        }
+</style>
 <div class="panel panel-default">
-  <div class="panel-heading">Groups</div>
+    <div class="panel-heading">
+        {% if ShowInactive -%}{% assign inactiveParamVal = 'Global' | PageParameter:InactiveParameter -%}
+        <div class="pull-right btn-group btn-toggle">
+            <a class="btn btn-default btn-xs {% if inactiveParamVal == '0' or InitialActive == 1 and inactiveParamVal == null %}active{% endif %}" href='{{ 'Global' | Page:'Path' }}?{{ InactiveParameter }}=0'>Active</a>
+            <a class="btn btn-default btn-xs {% if inactiveParamVal == '1' or InitialActive == 0 and PainactiveParamVal == null %}active{% endif %}" href='{{ 'Global' | Page:'Path' }}?{{ InactiveParameter }}=1'>All</a>
+        </div>
+        {% endif -%}
+        Groups
+    </div>
+    {% assign groupCount = Groups | Size %}
 
-  {% assign groupCount = Groups | Size %}
-
-  {% if groupCount == 0 %}
-  <div class="margin-all-md"> No Groups Available To List</div>
-  {% endif %}
-
-  <ul class="list-group list-group-panel">
-    {% for group in Groups %}
-
-    {% capture isLeaderIcon %}
-    {% if group.IsLeader %}
-      <i class='fa fa-asterisk'></i>
+    {% if groupCount == 0 %}
+    <div class="margin-all-md"> No Groups Available To List</div>
     {% endif %}
-    {% endcapture %}
 
-    <li class="list-group-item">
-      <a href="{{ LinkedPages.DetailPage }}?GroupId={{ group.Group.Id }}" class="js-group-item" data-toggle="tooltip" data-placement="top" title="{{ group.GroupType }}">
-        {{ group.Group.Name }} <small>({{ group.Role }}{{ isLeaderIcon }})</small>
-            {% if group.IsLeader %}
-              {% assign pending = 0 %}
-              {% for member in group.Group.Members %}
-                {% if member.GroupMemberStatus == 'Pending' %}
-                  {% assign pending = pending | Plus:1 %}
-                {% endif %}
-              {% endfor %}
-              {% if pending != 0 %}
-                <span title="number of pending members" class="badge badge-danger">{{ pending }}</span>
-              {% endif %}
-            {% endif %}
-      </a>
-    </li>
+    <ul class="list-group list-group-panel">
+        {% for group in Groups %}
+
+        {% capture isLeaderIcon -%}
+        {% if group.IsLeader -%}
+        <i class='fa fa-asterisk'></i>
+        {% endif -%}
+        {% endcapture -%}
+
+        <li class="list-group-item {% if group.Group.IsActive == false %}inactive{% endif %}">
+            <a href="{{ LinkedPages.DetailPage }}?GroupId={{group.Group.Id}}" class="js-group-item {% if group.Group.IsActive == false %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ group.GroupType }}">
+            {{ group.Group.Name }} <small>({{ group.Role }}{{ isLeaderIcon }})</small>
+                {% if group.IsLeader -%}
+                  {% assign pending = 0 -%}
+                  {% for member in group.Group.Members -%}
+                    {% if member.GroupMemberStatus == 'Pending' -%}
+                      {% assign pending = pending | Plus:1 -%}
+                    {% endif -%}
+                  {% endfor -%}
+                  {% if pending != 0 -%}
+                    <span title="number of pending members" class="badge badge-danger">{{ pending }}</span>
+                  {% endif -%}
+                {% endif -%}
+          </a>
+        </li>
     {% endfor %}
   </ul>
 
@@ -40,7 +62,7 @@
 <script type="text/javascript">
 
   $( document ).ready(function() {
-  $('.js-group-item').tooltip();
+      $('.js-group-item').tooltip();
   });
 
 </script>

--- a/RockWeb/Themes/Stark/Assets/Lava/GroupListSidebar.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/GroupListSidebar.lava
@@ -1,37 +1,59 @@
+<style>
+    .list-group > a.disabled, .list-group-item > a.disabled {
+        color: #999999;
+    }
+
+        .list-group > a.disabled:hover,
+        .list-group > a.disabled:focus,
+        .list-group-item > a.disabled:hover,
+        .list-group-item > a.disabled:focus {
+            color: #999999;
+            text-decoration: none;
+            background-color: transparent;
+            cursor: not-allowed;
+        }
+</style>
 <div class="panel panel-default">
-  <div class="panel-heading">Groups</div>
+    <div class="panel-heading">
+        {% if ShowInactive -%}{% assign inactiveParamVal = 'Global' | PageParameter:InactiveParameter -%}
+        <div class="pull-right btn-group btn-toggle">
+            <a class="btn btn-default btn-xs {% if inactiveParamVal == '0' or InitialActive == 1 and inactiveParamVal == null %}active{% endif %}" href='{{ 'Global' | Page:'Path' }}?{{ InactiveParameter }}=0'>Active</a>
+            <a class="btn btn-default btn-xs {% if inactiveParamVal == '1' or InitialActive == 0 and PainactiveParamVal == null %}active{% endif %}" href='{{ 'Global' | Page:'Path' }}?{{ InactiveParameter }}=1'>All</a>
+        </div>
+        {% endif -%}
+        Groups
+    </div>
+    {% assign groupCount = Groups | Size %}
 
-  {% assign groupCount = Groups | Size %}
-
-  {% if groupCount == 0 %}
-  <div class="margin-all-md"> No Groups Available To List</div>
-  {% endif %}
-
-  <ul class="list-group list-group-panel">
-    {% for group in Groups %}
-
-    {% capture isLeaderIcon %}
-    {% if group.IsLeader %}
-      <i class='fa fa-asterisk'></i>
+    {% if groupCount == 0 %}
+    <div class="margin-all-md"> No Groups Available To List</div>
     {% endif %}
-    {% endcapture %}
 
-    <li class="list-group-item">
-      <a href="{{ LinkedPages.DetailPage }}?GroupId={{ group.Group.Id }}" class="js-group-item" data-toggle="tooltip" data-placement="top" title="{{ group.GroupType }}">
-        {{ group.Group.Name }} <small>({{ group.Role }}{{ isLeaderIcon }})</small>
-        {% if group.IsLeader %}
-          {% assign pending = 0 %}
-          {% for member in group.Group.Members %}
-            {% if member.GroupMemberStatus == 'Pending' %}
-              {% assign pending = pending | Plus:1 %}
-            {% endif %}
-          {% endfor %}
-          {% if pending != 0 %}
-            <span title="number of pending members" class="badge badge-danger">{{ pending }}</span>
-          {% endif %}
-        {% endif %}
-      </a>
-    </li>
+    <ul class="list-group list-group-panel">
+        {% for group in Groups %}
+
+        {% capture isLeaderIcon -%}
+        {% if group.IsLeader -%}
+        <i class='fa fa-asterisk'></i>
+        {% endif -%}
+        {% endcapture -%}
+
+        <li class="list-group-item {% if group.Group.IsActive == false %}inactive{% endif %}">
+            <a href="{{ LinkedPages.DetailPage }}?GroupId={{group.Group.Id}}" class="js-group-item {% if group.Group.IsActive == false %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ group.GroupType }}">
+            {{ group.Group.Name }} <small>({{ group.Role }}{{ isLeaderIcon }})</small>
+                {% if group.IsLeader -%}
+                  {% assign pending = 0 -%}
+                  {% for member in group.Group.Members -%}
+                    {% if member.GroupMemberStatus == 'Pending' -%}
+                      {% assign pending = pending | Plus:1 -%}
+                    {% endif -%}
+                  {% endfor -%}
+                  {% if pending != 0 -%}
+                    <span title="number of pending members" class="badge badge-danger">{{ pending }}</span>
+                  {% endif -%}
+                {% endif -%}
+          </a>
+        </li>
     {% endfor %}
   </ul>
 
@@ -40,7 +62,7 @@
 <script type="text/javascript">
 
   $( document ).ready(function() {
-  $('.js-group-item').tooltip();
+      $('.js-group-item').tooltip();
   });
 
 </script>


### PR DESCRIPTION
# Rock PR Policy
The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
on your part and review time on ours, we have implemented the following guidelines for PRs:
1. If you are submitting a PR for a logged Issue / Enhancement request please reference it in your commit
2. If your PR is for an enhancement that has not been discussed and approved by the core team please get that approval BEFORE submitting
the request. In fact, this approval should be received before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.


## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Wanted the ability to display inactive groups in the Group List Personalized Lava block.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Give the users the ability to enable displaying inactive groups via a block setting.

## Strategy
_How have you implemented your solution?_

1. Added ability to Show inactive groups in GroupListPersonalizedLava block based on block setting
2. Added a couple more block settings to set the default display and give a PageParameter to be able to set it with a link.
3. Added lava merge fields for each new setting so you could do stuff based on the settings in the lava.
4. Updated the included lava in stark and rock themes to include a toggle if the block setting was enabled.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

All defaults are still the way the block has always functioned and requires a lava update to fully function as intended, it should not have any backwards compatibility issues or security considerations.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![image](https://user-images.githubusercontent.com/2990519/36803518-03ab4388-1c75-11e8-9bab-69afb3d02b78.png)

![image](https://user-images.githubusercontent.com/2990519/36803600-422edc5a-1c75-11e8-913f-66f35af7ba97.png)

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

Perhaps a UI screenshot could be added, but not necessary as it isn't the default.

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

No