### PR TITLE
Change placeholder text for Universal Search input field

### DIFF
--- a/RockWeb/Blocks/Cms/UniversalSearch.ascx
+++ b/RockWeb/Blocks/Cms/UniversalSearch.ascx
@@ -28,7 +28,7 @@
                 <asp:Literal ID="lPreHtml" runat="server" />
                 <div class="input-group searchbox">
                     <div class="input-group-addon"><i class="fa fa-search"></i></div>
-                    <asp:TextBox id="tbSearch" runat="server" CssClass="form-control" Placeholder="Search Rock" />
+                    <asp:TextBox id="tbSearch" runat="server" CssClass="form-control" Placeholder="Search" />
 
                     <span id="spanButtonGroup" runat="server" class="input-group-btn">
                         <asp:LinkButton ID="btnSearch" CssClass="btn btn-primary" runat="server" OnClick="btnSearch_Click">Go</asp:LinkButton>


### PR DESCRIPTION
I don't see a way to replace the placeholder text when using Universal Search on the front end site, so I wonder if it could just be the word "Search" instead of "Search Rock"