### PR TITLE
Added support to the Lava Sql block for Parameterized SQL statements

### DIFF
--- a/Rock/Lava/Blocks/Sql.cs
+++ b/Rock/Lava/Blocks/Sql.cs
@@ -127,13 +127,12 @@ namespace Rock.Lava.Blocks
                     internalMergeFields.AddOrReplace( item.Key, item.Value );
                 }
             }
-            var resolvedMarkup = markup.ResolveMergeFields( internalMergeFields );
 
             var parms = new Dictionary<string, string>();
             parms.Add( "return", "results" );
             parms.Add( "statement", "select" );
 
-            var markupItems = Regex.Matches( resolvedMarkup, "(.*?:'[^']+')" )
+            var markupItems = Regex.Matches( markup, "(.*?:'[^']+')" )
                 .Cast<Match>()
                 .Select( m => m.Value )
                 .ToList();
@@ -143,7 +142,14 @@ namespace Rock.Lava.Blocks
                 var itemParts = item.ToString().Split( new char[] { ':' }, 2 );
                 if ( itemParts.Length > 1 )
                 {
-                    parms.AddOrReplace( itemParts[0].Trim().ToLower(), itemParts[1].Trim().Substring( 1, itemParts[1].Length - 2 ) );
+                    var value = itemParts[1];
+
+                    if ( value.HasMergeFields() )
+                    {
+                        value = value.ResolveMergeFields( internalMergeFields );
+                    }
+
+                    parms.AddOrReplace( itemParts[0].Trim().ToLower(), value.Substring( 1, value.Length - 2 ).Trim() );
                 }
             }
             return parms;


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2866. Currently no way to use SQL parameters with Lava `{% sql %}` syntax which makes it harder to protect against SQL injection.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Provide parameters to `{% sql %}` syntax. See original issue for example(s).

## Strategy
_How have you implemented your solution?_

Added new code for passing extra parameters specified in the `{% sql %}` command into the SQL statement.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

https://www.rockrms.com/page/748 will need to be updated to provide an example of how to use parameters.

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
