### PR TITLE
Added Enabled Lava Commands setting to Dynamic Data block.

### DIFF
--- a/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
+++ b/RockWeb/Blocks/Reporting/DynamicData.ascx.cs
@@ -42,6 +42,7 @@ namespace RockWeb.Blocks.Reporting
 
     // Block Properties
     [BooleanField( "Update Page", "If True, provides fields for updating the parent page's Name and Description", true, "", 0 )]
+    [LavaCommandsField( "Enabled Lava Commands", "The Lava commands that should be enabled for this dynamic data block.", false, "", "", 1 )]
 
     // Custom Settings
     [CodeEditorField( "Query", "The query to execute. Note that if you are providing SQL you can add items from the query string using Lava like {{ QueryParmName }}.", CodeEditorMode.Sql, CodeEditorTheme.Rock, 400, false, "", "CustomSetting" )]
@@ -317,6 +318,7 @@ namespace RockWeb.Blocks.Reporting
             errorMessage = string.Empty;
 
             string query = GetAttributeValue( "Query" );
+            string enabledLavaCommands = this.GetAttributeValue( "EnabledLavaCommands" );
             if ( !string.IsNullOrWhiteSpace( query ) )
             {
                 try
@@ -329,7 +331,7 @@ namespace RockWeb.Blocks.Reporting
                         mergeFields.AddOrReplace( pageParam.Key, pageParam.Value );
                     }
 
-                    query = query.ResolveMergeFields( mergeFields );
+                    query = query.ResolveMergeFields( mergeFields, enabledLavaCommands );
 
                     var parameters = GetParameters();
                     int timeout = GetAttributeValue( "Timeout" ).AsInteger();
@@ -434,6 +436,7 @@ namespace RockWeb.Blocks.Reporting
         private void BuildControls( bool setData )
         {
             var showGridFilterControls = GetAttributeValue( "ShowGridFilter" ).AsBoolean();
+            string enabledLavaCommands = this.GetAttributeValue( "EnabledLavaCommands" );
             string errorMessage = string.Empty;
 
             // get just the schema of the data until we actually need the data
@@ -488,7 +491,7 @@ namespace RockWeb.Blocks.Reporting
                     // set page title
                     if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PageTitleLava" ) ) )
                     {
-                        string title = GetAttributeValue( "PageTitleLava" ).ResolveMergeFields( mergeFields );
+                        string title = GetAttributeValue( "PageTitleLava" ).ResolveMergeFields( mergeFields, enabledLavaCommands );
 
                         RockPage.BrowserTitle = title;
                         RockPage.PageTitle = title;
@@ -577,7 +580,7 @@ namespace RockWeb.Blocks.Reporting
                     }
                     else
                     {
-                        phContent.Controls.Add( new LiteralControl( formattedOutput.ResolveMergeFields( mergeFields ) ) );
+                        phContent.Controls.Add( new LiteralControl( formattedOutput.ResolveMergeFields( mergeFields, enabledLavaCommands ) ) );
                     }
                 }
 


### PR DESCRIPTION
## Proposed Changes

Adds block setting to the Dynamic Data block that allows the block to specify it's own enabled lava commands. This allows users to use entity commands and other things in a DD block without enabling them globally.

For completeness, this enabled the specified lava commands in the SQL Query Lava, the Page Title Lava, and the Custom Results Lava.

Fixes: #2474

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments

n/a

## Documentation

n/a