### PR TITLE
Add the ability for GetScheduledPayments to target a specific gateway

### DIFF
--- a/Rock/Jobs/GetScheduledPayments.cs
+++ b/Rock/Jobs/GetScheduledPayments.cs
@@ -67,7 +67,7 @@ namespace Rock.Jobs
             {
                 var targetGatewayGuid = dataMap.GetString( "TargetGateway" ).AsGuidOrNull();
                 var targetGateways = new FinancialGatewayService( rockContext ).Queryable()
-                    .Where( g => ( !targetGatewayGuid.HasValue && g.IsActive ) || g.Guid == targetGatewayGuid );
+                    .Where( g => g.IsActive && ( !targetGatewayGuid.HasValue || g.Guid == targetGatewayGuid.Value );
 
                 foreach ( var financialGateway in targetGateways )
                 {

--- a/Rock/Jobs/GetScheduledPayments.cs
+++ b/Rock/Jobs/GetScheduledPayments.cs
@@ -17,14 +17,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Quartz;
-
-using Rock.Model;
-using Rock.Cache;
 using Rock.Attribute;
-using Rock.Financial;
 using Rock.Data;
+using Rock.Model;
 
 namespace Rock.Jobs
 {
@@ -36,11 +32,11 @@ namespace Rock.Jobs
     [SystemEmailField( "Receipt Email", "The system email to use to send the receipts.", false, "", "", 3 )]
     [SystemEmailField( "Failed Payment Email", "The system email to use to send a notice about a scheduled payment that failed.", false, "", "", 4 )]
     [WorkflowTypeField( "Failed Payment Workflow", "An optional workflow to start whenever a scheduled payment has failed.", false, false, "", "", 5)]
+    [FinancialGatewayField( "Target Gateway", "By default payments will download from all active financial gateways.  Optionally select a single gateway to download scheduled payments from.  You will need to set up additional jobs targeting other active gateways.", false, "", "", 6 )]
     [DisallowConcurrentExecution]
     public class GetScheduledPayments : IJob
     {
-
-        /// <summary> 
+        /// <summary>
         /// Empty constructor for job initilization
         /// <para>
         /// Jobs require a public empty constructor so that the
@@ -51,10 +47,10 @@ namespace Rock.Jobs
         {
         }
 
-        /// <summary> 
+        /// <summary>
         /// Job that updates the JobPulse setting with the current date/time.
         /// This will allow us to notify an admin if the jobs stop running.
-        /// 
+        ///
         /// Called by the <see cref="IScheduler" /> when a
         /// <see cref="ITrigger" /> fires that is associated with
         /// the <see cref="IJob" />.
@@ -69,9 +65,11 @@ namespace Rock.Jobs
 
             using ( var rockContext = new RockContext() )
             {
-                foreach ( var financialGateway in new FinancialGatewayService( rockContext )
-                    .Queryable()
-                    .Where( g => g.IsActive ) )
+                var targetGatewayGuid = dataMap.GetString( "TargetGateway" ).AsGuidOrNull();
+                var targetGateways = new FinancialGatewayService( rockContext ).Queryable()
+                    .Where( g => ( !targetGatewayGuid.HasValue && g.IsActive ) || g.Guid == targetGatewayGuid );
+
+                foreach ( var financialGateway in targetGateways )
                 {
                     try
                     {
@@ -115,7 +113,6 @@ namespace Rock.Jobs
                         ExceptionLogService.LogException( ex, null );
                         exceptionMsgs.Add( ex.Message );
                     }
-
                 }
             }
 
@@ -126,6 +123,5 @@ namespace Rock.Jobs
 
             context.Result = string.Format( "{0} payments processed", scheduledPaymentsProcessed );
         }
-
     }
 }


### PR DESCRIPTION
## Context
_What is the problem you encountered that lead to you creating this pull request?_

By default payments will download from all active financial gateways.  Churches that run multiple gateways/bank accounts have difficulty reconciling transactions to the right funds if the batch includes transactions from all gateways.  

This PR adds the capability to select a single gateway to download scheduled payments from.  If selected, additional jobs need to set up targeting other active gateways (note included in the description).  This PR is sponsored by [Willamette Christian Church](http://willamette.cc/).


## Strategy
_How have you implemented your solution?_

Added a Target Gateway block attribute to the Rock GetScheduledPayments Job and filtered the active gateways queryable to return the target gateway if it was selected.

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

N/A, new functionality.  Descriptive explanation included in the block attribute.

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

Screenshots are for v8 but this is backwards compatible for v7.

![screenshot 2018-04-20 12 15 46](https://user-images.githubusercontent.com/1210933/39062442-805c2f58-4495-11e8-85d0-1a31c387dcce.png)

