### PR TITLE
Fixes RockListBox items selection

### DIFF
--- a/Rock/Web/UI/Controls/RockListBox.cs
+++ b/Rock/Web/UI/Controls/RockListBox.cs
@@ -280,7 +280,7 @@ namespace Rock.Web.UI.Controls
         /// </returns>
         protected override bool LoadPostData( string postDataKey, NameValueCollection postCollection )
         {
-            var selectedValues = this.Page.Request.Form[this.UniqueID].SplitDelimitedValues().ToList();
+            var selectedValues = this.Page.Request.Form[this.UniqueID].SplitDelimitedValues(false).ToList();
             foreach ( ListItem li in this.Items )
             {
                 li.Selected = selectedValues.Contains( li.Value );


### PR DESCRIPTION
The items selected on a RockListBox control should be splitter using a comma-delimiter.

## Context
It wasn't possible to select some items on the RockListBox control due to not using the correct delimiter to parse the selection string.

## Goal
It splits the items selected using a comma-delimiter.

