### PR TITLE
+ Added PersonByAliasGuid lava filter

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -1981,6 +1981,33 @@ namespace Rock.Lava
         }
 
         /// <summary>
+        /// Loads a person by their alias guid
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="input">The input.</param>
+        /// <returns></returns>
+        public static Person PersonByAliasGuid( DotLiquid.Context context, object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            Guid? personAliasGuid = input.ToString().AsGuidOrNull();
+
+            if ( personAliasGuid.HasValue )
+            {
+                var rockContext = new RockContext();
+
+                return new PersonAliasService( rockContext ).Get( personAliasGuid.Value ).Person;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Persons the by alias identifier.
         /// </summary>
         /// <param name="context">The context.</param>


### PR DESCRIPTION
## Documentation
Usage: {% assign person = Guid | PersonByAliasGuid %}

Allows a person to be loaded via a person alias guid. Useful in cases where a long-lived url referencing a person needs to exist, but a person alias id isn't appropriate for issues related to privacy.

(In our specific example at CCV, we email links to baptism photos. We don't use IDs because they can be enumerated by the recipient to view other's photos. We don't use the direct person guid because it can be lost during a person merge.)


