### PR TITLE
Fixed bug in Purchased Plugins page that would throw exception if a plugin is not installed

### DIFF
--- a/RockWeb/Blocks/Store/PurchasedPackages.ascx.cs
+++ b/RockWeb/Blocks/Store/PurchasedPackages.ascx.cs
@@ -104,6 +104,11 @@ namespace RockWeb.Blocks.Store
             DisplayPackages();
         }
 
+        /// <summary>
+        /// Handles the ItemDataBound event of the rptPurchasedProducts control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
         protected void rptPurchasedProducts_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
             var package = e.Item.DataItem as Package;
@@ -127,6 +132,12 @@ namespace RockWeb.Blocks.Store
                 lbInstall.Attributes.Add( "disabled", "disabled" );
                 lbInstall.CssClass = "btn btn-default margin-b-md";
             }
+            else if ( installedPackage == null )
+            {
+                lbInstall.Text = "Install";
+
+                lVersionNotes.Text = String.Format( "<p><strong>Latest Version</strong><br/>{0}</p>", latestVersion.VersionLabel );
+            }
             else if ( installedPackage.VersionId != latestVersion.Id )
             {
                 lbInstall.Text = "Update";
@@ -143,6 +154,11 @@ namespace RockWeb.Blocks.Store
             }
         }
 
+        /// <summary>
+        /// Handles the ItemCommand event of the rptPurchasedProducts control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
         protected void rptPurchasedProducts_ItemCommand( object source, RepeaterCommandEventArgs e )
         {
             var queryParams = new Dictionary<string, string>();


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2882. If you have purchased a plugin but it is not installed on the server, then viewing your purchased plugins will throw a null reference exception. This can happen, for example, if you have installed a plugin on your production system but not yet installed it on your dev system.

I think I did this correctly against the hotfix-1.7.4 branch.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the null reference exception so the user can see their purchase history.

## Strategy
_How have you implemented your solution?_

Check if there is no installed version of the plugin. If that is the case then display an Install button along with the latest available version.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

<img width="413" alt="installpackage" src="https://user-images.githubusercontent.com/1119863/37546249-23ce79d0-2929-11e8-9162-6ab6d692ce08.png">

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
