### PR TITLE
Fixed not able to save checkin areas due to validation

### DIFF
--- a/Rock/Model/GroupType.cs
+++ b/Rock/Model/GroupType.cs
@@ -474,7 +474,7 @@ namespace Rock.Model
             set { _triggers = value; }
         }
         private ICollection<GroupMemberWorkflowTrigger> _triggers;
-        
+
         /// <summary>
         /// Gets or sets the group schedule exclusions.
         /// </summary>
@@ -579,8 +579,10 @@ namespace Rock.Model
         /// <summary>
         /// A dictionary of actions that this class supports and the description of each.
         /// </summary>
-        public override Dictionary<string, string> SupportedActions {
-            get {
+        public override Dictionary<string, string> SupportedActions
+        {
+            get
+            {
                 if ( _supportedActions == null )
                 {
                     _supportedActions = new Dictionary<string, string>();
@@ -630,10 +632,17 @@ namespace Rock.Model
                         }
                     }
 
-                    if ( string.IsNullOrEmpty( GroupViewLavaTemplate ) )
+                    if ( string.IsNullOrWhiteSpace( GroupViewLavaTemplate ) )
                     {
-                        this.ValidationResults.Add( new ValidationResult( "Lava template for group view is mandatory." ) );
-                        return false;
+                        if ( InheritedGroupType != null && !string.IsNullOrWhiteSpace( InheritedGroupType.GroupViewLavaTemplate ) )
+                        {
+                            GroupViewLavaTemplate = InheritedGroupType.GroupViewLavaTemplate;
+                        }
+                        else
+                        {
+                            this.ValidationResults.Add( new ValidationResult( "Lava template for group view is mandatory." ) );
+                            return false;
+                        }
                     }
                 }
 
@@ -648,7 +657,7 @@ namespace Rock.Model
         /// <param name="state">The state.</param>
         public override void PreSaveChanges( Rock.Data.DbContext dbContext, System.Data.Entity.EntityState state )
         {
-            if (state == System.Data.Entity.EntityState.Deleted)
+            if ( state == System.Data.Entity.EntityState.Deleted )
             {
                 ChildGroupTypes.Clear();
 
@@ -672,7 +681,7 @@ namespace Rock.Model
                 var changeEntry = dbContext.ChangeTracker.Entries<GroupType>().Where( a => a.Entity == this ).FirstOrDefault();
                 if ( changeEntry != null )
                 {
-                    var originalIndexState = (bool)changeEntry.OriginalValues["IsIndexEnabled"];
+                    var originalIndexState = ( bool ) changeEntry.OriginalValues["IsIndexEnabled"];
 
                     if ( originalIndexState == true && IsIndexEnabled == false )
                     {
@@ -833,7 +842,7 @@ namespace Rock.Model
             var groups = new GroupService( rockContext ).Queryable()
                                             .Where( g =>
                                                 g.GroupTypeId == groupTypeId
-                                                && g.IsActive);
+                                                && g.IsActive );
 
             foreach ( var group in groups )
             {

--- a/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinArea.cs
+++ b/Rock/Web/UI/Controls/Checkin Configuration Controls/CheckinArea.cs
@@ -206,14 +206,19 @@ namespace Rock.Web.UI.Controls
         /// Gets the type of the checkin group.
         /// </summary>
         /// <param name="groupType">Type of the group.</param>
-        public void GetGroupTypeValues( GroupType groupType )
+        public void GetGroupTypeValues( GroupType groupType, RockContext rockContext )
         {
             EnsureChildControls();
 
             groupType.Name = _tbGroupTypeName.Text;
-            groupType.InheritedGroupTypeId = _ddlGroupTypeInheritFrom.SelectedValueAsId();
             groupType.AttendanceRule = _ddlAttendanceRule.SelectedValueAsEnum<AttendanceRule>();
             groupType.AttendancePrintTo = _ddlPrintTo.SelectedValueAsEnum<PrintTo>();
+
+            groupType.InheritedGroupTypeId = _ddlGroupTypeInheritFrom.SelectedValueAsId();
+            if ( groupType.InheritedGroupTypeId != null && groupType.InheritedGroupTypeId != 0 )
+            {
+                groupType.InheritedGroupType = new GroupTypeService( rockContext ).Get( groupType.InheritedGroupTypeId ?? 0 );
+            }
 
             // Reload Attributes
             groupType.Attributes = null;
@@ -236,8 +241,8 @@ namespace Rock.Web.UI.Controls
                 GroupTypeGuid = groupType.Guid;
                 _tbGroupTypeName.Text = groupType.Name;
                 _ddlGroupTypeInheritFrom.SetValue( groupType.InheritedGroupTypeId );
-                _ddlAttendanceRule.SetValue( (int)groupType.AttendanceRule );
-                _ddlPrintTo.SetValue( (int)groupType.AttendancePrintTo );
+                _ddlAttendanceRule.SetValue( ( int ) groupType.AttendanceRule );
+                _ddlPrintTo.SetValue( ( int ) groupType.AttendancePrintTo );
 
                 CreateGroupTypeAttributeControls( groupType, rockContext );
             }
@@ -387,7 +392,7 @@ namespace Rock.Web.UI.Controls
         /// </summary>
         /// <param name="groupType">Type of the group.</param>
         /// <param name="rockContext">The rock context.</param>
-        public void CreateGroupTypeAttributeControls( GroupType groupType,  RockContext rockContext )
+        public void CreateGroupTypeAttributeControls( GroupType groupType, RockContext rockContext )
         {
             EnsureChildControls();
 
@@ -419,7 +424,7 @@ namespace Rock.Web.UI.Controls
                 var groupType = new GroupTypeService( rockContext ).Get( GroupTypeGuid );
                 if ( groupType != null )
                 {
-                    GetGroupTypeValues( groupType );
+                    GetGroupTypeValues( groupType, rockContext );
                     CreateGroupTypeAttributeControls( groupType, rockContext );
                 }
             }

--- a/RockWeb/Blocks/CheckIn/Config/CheckinAreas.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Config/CheckinAreas.ascx.cs
@@ -520,7 +520,7 @@ namespace RockWeb.Blocks.CheckIn.Config
                     if ( groupType != null )
                     {
                         groupType.LoadAttributes( rockContext );
-                        checkinArea.GetGroupTypeValues( groupType );
+                        checkinArea.GetGroupTypeValues( groupType, rockContext   );
 
                         if ( groupType.IsValid )
                         {


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
While trying to save a new check-in area Rock (V8) threw the validation error:  "Lava template for group view is mandatory." This is because new check-in areas are group types which do not have a lava display template generated for them.

## Goal
Fix the validation issue.

## Strategy
I changed the GroupType validation so that if the entity doesn't have a lava template it will add on the lava template of it's inherited group type. If it's inherited group type doesn't have a template the validation will fail. 

I also did some work so that the CheckInArea control will add the inherited group type to the entity so that it can be properly validated.

## Tests
Tested creating new area and on existing areas. Tested creating and updating group types.

## Possible Implications
None

## Screenshots
N/A

## Documentation
N/A

## Migrations
N/A
