### PR TITLE
Fix possible NullReferenceException when converting an Entity to a dictionary (Fixes #3165)

### DIFF
--- a/Rock/Data/Entity.cs
+++ b/Rock/Data/Entity.cs
@@ -313,7 +313,8 @@ namespace Rock.Data
 
             foreach ( var propInfo in this.GetType().GetProperties() )
             {
-                if ( !propInfo.GetGetMethod().IsVirtual || virtualPropsWhiteList.Contains(propInfo.Name) )
+                MethodInfo getMethod = propInfo.GetGetMethod();
+                if ( getMethod != null && ( !getMethod.IsVirtual || virtualPropsWhiteList.Contains(propInfo.Name) ) )
                 {
                     dictionary.Add( propInfo.Name, propInfo.GetValue( this, null ) );
                 }


### PR DESCRIPTION
## Proposed Changes
Fixes a NullReferenceException in `Entity.ToDictionary()` that can occur when a property's getter isn't public (such as `PersonAlias.AliasPerson`).

Fixes: #3165

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [X] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] I have read the [CONTRIBUTING ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [ ] Unit tests pass locally with my changes
* [ ] I have added [REQUIRED tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
* [ ] I have included necessary documentation (if appropriate)

## Further comments
N/A

## Documentation
N/A

