### PR TITLE
Bulk Update block enhancements to performance and UI progress

### DIFF
--- a/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
+++ b/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
@@ -17,13 +17,14 @@
 using System;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Threading;
+using System.Data.Entity;
 using System.Linq;
-using System.Runtime.Caching;
 using System.Text;
+using System.Threading.Tasks;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using System.Xml.Linq;
-using System.Xml.Xsl;
+using Microsoft.AspNet.SignalR;
 
 using Rock;
 using Rock.Attribute;
@@ -36,7 +37,6 @@ using Rock.Web.UI;
 using Rock.Web.UI.Controls.Communication;
 using Rock.Web.UI.Controls;
 using Rock.Transactions;
-using System.Data.Entity;
 
 namespace RockWeb.Blocks.Crm
 {
@@ -50,6 +50,7 @@ namespace RockWeb.Blocks.Crm
     [AttributeCategoryField( "Attribute Categories", "The person attribute categories to display and allow bulk updating", true, "Rock.Model.Person", false, "", "", 0 )]
     [IntegerField( "Display Count", "The initial number of individuals to display prior to expanding list", false, 0, "", 1 )]
     [WorkflowTypeField( "Workflow Types", "The workflows to make available for bulk updating.", true, false, "", "", 2 )]
+    [IntegerField( "Task Count", "The number of concurrent tasks to use when performing updates. If left blank then it will be determined automatically.", false, 0, "", 3 )]
     public partial class BulkUpdate : RockBlock
     {
         #region Fields
@@ -59,6 +60,11 @@ namespace RockWeb.Blocks.Crm
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// This holds the reference to the RockMessageHub SignalR Hub context.
+        /// </summary>
+        private IHubContext HubContext = GlobalHost.ConnectionManager.GetHubContext<RockMessageHub>();
 
         private List<Individual> Individuals { get; set; }
         private bool ShowAllIndividuals { get; set; }
@@ -72,6 +78,8 @@ namespace RockWeb.Blocks.Crm
         protected override void OnInit( EventArgs e )
         {
             base.OnInit( e );
+
+            RockPage.AddScriptLink( "~/Scripts/jquery.signalR-2.2.0.min.js", false );
 
             var personEntityTypeId = CacheEntityType.Get( typeof( Rock.Model.Person ) ).Id;
 
@@ -775,19 +783,140 @@ namespace RockWeb.Blocks.Crm
             if ( Page.IsValid )
             {
                 var individuals = Individuals.ToList();
-                while ( individuals.Any() )
+
+                var task = new Task( () =>
                 {
-                    ProcessIndividuals( individuals.Take( 50 ).ToList() );
-                    individuals = individuals.Skip( 50 ).ToList();
+                    int taskCount = GetAttributeValue( "TaskCount" ).AsInteger();
+                    int totalCount = individuals.Count;
+                    int processedCount = 0;
+                    var workers = new List<Task>();
+                    DateTime lastNotified = RockDateTime.Now;
+
+                    //
+                    // Validate task count.
+                    //
+                    if ( taskCount > 64 )
+                    {
+                        // Prevent the user from doing too much damage.
+                        taskCount = 64;
+                    }
+                    else if ( taskCount < 1 )
+                    {
+                        taskCount = Environment.ProcessorCount;
+                    }
+
+                    //
+                    // Wait for the browser to finish loading.
+                    //
+                    Thread.Sleep( 1000 );
+                    HubContext.Clients.Client( hfConnectionId.Value ).bulkUpdateProgress( "0", "0" );
+
+                    if ( individuals.Any() )
+                    {
+                        //
+                        // Spin up some workers to process the updates.
+                        //
+                        for ( int i = 0; i < taskCount; i++ )
+                        {
+                            var worker = Task.Factory.StartNew( () => WorkerTask( individuals ) );
+                            workers.Add( worker );
+                        }
+
+                        //
+                        // Wait for the workers to finish processing.
+                        //
+                        while ( workers.Any( t => !t.IsCompleted ) )
+                        {
+                            var timeDiff = RockDateTime.Now - lastNotified;
+                            if ( timeDiff.TotalSeconds >= 2.5 )
+                            {
+                                lock ( individuals )
+                                {
+                                    processedCount = totalCount - individuals.Count;
+                                }
+
+                                HubContext.Clients.Client( hfConnectionId.Value ).bulkUpdateProgress(
+                                    processedCount.ToString( "n0" ),
+                                    totalCount.ToString( "n0" ) );
+
+                                lastNotified = RockDateTime.Now;
+                            }
+
+                            Thread.Sleep( 250 );
+                        }
+                    }
+
+                    //
+                    // Give any jQuery transitions a moment to settle.
+                    //
+                    Thread.Sleep( 600 );
+
+                    if ( workers.Any( w => w.IsFaulted ) )
+                    {
+                        string status = string.Join( "<br>", workers.Where( w => w.IsFaulted ).Select( w => w.Exception.InnerException.Message.EncodeHtml() ) );
+
+                        HubContext.Clients.Client( hfConnectionId.Value ).bulkUpdateStatus( status, false );
+                    }
+                    else
+                    {
+                        var status = string.Format( "{0} {1} successfully updated.",
+                            Individuals.Count().ToString( "N0" ), ( Individuals.Count() > 1 ? "people were" : "person was" ) );
+
+                        HubContext.Clients.Client( hfConnectionId.Value ).bulkUpdateStatus( status.EncodeHtml(), true );
+                    }
+                } );
+
+                task.ContinueWith( ( t ) =>
+                {
+                    if ( t.IsFaulted )
+                    {
+                        string status = t.Exception.InnerException.Message;
+                        HubContext.Clients.Client( hfConnectionId.Value ).exportStatus( status.EncodeHtml(), false );
+                    }
+                } );
+
+                pnlConfirm.Visible = false;
+                pnlProcessing.Visible = true;
+
+                task.Start();
+            }
+        }
+
+        /// <summary>
+        /// Worker task for processing individuals in batches.
+        /// </summary>
+        /// <param name="individualsList">The individuals list.</param>
+        protected void WorkerTask( object individualsList )
+        {
+            const int batchSize = 1;
+
+            var individuals = ( List<Individual> ) individualsList;
+
+            while ( true )
+            {
+                List<Individual> batch = null;
+
+                //
+                // Get the next chunk.
+                //
+                lock ( individuals )
+                {
+                    batch = individuals.Take( batchSize ).ToList();
+                    if ( batch.Count > 0 )
+                    {
+                        individuals.RemoveRange( 0, batch.Count );
+                    }
                 }
 
-                pnlEntry.Visible = false;
-                pnlConfirm.Visible = false;
+                //
+                // Check if we are all done.
+                //
+                if ( batch.Count == 0 )
+                {
+                    break;
+                }
 
-                nbResult.Text = string.Format( "{0} {1} successfully updated.",
-                    Individuals.Count().ToString( "N0" ), ( Individuals.Count() > 1 ? "people were" : "person was" ) );
-
-                pnlResult.Visible = true;
+                ProcessIndividuals( batch );
             }
         }
 

--- a/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
+++ b/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
@@ -888,7 +888,7 @@ namespace RockWeb.Blocks.Crm
         /// <param name="individualsList">The individuals list.</param>
         protected void WorkerTask( object individualsList )
         {
-            const int batchSize = 1;
+            const int batchSize = 50;
 
             var individuals = ( List<Individual> ) individualsList;
 


### PR DESCRIPTION
## Proposed Changes

1. Update block to use multiple background threads when performing updates. By default it will use the number of "cpu threads", but the user can override with a block setting (up to 64). A "cpu thread" is the number of cores available, including hyperthreading. So a quad-core CPU with hyper-threading would use 8 worker threads. (See Note Below)
2. Updated block to use SignalR to give live feedback to the user about the progress. This also means no more timeouts when doing massive updates. Progress is given in 2.5 second increments.

Note on worker threads: It looks like C# managed code (i.e. Rock) is limited to a single CPU group by default. From what I understand of the docs, it looks like a dual-CPU system would have 2 CPU groups. This means the C# code (Rock) could only use 50% of the available system CPU. The "cpu thread" auto-calculation takes this into account so it will not over-subscribe if you have multiple sockets.

Fixes: #2650 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## UI Example

![bulk_update](https://user-images.githubusercontent.com/1119863/42481947-d517cc08-8399-11e8-940f-89157767c237.gif)

## Further comments

I don't have a v8 massive database available for full-length testing. I was able to do some psuedo testing by introducing artifical delays and changing the batch size to 1; but I am going to see if somebody on v8 pre-alpha with a full database can test this by doing a massive update to see if it all works before I mark it as safe to merge.

## Documentation

Since we provide default value for the concurrent task count, no documentation should be needed.