### PR TITLE
Fixed the RockCheckBoxList control to properly trigger SelectedIndexChanged event.

### DIFF
--- a/Rock/Web/UI/Controls/RockCheckBoxList.cs
+++ b/Rock/Web/UI/Controls/RockCheckBoxList.cs
@@ -344,13 +344,21 @@ namespace Rock.Web.UI.Controls
             // make sure we are dealing with a postback for this control by seeing if the hidden field is included
             if ( postDataKey == _hfCheckListBoxId.UniqueID )
             {
+                bool hasChanged = false;
+
                 // Hack to get the selected items on postback.  
                 for ( int i = 0; i < this.Items.Count; i++ )
                 {
-                    this.Items[i].Selected = ( postCollection[string.Format( "{0}${1}", this.UniqueID, i )] != null );
+                    bool newCheckState = ( postCollection[string.Format( "{0}${1}", this.UniqueID, i )] != null );
+
+                    if ( this.Items[i].Selected != newCheckState )
+                    {
+                        this.Items[i].Selected = newCheckState;
+                        hasChanged = true;
+                    }
                 }
 
-                return false;
+                return hasChanged;
             }
             else
             {


### PR DESCRIPTION
## Proposed Changes

RockCheckBoxList has never properly triggered the SelectedIndexChanged event. This PR adds that functionality. Like the standard CheckBoxList control, this requires the `AutoPostBack` value to be enabled as well.

Fixes: #1169

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments

This is somewhere between a bugfix and a feature, but the related issue is listed as a bug.

## Documentation

n/a