### PR TITLE
 - Fixed issue with Content Channel Type attributes...

### DIFF
--- a/RockWeb/Blocks/Cms/ContentChannelTypeDetail.ascx.cs
+++ b/RockWeb/Blocks/Cms/ContentChannelTypeDetail.ascx.cs
@@ -663,6 +663,11 @@ namespace RockWeb.Blocks.Cms
                     a.EntityTypeQualifierValue.Equals( qualifierValue ) )
                 .ToList()
                 .ForEach( a => ChannelAttributesState.Add( a ) );
+            
+            // Set order 
+            int newOrder = 0;
+            ChannelAttributesState.ForEach( a => a.Order = newOrder++ );
+                
             BindChannelAttributesGrid();
 
             attributeService.GetByEntityTypeId( new ContentChannelItem().TypeId, true ).AsQueryable()
@@ -671,6 +676,11 @@ namespace RockWeb.Blocks.Cms
                     a.EntityTypeQualifierValue.Equals( qualifierValue ) )
                 .ToList()
                 .ForEach( a => ItemAttributesState.Add( a ) );
+                
+            // Set order 
+            newOrder = 0;
+            ItemAttributesState.ForEach( a => a.Order = newOrder++ );
+            
             BindItemAttributesGrid();
         }
 


### PR DESCRIPTION
not re-ordering correctly after one has been deleted.

## Proposed Changes
If you delete content channel type attributes and click Save, this would leave gaps in the attribute ordering like this (Attrib3 was deleted):
- Attrib1: order 1
- Attrib2: order 2
- Attrib4: order 4 
- Attrib5: order 5

Instead of:
- Attrib1: order 1
- Attrib2: order 2
- Attrib4: order 3
- Attrib5: order 4

This would cause problems down the road because if you tried to delete another attribute, it was possible the wrong one would be deleted.

## Types of changes

What types of changes does your code introduce to Rock?
- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)