### PR TITLE
Set debug property in web.config

### DIFF
--- a/RockWeb/web.config
+++ b/RockWeb/web.config
@@ -29,7 +29,7 @@
     <machineKey validationKey="09FC7CE0D57E55DCF18196743CDCDF77E86E8E522D0DDF2AB2663980F987A288B09BE034018539EAF87565AC5CB285B9C827CE0C251B8D1832627B14A7DC7697" decryptionKey="08CA6024B2BC3CA7B61165BAF1398D94212976EC00DAC895B23E4BADEE76386B" validation="SHA1" decryption="AES" />
     <trace enabled="false" />
     <trust level="Full" />
-    <compilation debug="true" targetFramework="4.5.2">
+    <compilation debug="false" targetFramework="4.5.2">
       <assemblies>
         <add assembly="System.Globalization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
         <add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
Reference [here](https://weblogs.asp.net/scottgu/442448) and [here](https://bitsandscrews.com/10-solid-tips-to-increase-and-optimize-iis-performance-for-2018-covers-asp-net-wordpresscoldfusion-and-sharepoint/#Disable_ASPNet_debugging_from_WebConfig).  This setting is the default, which gets passed to the installer and deployed to production environments.

To fix existing Rock installations, we may need to add a setting under System Settings > System Config.