### PR TITLE
Added missing order on fees

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -3852,7 +3852,7 @@ namespace RockWeb.Blocks.Event
                 // If the current form, is the last one, add any fee controls
                 if ( FormCount - 1 == CurrentFormIndex && !registrant.OnWaitList )
                 {
-                    foreach ( var fee in RegistrationTemplate.Fees.Where( f => f.IsActive == true ) )
+                    foreach ( var fee in RegistrationTemplate.Fees.Where( f => f.IsActive == true ).OrderBy( o => o .Order ) )
                     {
                         var feeValues = new List<FeeInfo>();
                         if ( registrant != null && registrant.FeeValues.ContainsKey( fee.Id ) )


### PR DESCRIPTION
Fees should retain the order they were assigned when showing on the form.

## Context
Fees are not being ordered on the form.

## Goal
Orders the fees.

## Possible Implications
N.A.
