### PR TITLE
Updated uses of Thread.Sleep() to call Task.Delay().Wait() instead. (Fixes #3125)

### DIFF
--- a/Rock/Communication/Transport/Twilio.cs
+++ b/Rock/Communication/Transport/Twilio.cs
@@ -111,7 +111,7 @@ namespace Rock.Communication.Transport
 
                     if ( throttlingWaitTimeMS.HasValue )
                     {
-                        System.Threading.Thread.Sleep( throttlingWaitTimeMS.Value );
+                        System.Threading.Tasks.Task.Delay( throttlingWaitTimeMS.Value ).Wait();
                     }
                 }
             }
@@ -267,7 +267,7 @@ namespace Rock.Communication.Transport
 
                                 if ( throttlingWaitTimeMS.HasValue )
                                 {
-                                    System.Threading.Thread.Sleep( throttlingWaitTimeMS.Value );
+                                    System.Threading.Tasks.Task.Delay( throttlingWaitTimeMS.Value ).Wait();
                                 }
                             }
                             else

--- a/Rock/Jobs/LocationServicesVerify.cs
+++ b/Rock/Jobs/LocationServicesVerify.cs
@@ -93,7 +93,7 @@ namespace Rock.Jobs
                     successes++;
                 }
                 rockContext.SaveChanges();
-                System.Threading.Thread.Sleep( throttlePeriod );
+                System.Threading.Tasks.Task.Delay( throttlePeriod ).Wait();
             }
 
             context.Result = string.Format( "{0:N0} address verifications attempted; {1:N0} successfully verified", attempts, successes );

--- a/Rock/Jobs/RockCleanup.cs
+++ b/Rock/Jobs/RockCleanup.cs
@@ -965,8 +965,8 @@ WHERE ExpireDateTime IS NOT NULL
                 // if IO Exception thrown and this is not a retry attempt
                 if ( !isRetryAttempt )
                 {
-                    // have thread sleep for 10 ms and retry delete
-                    System.Threading.Thread.Sleep( 10 );
+                    // wait for 10 ms and retry delete
+                    System.Threading.Tasks.Task.Delay( 10 ).Wait();
                     DeleteDirectory( directoryPath, true );
                 }
             }
@@ -993,8 +993,8 @@ WHERE ExpireDateTime IS NOT NULL
                 // If an IO exception has occurred and this is not a retry attempt
                 if ( !isRetryAttempt )
                 {
-                    // have the thread sleep for 10 ms and retry delete.
-                    System.Threading.Thread.Sleep( 10 );
+                    // wait for 10 ms and retry delete.
+                    System.Threading.Tasks.Task.Delay( 10 ).Wait();
                     DeleteFile( filePath, true );
                 }
             }

--- a/Rock/Services/NuGet/RockProjectManager.cs
+++ b/Rock/Services/NuGet/RockProjectManager.cs
@@ -103,7 +103,7 @@ namespace Rock.Services.NuGet
                 catch ( IOException )
                 {
                     // try one more time
-                    System.Threading.Thread.Sleep( 10 );
+                    System.Threading.Tasks.Task.Delay( 10 ).Wait();
                     if ( Directory.Exists( packageRestorePath ) )
                     {
                         Directory.Delete( packageRestorePath, recursive: true );

--- a/Rock/Transactions/RunJobNowTransaction.cs
+++ b/Rock/Transactions/RunJobNowTransaction.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Threading;
 
 using Quartz;
 using Quartz.Impl;
@@ -95,7 +94,7 @@ namespace Rock.Transactions
                         sched.Start();
 
                         // Wait 10secs to give job chance to start
-                        Thread.Sleep( new TimeSpan( 0, 0, 10 ) );
+                        System.Threading.Tasks.Task.Delay( new TimeSpan( 0, 0, 10 ) ).Wait();
 
                         // stop the scheduler when done with job
                         sched.Shutdown( true );

--- a/RockWeb/Blocks/BulkImport/BulkImportTool.ascx.cs
+++ b/RockWeb/Blocks/BulkImport/BulkImportTool.ascx.cs
@@ -260,7 +260,7 @@ namespace RockWeb.Blocks.BulkImport
             var importTask = new Task( () =>
             {
                 // wait a little so the browser can render and start listening to events
-                System.Threading.Thread.Sleep( 1000 );
+                Task.Delay( 1000 ).Wait();
                 _hubContext.Clients.All.showButtons( this.SignalRNotificationKey, false );
 
                 Stopwatch stopwatch = Stopwatch.StartNew();

--- a/RockWeb/Blocks/Core/ScheduledJobList.ascx.cs
+++ b/RockWeb/Blocks/Core/ScheduledJobList.ascx.cs
@@ -197,7 +197,7 @@ namespace RockWeb.Blocks.Administration
                 mdGridWarning.Show( string.Format( "The '{0}' job has been started.", job.Name ), ModalAlertType.Information );
 
                 // wait a split second for the job to start so that the grid will show the status (if it changed)
-                System.Threading.Thread.Sleep( 250 );
+                System.Threading.Tasks.Task.Delay( 250 ).Wait();
             }
 
             BindGrid();

--- a/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
+++ b/RockWeb/Blocks/Crm/BulkUpdate.ascx.cs
@@ -818,7 +818,7 @@ namespace RockWeb.Blocks.Crm
                     //
                     // Wait for the browser to finish loading.
                     //
-                    Thread.Sleep( 1000 );
+                    Task.Delay( 1000 ).Wait();
                     HubContext.Clients.Client( hfConnectionId.Value ).bulkUpdateProgress( "0", "0" );
 
                     if ( individuals.Any() )
@@ -852,14 +852,14 @@ namespace RockWeb.Blocks.Crm
                                 lastNotified = RockDateTime.Now;
                             }
 
-                            Thread.Sleep( 250 );
+                            Task.Delay( 250 ).Wait();
                         }
                     }
 
                     //
                     // Give any jQuery transitions a moment to settle.
                     //
-                    Thread.Sleep( 600 );
+                    Task.Delay( 600 ).Wait();
 
                     if ( workers.Any( w => w.IsFaulted ) )
                     {

--- a/RockWeb/Webhooks/LaunchWorkflow.ashx
+++ b/RockWeb/Webhooks/LaunchWorkflow.ashx
@@ -290,7 +290,7 @@ public class LaunchWorkflow : IHttpHandler
             {
                 if ( retry < maxRetry - 1 )
                 {
-                    System.Threading.Thread.Sleep( 2000 );
+                    System.Threading.Tasks.Task.Delay( 2000 ).Wait();
                 }
             }
         }

--- a/RockWeb/Webhooks/Lava.ashx
+++ b/RockWeb/Webhooks/Lava.ashx
@@ -272,7 +272,7 @@ public class Lava : IHttpHandler
             {
                 if ( retry < maxRetry - 1 )
                 {
-                    System.Threading.Thread.Sleep( 2000 );
+                    System.Threading.Tasks.Task.Delay( 2000 ).Wait();
                 }
             }
         }

--- a/RockWeb/Webhooks/Twilio.ashx
+++ b/RockWeb/Webhooks/Twilio.ashx
@@ -224,7 +224,7 @@ class TwilioResponseAsync : IAsyncResult
             {
                 if ( retry < maxRetry - 1 )
                 {
-                    System.Threading.Thread.Sleep( 2000 );
+                    System.Threading.Tasks.Task.Delay( 2000 ).Wait();
                 }
             }
         }


### PR DESCRIPTION
## Proposed Changes

Replaces calls to `Thread.Sleep(x)` with `Task.Delay(x).Wait()`.

Fixes: #3125 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments

I was only able to test the changes to the BulkUpdate block and the ScheduledJobList block. But I did run an additional check in a stand-alone console app of putting `Task.Delay(5000).Wait()` to verify that the method works outside of a "task" so this should not cause any change of functionality.

## Documentation

n/a