### PR TITLE
Alternate Communication page on Group Details and Fix for Communication Entry

### DIFF
--- a/RockWeb/Blocks/Communication/CommunicationEntry.ascx.cs
+++ b/RockWeb/Blocks/Communication/CommunicationEntry.ascx.cs
@@ -809,11 +809,6 @@ namespace RockWeb.Blocks.Communication
 
             CommunicationId = communication.Id;
 
-            var firstMedium = communication.GetMediums().FirstOrDefault();
-            if ( firstMedium != null && firstMedium.EntityType != null )
-            {
-                MediumEntityTypeId = firstMedium.EntityType.Id;
-            }
             BindMediums();
 
             CommunicationData = new CommunicationDetails();
@@ -890,15 +885,15 @@ namespace RockWeb.Blocks.Communication
                     }
                 }
             }
+            if ( !MediumEntityTypeId.HasValue || MediumEntityTypeId.Value == 0 && mediums.Any() )
+            {
+                MediumEntityTypeId = mediums.First().Key;
+            }
 
             LoadTemplates();
 
             divMediums.Visible = mediums.Count() > 1;
 
-            if ( !MediumEntityTypeId.HasValue || MediumEntityTypeId.Value == 0 && mediums.Any() )
-            {
-                MediumEntityTypeId = mediums.First().Key;
-            }
             rptMediums.DataSource = mediums;
             rptMediums.DataBind();
         }

--- a/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
@@ -313,6 +313,13 @@
 					</a>
 				{% endif %}
 			{% endif %}
+            {% if LinkedPages.AlternateCommunicationPage != '' %}
+                {% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
+                <a href="#" onclick="{{ '' | Postback:'SendAlternateCommunication' }}" class="btn btn-default btn-xs">
+                    <i class="fa fa-mobile-phone"></i> Text Roster
+                </a>
+                {% endif %}
+            {% endif %}
 		</div>
 		</p>
 	{% endif %}


### PR DESCRIPTION
# Rock PR Policy
The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
on your part and review time on ours, we have implemented the following guidelines for PRs:
1. If you are submitting a PR for a logged Issue / Enhancement request please reference it in your commit
2. If your PR is for an enhancement that has not been discussed and approved by the core team please get that approval BEFORE submitting
the request. In fact, this approval should be received before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.


## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

We would like the ability to lock down another communication page to specifically SMS communication to specific roles/leaders only. Once I added the block setting I found that SMS was not the medium selected if that was the only medium selected.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Add a new block setting to be able to specify an additional communication page and still create the communication with a postback similar to existing code. And fix the medium issue.

## Strategy
_How have you implemented your solution?_

- Added alternate communication page setting for a "Text Roster" ability on Group Details.
- Fixed communication entry block to show the correct medium if it was the only medium chosen in block settings.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

![image](https://user-images.githubusercontent.com/2990519/36911512-ff561d34-1e00-11e8-97a6-7d9fc5439c16.png)

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
