### PR TITLE
Fixes minor validation bug in PhoneNumberBox

### DIFF
--- a/Rock/Web/UI/Controls/PhoneNumberBox.cs
+++ b/Rock/Web/UI/Controls/PhoneNumberBox.cs
@@ -339,8 +339,7 @@ namespace Rock.Web.UI.Controls
     function phoneNumberBoxFormatNumber( tb ) {
         var countryCode = tb.closest('div.input-group').find('input:hidden').val();
         var origValue = tb.val();
-        var number = tb.val().replace(/\D/g,'');
-        var number = number.substring( 0, 20 );
+        var number = tb.val().replace(/\D/g,'').substring( 0, 20 );
         var formats = phoneNumberFormats[countryCode];
         for ( var i = 0; i < formats.length; i++) {
             var matchRegex = new RegExp(formats[i].match);

--- a/Rock/Web/UI/Controls/PhoneNumberBox.cs
+++ b/Rock/Web/UI/Controls/PhoneNumberBox.cs
@@ -340,6 +340,7 @@ namespace Rock.Web.UI.Controls
         var countryCode = tb.closest('div.input-group').find('input:hidden').val();
         var origValue = tb.val();
         var number = tb.val().replace(/\D/g,'');
+        var number = number.substring( 0, 20 );
         var formats = phoneNumberFormats[countryCode];
         for ( var i = 0; i < formats.length; i++) {
             var matchRegex = new RegExp(formats[i].match);


### PR DESCRIPTION
Added logic to only store in the phone number text-box the first 20 digits typed to match the phone number length set on the database.

## Context
_What is the problem you encountered that lead to you creating this pull request?_
The phone number box field allowed entering numbers longer than 20 digits causing an entity validation error when saving it on the database.

## Strategy
_How have you implemented your solution?_
Added a line of JavaScript code that only keeps the 20 first digits entered in the text-box.

