### PR TITLE
Fixed registration instance active list block empty column

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationInstanceActiveList.ascx
+++ b/RockWeb/Blocks/Event/RegistrationInstanceActiveList.ascx
@@ -15,7 +15,6 @@
                                 <Rock:RockBoundField DataField="Name" HeaderText="Name" SortExpression="Name" />
                                 <Rock:DateField DataField="StartDateTime" HeaderText="Start Date" SortExpression="StartDateTime" />
                                 <Rock:DateField DataField="EndDateTime" HeaderText="End Date" SortExpression="EndDateTime" />
-                                <Rock:RockBoundField DataField="Details" HeaderText="Details" SortExpression="Details" />
                                 <Rock:RockBoundField DataField="Registrants" HeaderText="Registrants" SortExpression="Registrants" />
                                 <Rock:BoolField DataField="IsActive" HeaderText="Active" SortExpression="IsActive" />
                             </Columns>

--- a/RockWeb/Blocks/Event/RegistrationInstanceActiveList.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceActiveList.ascx.cs
@@ -128,7 +128,6 @@ namespace RockWeb.Blocks.Event
                         i.StartDateTime,
                         i.EndDateTime,
                         i.IsActive,
-                        i.Details,
                         Registrants = i.Registrations.Where( r => !r.IsTemporary ).SelectMany( r => r.Registrants ).Count()
                     } );
 


### PR DESCRIPTION
## Contributor Agreement
Yes

## Context
Fully fixes #2702

## Goal
Removes empty details column until the details property is utilized in the UI

## Strategy
Removing the details column from query and grid.

## Tests
N/A

## Possible Implications
None

## Screenshots
N/A

## Documentation
N/A

## Migrations
N//A
