### PR TITLE
Added ability for Groups Lava filter to include inactive groups too

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -2757,9 +2757,10 @@ namespace Rock.Lava
         /// <param name="context">The context.</param>
         /// <param name="input">The input.</param>
         /// <param name="groupTypeId">The group type identifier.</param>
-        /// <param name="status">The status.</param>
+        /// <param name="memberStatus">If not <c>All</c> then only active group members will be included.</param>
+        /// <param name="groupStatus">If not <c>All</c> then only active groups will be included.</param>
         /// <returns></returns>
-        public static List<Rock.Model.GroupMember> Groups( DotLiquid.Context context, object input, string groupTypeId, string status = "Active" )
+        public static List<Rock.Model.GroupMember> Groups( DotLiquid.Context context, object input, string groupTypeId, string memberStatus = "Active", string groupStatus = "Active" )
         {
             var person = GetPerson( input );
             int? numericalGroupTypeId = groupTypeId.AsIntegerOrNull();
@@ -2770,13 +2771,17 @@ namespace Rock.Lava
                     .Queryable( "Group, GroupRole" )
                     .Where( m =>
                         m.PersonId == person.Id &&
-                        m.Group.GroupTypeId == numericalGroupTypeId.Value &&
-                        m.Group.IsActive );
+                        m.Group.GroupTypeId == numericalGroupTypeId.Value );
 
-                if ( status != "All" )
+                if (groupStatus != "All")
+                {
+                    groupQuery = groupQuery.Where( m => m.Group.IsActive );
+                }
+
+                if ( memberStatus != "All" )
                 {
                     GroupMemberStatus queryStatus = GroupMemberStatus.Active;
-                    queryStatus = (GroupMemberStatus)Enum.Parse( typeof( GroupMemberStatus ), status, true );
+                    queryStatus = (GroupMemberStatus)Enum.Parse( typeof( GroupMemberStatus ), memberStatus, true );
 
                     groupQuery = groupQuery.Where( m => m.GroupMemberStatus == queryStatus );
                 }


### PR DESCRIPTION
## Proposed Changes

Add optional third parameter to the `Groups` filter that allows for including inactive groups.

Fixes: #2380 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [X] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [X] I have included necessary documentation (if appropriate)

## Further comments

## Documentation

New item to add to Groups filter documentation:

* Group Status (optional): By default the filter will only include active groups. Pass the string 'All' to include inactive groups as well.