### PR TITLE
Fix incorectly marking some PMM checks as requiring review. (Fixes #3147)

### DIFF
--- a/Rock/Security/BackgroundCheck/ProtectMyMinistry.cs
+++ b/Rock/Security/BackgroundCheck/ProtectMyMinistry.cs
@@ -589,7 +589,7 @@ Response XML ({0}):
                         if ( xStatus != null )
                         {
                             resultFound = true;
-                            if ( xStatus.Value != "NO RECORD" )
+                            if ( !( xStatus.Value.Equals( "NO RECORD", StringComparison.OrdinalIgnoreCase ) || xStatus.Value.Equals( "COMPLETE", StringComparison.OrdinalIgnoreCase ) ) )
                             {
                                 reportStatus = "Review";
                                 break;


### PR DESCRIPTION
## Proposed Changes
Adjusts the review check to look for both "NO RECORD" and "COMPLETED" (case insensitive).

We've applied this fix on our own instance and it behaves as expected.

Fixes: #3147

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments
N/A

## Documentation
N/A