### PR TITLE
Fixed Fundraising Progress to not divide by zero if goal is zero.

### DIFF
--- a/RockWeb/Blocks/Fundraising/FundraisingProgress.ascx.cs
+++ b/RockWeb/Blocks/Fundraising/FundraisingProgress.ascx.cs
@@ -171,7 +171,7 @@ namespace RockWeb.Blocks.Fundraising
                 decimal percentageAchieved = 0;
                 if ( individualFundraisingGoal != null )
                 {
-                    percentageAchieved = individualFundraisingGoal == 0 ? 0 : contributionTotal / ( 0.01M * individualFundraisingGoal.Value );
+                    percentageAchieved = individualFundraisingGoal == 0 ? 100 : contributionTotal / ( 0.01M * individualFundraisingGoal.Value );
                 }
 
                 var progressBarWidth = percentageAchieved;
@@ -200,7 +200,7 @@ namespace RockWeb.Blocks.Fundraising
 
             this.GroupIndividualFundraisingGoal = groupMemberList.Sum( a => decimal.Parse( a.IndividualFundraisingGoal ) );
             this.GroupContributionTotal = groupMemberList.Sum( a => decimal.Parse( a.ContributionTotal ) );
-            this.PercentComplete = decimal.Round( this.GroupContributionTotal == 0 ? 0 : this.GroupContributionTotal / ( this.GroupIndividualFundraisingGoal * 0.01M ), 2 );
+            this.PercentComplete = decimal.Round( this.GroupIndividualFundraisingGoal == 0 ? 100 : this.GroupContributionTotal / ( this.GroupIndividualFundraisingGoal * 0.01M ), 2 );
             this.ProgressCssClass = GetProgressCssClass( this.PercentComplete );
 
             rptFundingProgress.DataSource = groupMemberList;


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

See #2897. If the total goal amount for the main progress bar was 0, a divide by zero error occurred.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the bug.

## Strategy
_How have you implemented your solution?_

Computers should be able to divide by zero, but changing the code to not divide by zero seemed like a simpler solution.

Progress bars now show 100% if the goal is zero since the goal would always be reached.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

If somebody had a goal of zero and a negative balance (not sure how that could happen), it would probably still show 100% complete.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
