### PR TITLE
Adding an option to allow for not displaying workflow entry in a panel.

### DIFF
--- a/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx
+++ b/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx
@@ -6,9 +6,9 @@
         <div class="row">
             <div id="divForm" runat="server" class="col-md-6">
 
-                <div class="panel panel-block">
+                <div class="panel panel-block" id="divPanel" runat="server">
 
-                    <div class="panel-heading">
+                    <div class="panel-heading" id="divPanelHeading" runat="server">
                         <h1 class="panel-title">
                             <asp:Literal ID="lIconHtml" runat="server" ><i class="fa fa-gear"></i></asp:Literal>
                             <asp:Literal ID="lTitle" runat="server" >Workflow Entry</asp:Literal>
@@ -18,7 +18,7 @@
                             <Rock:HighlightLabel ID="hlblDateAdded" runat="server" LabelType="Default" />
                         </div>
                     </div>
-                    <div class="panel-body">
+                    <div class="panel-body" id="divPanelBody" runat="server">
 
                         <asp:Literal ID="lSummary" runat="server" Visible="false" />
 

--- a/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
@@ -43,6 +43,7 @@ namespace RockWeb.Blocks.WorkFlow
 
     [WorkflowTypeField( "Workflow Type", "Type of workflow to start." )]
     [BooleanField( "Show Summary View", "If workflow has been completed, should the summary view be displayed?", false, "", 1)]
+    [BooleanField( "Display in Panel", "Should this workflow entry display in a panel block?", true, "", 2)]
     public partial class WorkflowEntry : Rock.Web.UI.RockBlock, IPostBackEventHandler
     {
         #region Fields
@@ -171,6 +172,13 @@ namespace RockWeb.Blocks.WorkFlow
             base.OnLoad( e );
 
             nbMessage.Visible = false;
+
+            if ( !GetAttributeValue( "DisplayinPanel" ).AsBoolean() )
+            {
+                divPanel.RemoveCssClass( "panel panel-block" );
+                divPanelBody.RemoveCssClass( "panel-body" );
+                divPanelHeading.Visible = false;
+            }
 
             if ( !Page.IsPostBack )
             {


### PR DESCRIPTION
# Rock PR Policy
The Rock Community loves Pull Requests! In an effort to 'row in the same direction' and minimize wasted development time
on your part and review time on ours, we have implemented the following guidelines for PRs:
1. If you are submitting a PR for a logged Issue / Enhancement request please reference it in your commit
2. If your PR is for an enhancement that has not been discussed and approved by the core team please get that approval BEFORE submitting
the request. In fact, this approval should be received before writing the code to limit rework on your part. This will ensure that all code is working into the same vision and direction of the core project.


## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_
We often want to use the workflow entry block without displaying it in a panel.  It's pretty easy to hide it with CSS but that feels wrong.

## Goal
_What will this pull request achieve and how will this fix the problem?_
This adds a block attribute giving you the option to not show the panel.

## Strategy
_How have you implemented your solution?_
The OnLoad method simply removes the css and hides the heading of the panel if the panel is set to not display.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._
None

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_
None that I know of

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._
With the panel:
![image](https://user-images.githubusercontent.com/1248118/37111707-6393c826-220e-11e8-96d5-35913f604bb6.png)
Without the panel:
![image](https://user-images.githubusercontent.com/1248118/37111762-9009937c-220e-11e8-818f-5f6aeafd7554.png)

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_
I don't think it needs documented but I'm not sure if documentation for the Workflow Entry block exists somewhere.

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
None.