### PR TITLE
Fixed Content Channel View to show buttons when new filter groups are added.

### DIFF
--- a/RockWeb/Blocks/Cms/ContentChannelView.ascx.cs
+++ b/RockWeb/Blocks/Cms/ContentChannelView.ascx.cs
@@ -329,6 +329,8 @@ namespace RockWeb.Blocks.Cms
             filterField.ExcludedFilterTypes = new string[] { typeof( Rock.Reporting.DataFilter.OtherDataViewFilter ).FullName };
             filterField.FilteredEntityTypeName = groupControl.FilteredEntityTypeName;
             filterField.Expanded = true;
+
+            filterField.DeleteClick += filterControl_DeleteClick;
         }
 
         /// <summary>
@@ -345,6 +347,10 @@ namespace RockWeb.Blocks.Cms
             childGroupControl.ID = string.Format( "fg_{0}", childGroupControl.DataViewFilterGuid.ToString( "N" ) );
             childGroupControl.FilteredEntityTypeName = groupControl.FilteredEntityTypeName;
             childGroupControl.FilterType = FilterExpressionType.GroupAll;
+
+            childGroupControl.AddFilterClick += groupControl_AddFilterClick;
+            childGroupControl.AddGroupClick += groupControl_AddGroupClick;
+            childGroupControl.DeleteGroupClick += groupControl_DeleteGroupClick;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes

When using the Content Channel View block and editing filters, if you add a new Filter Group or Filter, the action buttons for those new items will now show up until a second postback occurs. This was due to the event handlers not being installed before the new items were rendered.

Fixes: #1574

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments

n/a

## Documentation

n/a