### PR TITLE
Fixed icon (v7) and layout issues (v8) with the Verify Security block.

### DIFF
--- a/RockWeb/Blocks/Security/VerifySecurity.ascx
+++ b/RockWeb/Blocks/Security/VerifySecurity.ascx
@@ -2,48 +2,53 @@
 
 <asp:UpdatePanel ID="upnlContent" runat="server">
     <ContentTemplate>
-        <asp:Panel ID="pnlSecurity" runat="server" CssClass="panel panel-block">
+        <div class="panel panel-block">
             <div class="panel-heading">
                 <h1 class="panel-title"><i class="fa fa-lock"></i> Verify Security</h1>
             </div>
 
             <div class="panel-body">
-                <div class="grid grid-panel">
+                <Rock:NotificationBox ID="nbWarning" runat="server" NotificationBoxType="Warning" Dismissable="true" />
+                <Rock:NotificationBox ID="nbCacheCleared" runat="server" NotificationBoxType="Success" Visible="false" Dismissable="true">
+                    The authorization cache has been successfully cleared.
+                </Rock:NotificationBox>
+                <Rock:NotificationBox ID="nbPoppedLock" runat="server" NotificationBoxType="Success" Dismissable="true" />
 
-                    <div class="grid-filter padding-b-md">
-                        <Rock:NotificationBox ID="nbWarning" runat="server" NotificationBoxType="Warning" Dismissable="true" />
-                        <Rock:NotificationBox ID="nbCacheCleared" runat="server" NotificationBoxType="Success" Visible="false" Dismissable="true">
-                            The authorization cache has been successfully cleared.
-                        </Rock:NotificationBox>
-                        <Rock:NotificationBox ID="nbPoppedLock" runat="server" NotificationBoxType="Success" Dismissable="true" />
-
-                        <Rock:PersonPicker ID="ppPerson" runat="server" Label="Person" Help="The person to check security against, if not set then your security is checked." />
-                        <div class="row">
-                            <div class="col-sm-6">
-                                <Rock:EntityTypePicker ID="pEntityType" runat="server" Label="Entity Type" Required="true" IncludeGlobalOption="false" Help="Select the entity type you are wanting to verify access to. If you are trying to check the security on a page then set this to 'Page'." />
-                            </div>
-                            <div class="col-sm-6">
-                                <Rock:RockTextBox ID="tbEntityId" runat="server" Label="Entity Id" Help="Integer ID or Guid of the entity you are trying to check security of. If you are trying to check the security of the default external homepage (which is Id #1) then set this to 1." />
-                            </div>
-                        </div>
-
-                        <Rock:BootstrapButton ID="btnCheck" runat="server" CssClass="btn btn-primary btn-sm" Text="Show Security" OnClick="btnCheck_Click" />
-                        <asp:Button ID="btnClearCache" runat="server" CssClass="btn btn-default btn-sm" Text="Clear Auth Cache" OnClick="btnClearCache_Click" ValidationGroup="VerifySecurity_ClearCache" />
+                <Rock:PersonPicker ID="ppPerson" runat="server" Label="Person" Help="The person to check security against, if not set then your security is checked." />
+                <div class="row">
+                    <div class="col-sm-6">
+                        <Rock:EntityTypePicker ID="pEntityType" runat="server" Label="Entity Type" Required="true" IncludeGlobalOption="false" Help="Select the entity type you are wanting to verify access to. If you are trying to check the security on a page then set this to 'Page'." />
                     </div>
-                
-                    <asp:Panel ID="pnlResult" runat="server" Visible="false">
-                        <Rock:Grid ID="gResults" runat="server" AllowPaging="false" AllowSorting="false" OnRowDataBound="gResults_RowDataBound" DataKeyNames="Id">
-                            <Columns>
-                                <Rock:RockBoundField DataField="Action" HeaderText="Action"></Rock:RockBoundField>
-                                <Rock:RockBoundField DataField="EntityType" HeaderText="Source Type"></Rock:RockBoundField>
-                                <Rock:RockBoundField DataField="EntityId" HeaderText="Source Id"></Rock:RockBoundField>
-                                <Rock:RockBoundField DataField="EntityName" HeaderText="Source Name"></Rock:RockBoundField>
-                                <Rock:RockBoundField DataField="Role" HeaderText="User / Role"></Rock:RockBoundField>
-                                <Rock:RockBoundField DataField="Access" HeaderText="Access" HtmlEncode="false"></Rock:RockBoundField>
-                                <Rock:LinkButtonField HeaderText="" CssClass="btn btn-default btn-sm fa fa-unlock" OnClick="gUnlock_Click"></Rock:LinkButtonField>
-                            </Columns>
-                        </Rock:Grid>
-                    </asp:Panel>
+                    <div class="col-sm-6">
+                        <Rock:RockTextBox ID="tbEntityId" runat="server" Label="Entity Id" Required="true" Help="Integer ID or Guid of the entity you are trying to check security of. If you are trying to check the security of the default external homepage (which is Id #1) then set this to 1." />
+                    </div>
+                </div>
+
+                <div class="actions">
+                    <Rock:BootstrapButton ID="btnCheck" runat="server" CssClass="btn btn-primary btn-sm" Text="Show Security" OnClick="btnCheck_Click" />
+                    <asp:Button ID="btnClearCache" runat="server" CssClass="btn btn-default btn-sm margin-l-sm" Text="Clear Auth Cache" OnClick="btnClearCache_Click" ValidationGroup="VerifySecurity_ClearCache" />
+                </div>
+            </div>
+        </div>
+
+        <asp:Panel ID="pnlResult" runat="server" CssClass="panel panel-block" Visible="false">
+            <div class="panel-heading">
+                <h1 class="panel-title"><i class="fa fa-list-ul"></i> Results</h1>
+            </div>
+
+            <div class="panel-body">
+                <div class="grid grid-panel">
+                    <Rock:Grid ID="gResults" runat="server" AllowPaging="false" AllowSorting="false" OnRowDataBound="gResults_RowDataBound" DataKeyNames="Id">
+                        <Columns>
+                            <Rock:RockBoundField DataField="Action" HeaderText="Action"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="EntityType" HeaderText="Source Type"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="EntityId" HeaderText="Source Id"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="EntityName" HeaderText="Source Name"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="Role" HeaderText="User / Role"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="Access" HeaderText="Access" HtmlEncode="false"></Rock:RockBoundField>
+                            <Rock:LinkButtonField HeaderText="" CssClass="btn btn-default btn-sm" Text="<i class='fa fa-unlock'></i>" OnClick="gUnlock_Click" />
+                        </Columns>
+                    </Rock:Grid>
                 </div>
             </div>
         </asp:Panel>


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

> Note: There has been no issue created as this originally started as a one line fix for the icon and then I noticed the layout issue on v8 (since that is what my develop branch is on).

### Icon Missing

When Rock changed to FontAwesome 5, many icons in my personal plugins stopped working because the `fa fa-` classes were on the `a` tags instead of embedded in `i` tags inside the `a` tags.

Examples:

Works: `<a class="btn btn-sm"><i class="fa fa-unlock"></i></a>`

Doesn't work: `<a class="btn btn-sm fa fa-unlock"></a>`

Most things use the working style, but a few use the latter style that doesn't always work. I've been updating my plugins as I find these, but this one is in core.

See "Before" screenshot for example of missing icon in lower left.

### Layout Issues

The way I designed the layout of this block causes issues with the new theme changes in v8. I used some CSS classes in ways that I apparently should not have. See margin issues in the "Before" screenshot, arrow pointing on the left edge.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Fix the icon and the layout issues.

## Strategy
_How have you implemented your solution?_

To fix the icon, instead of the `fa fa-unlock` class going on the anchor tag, it now uses a standard `<i class="fa fa-unlock"></i>` inside the anchor tag.

To fix the layout issues, split the block layout from one panel into two panels, one for the results grid.

Tested the changes on both v8 and v7 to ensure this PR can be cherry picked back to a 1.7.5 release if we do one.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

Before:

<img width="856" alt="before" src="https://user-images.githubusercontent.com/1119863/40562500-10e21ede-6016-11e8-945b-ff7849b93d53.png">

After (v7):

![afterv7](https://user-images.githubusercontent.com/1119863/40562531-35c2610a-6016-11e8-985f-af031a6e2d6a.png)

After (v8):

![afterv8](https://user-images.githubusercontent.com/1119863/40562538-3930ae50-6016-11e8-97e9-1f4a9ab7b7e7.png)

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
