### PR TITLE
Fixed issue with slingshot images getting enumerated multiple times

### DIFF
--- a/Rock.Slingshot/SlingshotImport/SlingshotImporter.cs
+++ b/Rock.Slingshot/SlingshotImport/SlingshotImporter.cs
@@ -103,10 +103,10 @@ namespace Rock.Slingshot
                          System.Diagnostics.Debug.WriteLine( $"Unable to extract {a.FullName} from imageZipFile: {ex.Message}" );
                      }
                  } );
-
-                var imageFilesInFolder = Directory.EnumerateFiles( extractedImagesFolder );
-                this.SlingshotImageFileNames.AddRange( imageFilesInFolder );
             }
+
+            var imageFilesInFolder = Directory.EnumerateFiles( extractedImagesFolder );
+            this.SlingshotImageFileNames.AddRange( imageFilesInFolder );
 
             BulkImporter = new BulkImporter();
             BulkImporter.ImportUpdateOption = importUpdateType;


### PR DESCRIPTION
# Rock PR Policy
The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
on your part and review time on ours, we have implemented the following guidelines for PRs:
1. If you are submitting a PR for a logged Issue / Enhancement request please reference it in your commit
2. If your PR is for an enhancement that has not been discussed and approved by the core team please get that approval BEFORE submitting
the request. In fact, this approval should be received before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.


## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Noticed that when uploading multiple slingshot image files to Rock that the total image count was off.  Also, the import takes much longer since the images get imported multiple times.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix it by enumerating the photos at the end.

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

N/A

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

N/A

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

N/A
