### PR TITLE
Added new DataView filter for Days Until Anniversary

### DIFF
--- a/Rock.Migrations/Migrations/20180313_AddDaysUntilAnniversary.sql
+++ b/Rock.Migrations/Migrations/20180313_AddDaysUntilAnniversary.sql
@@ -1,0 +1,42 @@
+﻿BEGIN TRY
+    ALTER TABLE Person
+
+    DROP COLUMN DaysUntilAnniversary
+END TRY
+
+BEGIN CATCH
+END CATCH
+
+ALTER TABLE Person ADD DaysUntilAnniversary AS (
+    CASE 
+        -- if there anniversary is Feb 29 and their next anniversary is this year and it isn't a leap year, set their anniversary to Feb 28 (this year)
+        WHEN (
+                DATEPART(MONTH, AnniversaryDate) = 2
+                AND DATEPART(DAY, AnniversaryDate) = 29
+                AND datepart(month, sysdatetime()) < 3
+                AND (isdate(convert(VARCHAR(4), datepart(year, sysdatetime())) + '-02-29') = 0)
+                )
+            THEN datediff(day, sysdatetime(), convert(DATE, convert(VARCHAR(4), datepart(year, sysdatetime())) + '-02-28'))
+        -- if there anniversary is Feb 29 and their next anniversary is next year and it isn't a leap year, set their anniversary to Feb 28 (next year)
+        WHEN (
+                DATEPART(MONTH, AnniversaryDate) = 2
+                AND DATEPART(DAY, AnniversaryDate) = 29
+                AND (isdate(convert(VARCHAR(4), datepart(year, dateadd(year, 1, sysdatetime()))) + '-02-29') = 0)
+                )
+            THEN datediff(day, sysdatetime(), convert(DATE, convert(VARCHAR(4), datepart(year, dateadd(year, 1, sysdatetime()))) + '-02-28'))
+        -- otherwise return the number of days normally if they have a valid Anniversary Month and Anniversary Day 
+        ELSE CASE 
+                WHEN ((DATEPART(MONTH, AnniversaryDate) = 2 and DATEPART(DAY, AnniversaryDate) < 30) or
+                isdate(convert(VARCHAR(4), datepart(year, sysdatetime())) + '-' + right('00' + CONVERT([varchar](2), DATEPART(MONTH, AnniversaryDate)), (2)) + '-' + right('00' + CONVERT([varchar](2), DATEPART(DAY, AnniversaryDate)), (2))) = 1
+                )
+                    THEN CASE 
+                            WHEN ( (datepart(month, sysdatetime())*100) + datepart(day,sysdatetime()) > ((DATEPART(MONTH, AnniversaryDate)*100) + DATEPART(DAY, AnniversaryDate)))
+                                -- next anniversary is next year
+                                THEN datediff(day, sysdatetime(), convert(DATE, convert(VARCHAR(4), datepart(year, dateadd(year, 1, sysdatetime()))) + '-' + right('00' + CONVERT([varchar](2), DATEPART(MONTH, AnniversaryDate)), (2)) + '-' + right('00' + CONVERT([varchar](2), DATEPART(DAY, AnniversaryDate)), (2))))
+                                -- next anniversary is this year
+                                ELSE datediff(day, sysdatetime(), convert(DATE, convert(VARCHAR(4), datepart(year, sysdatetime())) + '-' + right('00' + CONVERT([varchar](2), DATEPART(MONTH, AnniversaryDate)), (2)) + '-' + right('00' + CONVERT([varchar](2), DATEPART(DAY, AnniversaryDate)), (2))))
+                            END
+                ELSE NULL
+                END
+        END
+    )    

--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -1342,6 +1342,19 @@ namespace Rock.Model
         }
 
         /// <summary>
+        /// Gets or sets the number of days until their next anniversay. This is a computed column and can be used
+        /// in LinqToSql queries, but there is no in-memory calculation. Avoid using property outside
+        /// a linq query
+        /// NOTE: If their anniversay is Feb 29, and this isn't a leap year, it'll treat Feb 28th as their anniversay when doing this calculation
+        /// </summary>
+        /// <value>
+        /// The the number of days until their next anniversary
+        /// </value>
+        [DataMember]
+        [DatabaseGenerated( DatabaseGeneratedOption.Computed )]
+        public int? DaysUntilAnniversary { get; set; }
+
+        /// <summary>
         /// Gets or sets the grade offset, which is the number of years until their graduation date.  This is used to determine which Grade (Defined Value) they are in
         /// </summary>
         /// <value>


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #662.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Ability to query in a DataView by the number of days until an anniversary, in the same way you can filter by the number of days until a birthday.

## Strategy
_How have you implemented your solution?_

Add the placeholder property in the code and a new SQL script to add a dynamic column that is calculated the same way as the Days Until Birthday column.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

The SQL script (copied from the birthday version) to generate the column is included, but no migration was generated.