### PR TITLE
Added support for automated registration discounts

### DIFF
--- a/Rock/Model/RegistrationTemplateDiscount.cs
+++ b/Rock/Model/RegistrationTemplateDiscount.cs
@@ -132,6 +132,15 @@ namespace Rock.Model
         [DataMember]
         public DateTime? EndDate { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the discount applies automatically.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this discount applies automatically; otherwise, <c>false</c>.
+        /// </value>
+        [DataMember]
+        public bool AutoApplyDiscount { get; set; }
+
         #endregion
 
         #region Virtual Properties

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -3453,6 +3453,11 @@ namespace RockWeb.Blocks.Event
         {
             CurrentPanel = currentPanel;
 
+            if ( CurrentPanel == 2 )
+            {
+                AutoApplyDiscounts();
+            }               
+
             CreateDynamicControls( true );
 
             pnlHowMany.Visible = CurrentPanel <= 0;
@@ -5104,6 +5109,83 @@ namespace RockWeb.Blocks.Event
         #endregion
 
         #endregion
+
+        /// <summary>
+        /// Applies the first automatic discount that matches the set limits.
+        /// </summary>
+        private void AutoApplyDiscounts()
+        {
+            if ( RegistrationState != null )
+            {
+                RegistrationState.Registrants.ForEach( r => r.DiscountApplies = true );
+
+                var discounts = RegistrationTemplate.Discounts
+                        .Where( d => d.AutoApplyDiscount )
+                        .OrderBy( d => d.Order )
+                        .ToList();
+
+                foreach ( var discount in discounts )
+                {
+                    bool validDiscount = true;
+
+                    if ( validDiscount && discount.MinRegistrants.HasValue && RegistrationState.RegistrantCount < discount.MinRegistrants.Value )
+                    {
+                        nbDiscountCode.Visible = true;
+                        validDiscount = false;
+                    }
+
+                    if ( validDiscount && discount.StartDate.HasValue && RockDateTime.Today < discount.StartDate.Value )
+                    {
+                        nbDiscountCode.Visible = true;
+                        validDiscount = false;
+                    }
+
+                    if ( validDiscount && discount.EndDate.HasValue && RockDateTime.Today > discount.EndDate.Value )
+                    {
+                        nbDiscountCode.Visible = true;
+                        validDiscount = false;
+                    }
+
+                    if ( validDiscount && discount.MaxUsage.HasValue && RegistrationInstanceState != null )
+                    {
+                        using ( var rockContext = new RockContext() )
+                        {
+                            var instances = new RegistrationService( rockContext )
+                                .Queryable().AsNoTracking()
+                                .Where( r =>
+                                    r.RegistrationInstanceId == RegistrationInstanceState.Id &&
+                                    ( !RegistrationState.RegistrationId.HasValue || r.Id != RegistrationState.RegistrationId.Value ) &&
+                                    r.DiscountCode == discount.Code )
+                                .Count();
+                            if ( instances >= discount.MaxUsage.Value )
+                            {
+                                nbDiscountCode.Visible = true;
+                                validDiscount = false;
+                            }
+                        }
+                    }
+
+                    if ( validDiscount && discount.MaxRegistrants.HasValue )
+                    {
+                        for ( int i = 0; i < RegistrationState.Registrants.Count; i++ )
+                        {
+                            RegistrationState.Registrants[i].DiscountApplies = i < discount.MaxRegistrants.Value;
+                        }
+                    }
+
+                    RegistrationState.DiscountCode = validDiscount ? discount.Code : string.Empty;
+                    RegistrationState.DiscountPercentage = validDiscount ? discount.DiscountPercentage : 0.0m;
+                    RegistrationState.DiscountAmount = validDiscount ? discount.DiscountAmount : 0.0m;
+
+                    if ( validDiscount )
+                    {
+                        nbDiscountCode.Visible = true;
+                        nbDiscountCode.Text = string.Format( "The {0} '{1}' was applied automatically.", DiscountCodeTerm, discount.Code );
+                        break;
+                    }
+                }
+            }
+        }
 
         #endregion
     }

--- a/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx
@@ -443,6 +443,8 @@
                         </Rock:RockRadioButtonList>
                         <Rock:NumberBox ID="nbDiscountPercentage" runat="server" AppendText="%" CssClass="input-width-md" Label="Discount Percentage" NumberType="Integer" ValidationGroup="Discount"  />
                         <Rock:CurrencyBox ID="cbDiscountAmount" runat="server" CssClass="input-width-md" Label="Discount Amount" ValidationGroup="Discount" />
+                        <Rock:RockCheckBox ID="cbcAutoApplyDiscount" runat="server" Label="Auto Apply Discount" 
+                            Help="Will automatically apply the discount if the registration meet the criteria.  If multiple automatic discounts exist, only the first one that meets the criteria will be applied." />
                     </div>
                     <div class="col-md-6">
                         <Rock:NumberBox ID="nbDiscountMaxUsage" runat="server" NumberType="Integer" MinimumValue="0" Label="Maximum Usage" 

--- a/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx.cs
@@ -1110,6 +1110,7 @@ namespace RockWeb.Blocks.Event
                     discount.MinRegistrants = discountUI.MinRegistrants;
                     discount.StartDate = discountUI.StartDate;
                     discount.EndDate = discountUI.EndDate;
+                    discount.AutoApplyDiscount = discountUI.AutoApplyDiscount;
                 }
 
                 // add/updated fees
@@ -1717,6 +1718,7 @@ namespace RockWeb.Blocks.Event
             discount.MinRegistrants = nbDiscountMinRegistrants.Text.AsIntegerOrNull();
             discount.StartDate = drpDiscountDateRange.LowerValue;
             discount.EndDate = drpDiscountDateRange.UpperValue;
+            discount.AutoApplyDiscount = cbcAutoApplyDiscount.Checked;
 
             HideDialog();
 
@@ -2776,6 +2778,7 @@ namespace RockWeb.Blocks.Event
             nbDiscountMinRegistrants.Text = discount.MinRegistrants.HasValue ? discount.MinRegistrants.ToString() : string.Empty;
             drpDiscountDateRange.LowerValue = discount.StartDate;
             drpDiscountDateRange.UpperValue = discount.EndDate;
+            cbcAutoApplyDiscount.Checked = discount.AutoApplyDiscount;
 
             ShowDialog( "Discounts" );
         }


### PR DESCRIPTION
## Context
There are times when an organization has an event that offers a discount.  Instead of providing a discount code, they want to have the discount apply automatically based on the configured limits.

*Scenario 1: Group Discounts*
An organization offers an event with a cost of $25 per person.  If two or more people are registered together, the cost is automatically reduced to $15 per person.

 *Scenario 2: Limited Time Discount*
An organization offers an event that has a limited time discount.  If the person registers before the deadline, they automatically receive a 20% discount.


## Strategy
This will add a new registration discount setting that will allow the discount to be applied automatically based on the configured limits:
![image](https://user-images.githubusercontent.com/2349102/38276223-2611d34e-3749-11e8-9dc1-dbd708460895.png)


When the registrar gets to the summary screen and they qualify for a discount, the discount will be applied automatically.  A message will also be displayed with the discount that was applied:
![image](https://user-images.githubusercontent.com/2349102/38276353-938c06ec-3749-11e8-8a08-22b363cc3686.png)

*Additional Details:*

- Since only one discount code can ever be applied at a time, the first automatic discount that matches will be applied.  The first one is determined by the order of the discount codes in the registration template settings.

- The registrar can still apply a discount manually.  In that case, the manually entered discount will override the automated one.  


## Possible Implications
There is no potential impact for existing users since this feature is disabled by default.  The registration block will function exactly the same unless an admin enables "Auto Apply Discount" on a discount.


## Documentation
This section of the documentation will need to be updated to reflect the changes.  Also, it looks like this section is missing the newly added limits.
https://www.rockrms.com/Rock/BookContent/29/118#discounts


## Migrations
This pull request will need a migration to add a new column to the RegistrationTemplateDiscount table.  Let me know if you want me to provide one.
