### PR TITLE
Fix up file handlers (Fixes #2599)

### DIFF
--- a/Rock/Model/BinaryFileService.Partial.cs
+++ b/Rock/Model/BinaryFileService.Partial.cs
@@ -15,12 +15,10 @@
 // </copyright>
 //
 using System;
-using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Data.SqlClient;
 using System.Web;
-using Rock.Cache;
 
 namespace Rock.Model
 {
@@ -110,43 +108,50 @@ namespace Rock.Model
 
             using ( SqlDataReader reader = cmd.EndExecuteReader( asyncResult ) )
             {
-                BinaryFile binaryFile = new BinaryFile();
-
-                // Columns must be read in Sequential Order (see stored procedure spCore_BinaryFileGet)
-                reader.Read();
-                binaryFile.Id = reader["Id"] as int? ?? 0;
-                binaryFile.IsTemporary = ( (bool)reader["IsTemporary"] );
-                binaryFile.IsSystem = (bool)reader["IsSystem"];
-                binaryFile.BinaryFileTypeId = reader["BinaryFileTypeId"] as int?;
-
-                // return requiresViewSecurity to let caller know that security needs to be checked on this binaryFile before viewing
-                requiresViewSecurity = (bool)reader["RequiresViewSecurity"];
-
-                binaryFile.FileName = reader["FileName"] as string;
-                binaryFile.MimeType = reader["MimeType"] as string;
-                binaryFile.ModifiedDateTime = reader["ModifiedDateTime"] as DateTime?;
-                binaryFile.Description = reader["Description"] as string;
-                int? storageEntityTypeId = reader["StorageEntityTypeId"] as int?;
-                binaryFile.SetStorageEntityTypeId( storageEntityTypeId );
-                var guid = reader["Guid"];
-                if ( guid is Guid )
+                if ( reader.Read() )
                 {
-                    binaryFile.Guid = (Guid)guid;
-                }
-                binaryFile.StorageEntitySettings = reader["StorageEntitySettings"] as string;
-                binaryFile.Path = reader["Path"] as string;
-                binaryFile.FileSize = reader["FileSize"] as long?;
-                binaryFile.DatabaseData = new BinaryFileData();
+                    BinaryFile binaryFile = new BinaryFile();
 
-                // read the fileContent from the database just in case it's stored in the database, otherwise, the Provider will get it
-                // TODO do as a stream instead
-                var content = reader["Content"] as byte[];
-                if ( content != null )
+                    // Columns must be read in Sequential Order (see stored procedure spCore_BinaryFileGet)
+                    binaryFile.Id = reader["Id"] as int? ?? 0;
+                    binaryFile.IsTemporary = ( (bool)reader["IsTemporary"] );
+                    binaryFile.IsSystem = (bool)reader["IsSystem"];
+                    binaryFile.BinaryFileTypeId = reader["BinaryFileTypeId"] as int?;
+
+                    // return requiresViewSecurity to let caller know that security needs to be checked on this binaryFile before viewing
+                    requiresViewSecurity = (bool)reader["RequiresViewSecurity"];
+
+                    binaryFile.FileName = reader["FileName"] as string;
+                    binaryFile.MimeType = reader["MimeType"] as string;
+                    binaryFile.ModifiedDateTime = reader["ModifiedDateTime"] as DateTime?;
+                    binaryFile.Description = reader["Description"] as string;
+                    int? storageEntityTypeId = reader["StorageEntityTypeId"] as int?;
+                    binaryFile.SetStorageEntityTypeId( storageEntityTypeId );
+                    var guid = reader["Guid"];
+                    if ( guid is Guid )
+                    {
+                        binaryFile.Guid = (Guid)guid;
+                    }
+                    binaryFile.StorageEntitySettings = reader["StorageEntitySettings"] as string;
+                    binaryFile.Path = reader["Path"] as string;
+                    binaryFile.FileSize = reader["FileSize"] as long?;
+                    binaryFile.DatabaseData = new BinaryFileData();
+
+                    // read the fileContent from the database just in case it's stored in the database, otherwise, the Provider will get it
+                    // TODO do as a stream instead
+                    var content = reader["Content"] as byte[];
+                    if ( content != null )
+                    {
+                        binaryFile.DatabaseData.Content = content;
+                    }
+
+                    return binaryFile;
+                }
+                else
                 {
-                    binaryFile.DatabaseData.Content = content;
+                    requiresViewSecurity = false;
+                    return null;
                 }
-
-                return binaryFile;
             }
         }
     }

--- a/Rock/Web/UI/Controls/FileUploader.cs
+++ b/Rock/Web/UI/Controls/FileUploader.cs
@@ -645,7 +645,7 @@ namespace Rock.Web.UI.Controls
                 }
                 else
                 {
-                    _aFileName.HRef = string.Format( "{0}GetFile.ashx?isBinaryFile=F&rootFolder={1}&fileName={2}", ResolveUrl( "~" ), Rock.Security.Encryption.EncryptString( this.RootFolder ), BinaryFileId );
+                    _aFileName.HRef = ResolveUrl( this.UploadedContentFilePath );
                     _aFileName.InnerText = this.UploadedContentFilePath;
                 }
 

--- a/RockWeb/App_Code/FileUploader.ashx.cs
+++ b/RockWeb/App_Code/FileUploader.ashx.cs
@@ -144,6 +144,13 @@ namespace RockWeb
 
             string scrubedFileName = ScrubFileName( untrustedFileName );
 
+            if( string.IsNullOrWhiteSpace( scrubedFileName ) )
+            {
+                throw new Rock.Web.FileUploadException( "Invalid File Name", System.Net.HttpStatusCode.BadRequest );
+            }
+
+            /* Scrub the folder path */
+            string scrubedFolderPath = ScrubFileName( untrustedFolderPath );
 
             /* Determine the root upload folder */
 
@@ -168,7 +175,11 @@ namespace RockWeb
             string trustedPhysicalRootFolder = Path.GetFullPath( context.Request.MapPath( trustedRootFolder ) );
 
             // Treat rooted folder paths as relative
-            string untrustedRelativeFolderPath = untrustedFolderPath.TrimStart( Path.GetPathRoot( untrustedFolderPath ).ToCharArray() );
+            string untrustedRelativeFolderPath = "";
+            if ( !string.IsNullOrWhiteSpace( scrubedFolderPath ) )
+            {
+                untrustedRelativeFolderPath = scrubedFolderPath.TrimStart( Path.GetPathRoot( scrubedFolderPath ).ToCharArray() );
+            }
 
             // Get the absolute path for our untrusted folder.
             string untrustedPhysicalFolderPath = Path.GetFullPath( Path.Combine( trustedPhysicalRootFolder, untrustedRelativeFolderPath ) );
@@ -336,17 +347,32 @@ namespace RockWeb
         }
 
         /// <summary>
-        /// Scrubs a filename to make sure it doen't have any directories or bad characters
+        /// Scrubs a filename to make sure it doesn't have any directories or invalid characters
         /// </summary>
         /// <param name="untrustedFileName">The filename.</param>
         /// <returns>A scrubed filename.</returns>
         public string ScrubFileName(string untrustedFileName )
         {
+            // Scrub invalid path characters
+            untrustedFileName = ScrubFilePath( untrustedFileName );
+
             // Get the base filename
             string baseFileName = Path.GetFileName( untrustedFileName );
 
-            // Scrub invalid characters
+            // Scrub invalid file characters
             return Regex.Replace( baseFileName, "[" + Regex.Escape( Path.GetInvalidFileNameChars().ToString() ) + "]", string.Empty, RegexOptions.CultureInvariant );
         }
+
+        /// <summary>
+        /// Scrubs a file path to make sure it doesn't have any invalid characters
+        /// </summary>
+        /// <param name="untrustedFilePath">The file path.</param>
+        /// <returns>A scrubed file path.</returns>
+        public string ScrubFilePath( string untrustedFilePath )
+        {
+            // Scrub invalid path characters
+            return Regex.Replace( untrustedFilePath, "[" + Regex.Escape( Path.GetInvalidPathChars().ToString() ) + "]", string.Empty, RegexOptions.CultureInvariant );
+        }
+
     }
 }

--- a/RockWeb/App_Code/GetImage.ashx.cs
+++ b/RockWeb/App_Code/GetImage.ashx.cs
@@ -63,7 +63,7 @@ namespace RockWeb
                 }
                 else
                 {
-                    ExceptionLogService.LogException( ex, context );
+                    throw ex;
                 }
             }
         }
@@ -72,56 +72,114 @@ namespace RockWeb
         /// Processes the content file request.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <exception cref="System.Exception">fileName must be specified</exception>
         private void ProcessContentFileRequest( HttpContext context )
         {
-            string relativeFilePath = context.Request.QueryString["fileName"];
-            string rootFolderParam = context.Request.QueryString["rootFolder"];
 
-            if ( string.IsNullOrWhiteSpace( relativeFilePath ) )
+            // Don't trust query strings
+            string untrustedFilePath = context.Request.QueryString["fileName"];
+            string encryptedRootFolder = context.Request.QueryString["rootFolder"];
+
+            // Make sure a filename was provided
+            if ( string.IsNullOrWhiteSpace( untrustedFilePath ) )
             {
-                throw new Exception( "fileName must be specified" );
+                SendBadRequest( context, "fileName must be specified" );
+                return;
             }
 
-            string rootFolder = string.Empty;
+            // Count of query parameters used. Start at 2 since "isBinaryFile" and "fileName" are required to get here.
+            var queryCount = 2;
 
-            if ( !string.IsNullOrWhiteSpace( rootFolderParam ) )
+            string trustedRootFolder = string.Empty;
+
+            // If a rootFolder was specified in the URL
+            if ( !string.IsNullOrWhiteSpace( encryptedRootFolder ) )
             {
-                // if a rootFolder was specified in the URL, decrypt it (it is encrypted to help prevent direct access to filesystem)
-                rootFolder = Rock.Security.Encryption.DecryptString( rootFolderParam );
+                // Bump query count
+                queryCount++;
+
+                // Decrypt it (It is encrypted to help prevent direct access to filesystem).
+                trustedRootFolder = Encryption.DecryptString( encryptedRootFolder );
             }
 
-            if ( string.IsNullOrWhiteSpace( rootFolder ) )
+            // If we don't have a rootFolder, default to the ~/Content folder.
+            if ( string.IsNullOrWhiteSpace( trustedRootFolder ) )
             {
-                // set to default rootFolder if not specified in the params
-                rootFolder = "~/Content";
+                trustedRootFolder = "~/Content";
             }
 
-            string physicalRootFolder = context.Request.MapPath( rootFolder );
-            string physicalContentFileName = Path.Combine( physicalRootFolder, relativeFilePath.TrimStart( new char[] { '/', '\\' } ) );
-            using ( Stream fileContents = File.OpenRead( physicalContentFileName ) )
+            // Get the absolute path for our trusted root.
+            string trustedPhysicalRootFolder = Path.GetFullPath( context.Request.MapPath( trustedRootFolder ) );
+
+            // Treat rooted file paths as relative
+            string untrustedRelativeFilePath = untrustedFilePath.TrimStart( Path.GetPathRoot( untrustedFilePath ).ToCharArray() );
+
+            // Get the absolute path for our untrusted file.
+            string untrustedPhysicalFilePath = Path.GetFullPath( Path.Combine( trustedPhysicalRootFolder, untrustedRelativeFilePath ) );
+
+            // Make sure the untrusted file is inside our trusted root folder.
+            string trustedPhysicalFilePath = string.Empty;
+            if ( untrustedPhysicalFilePath.StartsWith( trustedPhysicalRootFolder ) )
             {
-                if ( fileContents != null )
+                // If so, then we can trust it.
+                trustedPhysicalFilePath = untrustedPhysicalFilePath;
+            }
+            else
+            {
+                // Otherwise, say the file doesn't exist.
+                SendNotFound( context );
+                return;
+            }
+
+            // Try to open a file stream
+            try
+            {
+                using ( Stream fileContents = File.OpenRead( trustedPhysicalFilePath ) )
                 {
-                    string mimeType = System.Web.MimeMapping.GetMimeMapping( physicalContentFileName );
-                    context.Response.AddHeader( "content-disposition", string.Format( "inline;filename={0}", Path.GetFileName( physicalContentFileName ) ) );
-                    context.Response.ContentType = mimeType;
-                    
-                    // If more than 1 query string param is passed in and it isn't an SVG file, do a Resize, assume resize is needed
-                    if ( (context.Request.QueryString.Count > 1) && ( mimeType != "image/svg+xml" ))
+                    if ( fileContents != null )
                     {
-                        using ( var resizedStream = GetResized( context.Request.QueryString, fileContents ) )
+                        string mimeType = MimeMapping.GetMimeMapping( trustedPhysicalFilePath );
+                        context.Response.AddHeader( "content-disposition", string.Format( "inline;filename={0}", Path.GetFileName( trustedPhysicalFilePath ) ) );
+                        context.Response.ContentType = mimeType;
+
+                        // If extra query string params are passed in and it isn't an SVG file, assume resize is needed
+                        if ( ( context.Request.QueryString.Count > queryCount ) && ( mimeType != "image/svg+xml" ) )
                         {
-                            resizedStream.CopyTo( context.Response.OutputStream );
+                            using ( var resizedStream = GetResized( context.Request.QueryString, fileContents ) )
+                            {
+                                resizedStream.CopyTo( context.Response.OutputStream );
+                            }
                         }
+                        else
+                        {
+                            fileContents.CopyTo( context.Response.OutputStream );
+                        }
+
+                        context.Response.Flush();
+                        context.ApplicationInstance.CompleteRequest();
                     }
                     else
                     {
-                        fileContents.CopyTo( context.Response.OutputStream );
+                        SendNotFound( context );
                     }
-                    
-                    context.Response.Flush();
-                    context.ApplicationInstance.CompleteRequest();
+                }
+            }
+            catch (Exception ex)
+            {
+                if ( ex is ArgumentException || ex is ArgumentNullException || ex is NotSupportedException )
+                {
+                    SendBadRequest( context, "fileName is invalid.");
+                }
+                else if( ex is DirectoryNotFoundException || ex is FileNotFoundException )
+                {
+                    SendNotFound( context );
+                }
+                else if ( ex is UnauthorizedAccessException )
+                {
+                    SendNotAuthorized( context );
+                }
+                else
+                {
+                    throw ex;
                 }
             }
         }
@@ -135,9 +193,10 @@ namespace RockWeb
             int fileId = context.Request.QueryString["id"].AsInteger();
             Guid fileGuid = context.Request.QueryString["guid"].AsGuid();
 
-            if ( fileId == 0 && fileGuid.Equals( Guid.Empty ) )
+            if ( fileId == 0 && fileGuid == Guid.Empty )
             {
-                SendNotFound( context );
+                SendBadRequest( context, "File id key must be a guid or an int." );
+                return;
             }
 
             var rockContext = new RockContext();
@@ -156,6 +215,7 @@ namespace RockWeb
             //// a null ModifiedDateTime shouldn't happen, but just in case, set it to DateTime.MaxValue so we error on the side of not getting it from the cache
             var binaryFileMetaData = binaryFileQuery.Select( a => new
             {
+                a.Id,
                 BinaryFileType_AllowCaching = a.BinaryFileType.AllowCaching,
                 BinaryFileType_RequiresViewSecurity = a.BinaryFileType.RequiresViewSecurity,
                 ModifiedDateTime = a.ModifiedDateTime ?? DateTime.MaxValue,
@@ -175,7 +235,7 @@ namespace RockWeb
             {
                 var currentUser = new UserLoginService( rockContext ).GetByUserName( UserLogin.GetCurrentUserName() );
                 Person currentPerson = currentUser != null ? currentUser.Person : null;
-                BinaryFile binaryFileAuth = new BinaryFileService( rockContext ).Queryable( "BinaryFileType" ).First( a => a.Guid == fileGuid || a.Id == fileId );
+                BinaryFile binaryFileAuth = new BinaryFileService( rockContext ).Queryable( "BinaryFileType" ).First( a => a.Id == binaryFileMetaData.Id );
                 if ( !binaryFileAuth.IsAuthorized( Authorization.VIEW, currentPerson ) )
                 {
                     SendNotAuthorized( context );
@@ -183,7 +243,7 @@ namespace RockWeb
                 }
             }
 
-            
+
             Stream fileContent = null;
             try
             {
@@ -206,7 +266,7 @@ namespace RockWeb
                 if ( fileContent == null )
                 {
                     // If we didn't get it from the cache, get it from the binaryFileService
-                    BinaryFile binaryFile = GetFromBinaryFileService( context, fileId, fileGuid );
+                    BinaryFile binaryFile = GetFromBinaryFileService( context, binaryFileMetaData.Id );
 
                     if ( binaryFile != null )
                     {
@@ -298,7 +358,7 @@ namespace RockWeb
             }
             finally
             {
-                if (fileContent != null)
+                if ( fileContent != null )
                 {
                     fileContent.Dispose();
                 }
@@ -347,7 +407,7 @@ namespace RockWeb
         /// <param name="fileId">The file identifier.</param>
         /// <param name="fileGuid">The file unique identifier.</param>
         /// <returns></returns>
-        private BinaryFile GetFromBinaryFileService( HttpContext context, int fileId, Guid fileGuid )
+        private BinaryFile GetFromBinaryFileService( HttpContext context, int fileId )
         {
             BinaryFile binaryFile = null;
             System.Threading.ManualResetEvent completedEvent = new ManualResetEvent( false );
@@ -363,16 +423,7 @@ namespace RockWeb
                 completedEvent.Set();
             };
 
-            IAsyncResult beginGetResult;
-
-            if ( fileGuid != Guid.Empty )
-            {
-                beginGetResult = new BinaryFileService( rockContext ).BeginGet( cb, context, fileGuid );
-            }
-            else
-            {
-                beginGetResult = new BinaryFileService( rockContext ).BeginGet( cb, context, fileId );
-            }
+            IAsyncResult beginGetResult = new BinaryFileService( rockContext ).BeginGet( cb, context, fileId );
 
             // wait up to 5 minutes for the response
             completedEvent.WaitOne( 300000 );
@@ -391,16 +442,17 @@ namespace RockWeb
             {
                 ResizeSettings settings = new ResizeSettings( queryString );
 
-                if ( settings["mode"] == null || settings["mode"] == "clip") 
+                if ( settings["mode"] == null || settings["mode"] == "clip" )
                 {
                     settings.Add( "mode", "max" );
-                    
-                    if ( !string.IsNullOrEmpty(settings["width"]) && !string.IsNullOrEmpty(settings["height"])) {
-                        if ( settings["width"].AsInteger() > settings["height"].AsInteger() ) 
+
+                    if ( !string.IsNullOrEmpty( settings["width"] ) && !string.IsNullOrEmpty( settings["height"] ) )
+                    {
+                        if ( settings["width"].AsInteger() > settings["height"].AsInteger() )
                         {
                             settings.Remove( "height" );
-                        } 
-                        else 
+                        }
+                        else
                         {
                             settings.Remove( "width" );
                         }
@@ -409,7 +461,7 @@ namespace RockWeb
 
                 MemoryStream resizedStream = new MemoryStream();
 
-                ImageBuilder.Current.Build( fileContent, resizedStream, settings );
+                ImageBuilder.Current.Build( fileContent, resizedStream, settings, false );
                 return resizedStream;
             }
             catch
@@ -491,6 +543,17 @@ namespace RockWeb
         }
 
         /// <summary>
+        /// Sends a 400 (bad request)
+        /// </summary>
+        /// <param name="context">The context.</param>
+        private void SendBadRequest( HttpContext context, string message )
+        {
+            context.Response.StatusCode = System.Net.HttpStatusCode.BadRequest.ConvertToInt();
+            context.Response.StatusDescription = message;
+            context.ApplicationInstance.CompleteRequest();
+        }
+
+        /// <summary>
         /// Gets a value indicating whether another request can use the <see cref="T:System.Web.IHttpHandler" /> instance.
         /// </summary>
         /// <returns>true if the <see cref="T:System.Web.IHttpHandler" /> instance is reusable; otherwise, false.</returns>
@@ -498,7 +561,7 @@ namespace RockWeb
         {
             get
             {
-                return false;
+                return true;
             }
         }
     }

--- a/RockWeb/App_Code/ImageUploader.ashx.cs
+++ b/RockWeb/App_Code/ImageUploader.ashx.cs
@@ -57,7 +57,9 @@ namespace RockWeb
             // clean up list
             contentImageFileTypeWhiteList = contentImageFileTypeWhiteList.Select( a => a.ToLower().TrimStart( new char[] { '.', ' ' } ) );
 
-            string fileExtension = Path.GetExtension( uploadedFile.FileName ).ToLower().TrimStart( new char[] { '.' } );
+            var filename = base.ScrubFileName( uploadedFile.FileName );
+
+            string fileExtension = Path.GetExtension( filename ).ToLower().TrimStart( new char[] { '.' } );
             if ( !contentImageFileTypeWhiteList.Contains( fileExtension ) )
             {
                 throw new Rock.Web.FileUploadException( "Image filetype not allowed", System.Net.HttpStatusCode.NotAcceptable );


### PR DESCRIPTION
## Context
The original problem was that the get file handlers responded improperly to some requests and were generating a lot of exceptions in those cases (See #2599). I've also discovered some more issues with them in the process of fixing that issue.

## Changes:
1. `GetFile.ashx.cs`
  * Removed content file support (the `isBinaryFile` parameter).
    * The current implementation has been broken for a while.
    * I can't find it used anywhere.
    * It's unnecessary (These files can already be accessed from `/Content`).
  * Invalid parameter options now return a 400 Bad Request instead of throwing an exception.
  * Missing or deleted files now return a 404 Not Found instead of throwing an exception.
    * For this, `BinaryFileService.EndGet()` was modified to properly check if data could be read, and now returns null if a file is missing instead of throwing an exception (existing usages already expect this behavior).
  * Changed `IsReusable` to return `true`.
    * Since we don't store the current request state in the handler, we can tell IIS to reuse it instead of making a new one for each request. This should make it a tiny bit more efficient.
1. `GetImage.ashx.cs`
  * Content files (`?isBinaryFile=F`):
    * Fixed issues with path handling
    * Fixed parameter counting for determining if a content file should try to be resized.
    * Missing or deleted content files now return a 404 Not Found instead of an empty 200 Success.
    * Invalid content files now return a 400 Bad Request instead of an empty 200 Success.
    * Content files that don't have permission to be read now return a 403 Forbidden instead of an empty 200 Success.
  * Binary files (`?isBinaryFile=T`):
    * Invalid parameters now return a 400 Bad Request instead of an empty 200 Success.
    * Fixed an issue with file security
  * General:
    * Exceptions now return a 500 Internal Server Error instead of an empty 200 Success.
    * Files that fail to resize now fallback to their original content instead of throwing an ObjectDisposedException.
    * Changed `IsReusable` to return `true`.
      * Since we don't store the current request state in the handler, we can tell IIS to reuse it instead of making a new one for each request. This should make it a tiny bit more efficient.
1. `FileUploader.ashx.cs`
  * Content files (`?isBinaryFile=F`):
    * Fixed issues with path handling.
    * Changed handling to prevent overwriting existing files (If you actually need to replace a file, you should delete it in the file browser and re-upload it).
  * General
    * Fixed file type validation.
1. `ImageUploader.ashx.cs`
  * Fixed file type validation.

