### PR TITLE
Hides wrong manual payment submit button

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationDetail.ascx.cs
@@ -774,6 +774,9 @@ namespace RockWeb.Blocks.Event
                 phPaymentAmount.Visible = true;
                 phManualDetails.Visible = true;
                 phCCDetails.Visible = false;
+                aStep2Submit.Visible = false;
+                lbSubmitPayment.Visible = true;
+                
             }
         }
 


### PR DESCRIPTION
Hides the new submit button used only for 3step gateways when submitting a manual payment.

## Context
2 submit buttons are displayed when trying to add a manual payment. The new Submit button that is used for 3 step gateways shouldn't be visible when processing manual payments.

## Goal
Hides the wrong submit button on the manual payment screen.

## Screenshots
![screen shot 2018-05-04 at 11 09 38 am](https://user-images.githubusercontent.com/18447151/39638463-e0954142-4f8b-11e8-8201-8fb784213998.png)
