### PR TITLE
Updates to Notification List block to mark notifications as read intead of deleting them

### DIFF
--- a/RockWeb/Blocks/Administration/NotificationList.ascx
+++ b/RockWeb/Blocks/Administration/NotificationList.ascx
@@ -16,9 +16,12 @@
                 <asp:Repeater ID="rptNotifications" OnItemDataBound="rptNotifications_ItemDataBound" OnItemCommand="rptProjects_ItemCommand" runat="server" >
                     <ItemTemplate>
                         <div class="alert" id="rptNotificationAlert" runat="server">
-                            <div class="pull-right"><asp:LinkButton runat="server" CssClass="action" CommandName="Close" CommandArgument='<%#Eval("Guid") %>'><i class="fa fa-times"></i></asp:LinkButton></div>
-                            <h4><%# Eval("Notification.Title") %></h4>
-                            <p><%# Eval("Notification.Message") %></p>
+                            <div class="pull-right"><asp:LinkButton runat="server" CssClass="action" CommandName="Close" CommandArgument='<%#Eval("Guid") %>' CausesValidation="false"><i class="fa fa-times"></i></asp:LinkButton></div>
+                            <h4>
+                                <i id="iIconCssClass" runat="server" class='<%# Eval("Notification.IconCssClass") %>'></i>
+                                <span><%# Eval("Notification.Title") %></span>
+                            </h4>
+                            <div class="notification-content"><%# Eval("Notification.Message") %></div>
                         </div>
                     </ItemTemplate>
                 </asp:Repeater>

--- a/RockWeb/Blocks/Administration/NotificationList.ascx.cs
+++ b/RockWeb/Blocks/Administration/NotificationList.ascx.cs
@@ -142,7 +142,8 @@ namespace RockWeb.Blocks.Utility
                     var notificationItem = notificationRecipientService.Get( notificationRecipientGuid.Value );
                     if ( notificationItem != null )
                     {
-                        notificationRecipientService.Delete( notificationItem );
+                        notificationItem.Read = true;
+                        notificationItem.ReadDateTime = RockDateTime.Now;
                     }
 
                     var toHide = e.Item.FindControl( "rptNotificationAlert" );
@@ -168,6 +169,9 @@ namespace RockWeb.Blocks.Utility
             var div = e.Item.FindControl( "rptNotificationAlert" ) as HtmlGenericControl;
             string alertType = notificationRecipient.Notification.Classification.ToString().ToLowerInvariant();
             div.AddCssClass( "alert-" + alertType );
+
+            var icon = e.Item.FindControl( "iIconCssClass" ) as HtmlGenericControl;
+            icon.Visible = !string.IsNullOrWhiteSpace( notificationRecipient.Notification.IconCssClass );
         }
     }
 }

--- a/RockWeb/Blocks/Administration/NotificationList.ascx.cs
+++ b/RockWeb/Blocks/Administration/NotificationList.ascx.cs
@@ -34,16 +34,18 @@ using System.Web.UI.HtmlControls;
 namespace RockWeb.Blocks.Utility
 {
     /// <summary>
-    /// Template block for developers to use to start a new block.
+    /// Displays notifications to the user and allows them to be marked as read.
     /// </summary>
     [DisplayName( "Notification List" )]
     [Category( "Core" )]
     [Description( "Displays Notifications." )]
     public partial class NotificationList : Rock.Web.UI.RockBlock
     {
-
         #region Properties
 
+        /// <summary>
+        /// Gets or sets the number of notifications currently being displayed.
+        /// </summary>
         public int NotificationCount
         {
             get { return ViewState["NotificationCount"] as int? ?? 0; }
@@ -53,8 +55,6 @@ namespace RockWeb.Blocks.Utility
         #endregion
 
         #region Base Control Methods
-
-        //  overrides of the base RockBlock methods (i.e. OnInit, OnLoad)
 
         /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
@@ -107,8 +107,6 @@ namespace RockWeb.Blocks.Utility
 
         #region Events
 
-        // handlers called by the controls on your block
-
         /// <summary>
         /// Handles the BlockUpdated event of the control.
         /// </summary>
@@ -119,17 +117,11 @@ namespace RockWeb.Blocks.Utility
             OnLoad( e );
         }
 
-        #endregion
-
-        #region Methods
-
-        protected void HidePanel()
-        {
-            upnlContent.Visible = false;
-        }
-
-        #endregion
-
+        /// <summary>
+        /// Handles the ItemCommand event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterCommandEventArgs"/> instance containing the event data.</param>
         protected void rptProjects_ItemCommand( object Sender, RepeaterCommandEventArgs e )
         {
             if ( e.CommandName == "Close" )
@@ -155,7 +147,7 @@ namespace RockWeb.Blocks.Utility
                     rockContext.SaveChanges();
 
                     NotificationCount--;
-                    if (NotificationCount == 0 )
+                    if ( NotificationCount == 0 )
                     {
                         HidePanel();
                     }
@@ -163,6 +155,11 @@ namespace RockWeb.Blocks.Utility
             }
         }
 
+        /// <summary>
+        /// Handles the ItemDataBound event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterCommandEventArgs"/> instance containing the event data.</param>
         protected void rptNotifications_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
             var notificationRecipient = e.Item.DataItem as NotificationRecipient;
@@ -173,5 +170,19 @@ namespace RockWeb.Blocks.Utility
             var icon = e.Item.FindControl( "iIconCssClass" ) as HtmlGenericControl;
             icon.Visible = !string.IsNullOrWhiteSpace( notificationRecipient.Notification.IconCssClass );
         }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Hides the top-most content panel of this block so it is no longer visible.
+        /// </summary>
+        protected void HidePanel()
+        {
+            upnlContent.Visible = false;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2896. Notifications were deleted instead of marked as read, thus making it impossible to tell when a user read (that is, acknowledged) the notification.

Also fixed up a few UI issues and some comments and method locations in the code behind.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Notifications should be marked as read instead of deleted.

## Strategy
_How have you implemented your solution?_

1. When clicking the "X" button the notification recipient record is now marked `Read = 1` and `ReadDateTime = RockDateTime.Now()` instead of being deleted.
2. The "X" button no longer causes validation, which can cause issues if other blocks are on the page with required fields.
3. If the notification has an IconCssClass defined, it is displayed to the left of the title.
4. The notification message is now wrapped in a `<div></div>` instead of `<p></p>`.
5. Various fixes to missing and incorrect comments in the code behind.
6. Moved the two event methods that were not part of a region into the Events region in the code behind.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

Before and after of the `<p>` to `<div>` change. The 7.0 notice is "plain text" (no wrapping element). The 7.3 notice is wrapped inside a `<p>` already (this was actually causing triple paragraph tags to be rendered in the client).

<img width="535" alt="notificationsample" src="https://user-images.githubusercontent.com/1119863/37932669-f9937332-30fd-11e8-8f08-4b1e7da19bf7.png">

Full screenshot with the icon on display in all it's glory:

<img width="535" alt="notificationfullsample" src="https://user-images.githubusercontent.com/1119863/37932759-2e33f83c-30fe-11e8-960c-60d748817ba3.png">

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
