### PR TITLE
+ Added some help text to the Registration Detail payment section to …

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationDetail.ascx
+++ b/RockWeb/Blocks/Event/RegistrationDetail.ascx
@@ -240,6 +240,7 @@
 
                                     <div class="row">
                                         <div class="col-md-12">
+                                            <Rock:NotificationBox ID="nbNoAssociatedPerson" runat="server" CssClass="margin-t-md" NotificationBoxType="Info" Text="In order to process a payment you will need to link this registration to an individual." Visible="false" />
                                             <asp:LinkButton ID="lbProcessPayment" runat="server" CssClass="btn btn-primary btn-xs margin-t-sm" Text="Process New Payment" OnClick="lbProcessPayment_Click" CausesValidation="false"></asp:LinkButton>
                                             <asp:LinkButton ID="lbAddPayment" runat="server" CssClass="btn btn-default btn-xs margin-t-sm margin-l-sm" Text="Add Manual Payment" OnClick="lbAddPayment_Click" CausesValidation="false"></asp:LinkButton>
                                             <asp:LinkButton ID="lbCancelPaymentDetails" runat="server" Text="Cancel" CssClass="btn btn-link pull-right" OnClick="lbCancelPaymentDetails_Click" CausesValidation="false" />

--- a/RockWeb/Blocks/Event/RegistrationDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationDetail.ascx.cs
@@ -2281,11 +2281,13 @@ namespace RockWeb.Blocks.Event
                 {
                     lbAddPayment.Visible = true;
                     lbProcessPayment.Visible = RegistrationTemplateState.FinancialGateway != null;
+                    nbNoAssociatedPerson.Visible = false;
                 }
                 else
                 {
                     lbAddPayment.Visible = false;
                     lbProcessPayment.Visible = false;
+                    nbNoAssociatedPerson.Visible = registration.BalanceDue > 0.0m ? true : false;
                 }
             }
             else


### PR DESCRIPTION
…let the user know that a registration needs to be linked to an individual before a payment can be added.

## Proposed Changes
This adds a notification box to the payment section of the registration detail reminding the user to link the registration to a person to add a payment.  This clears up the confusion as to why a payment can't be added to a registration.  

This will only appear on screen if:
- the registration is not linked to a person
- the registration owes money

![image](https://user-images.githubusercontent.com/2349102/44927573-df738180-ad09-11e8-8827-bbea1858a634.png)


## Types of changes

What types of changes does your code introduce to Rock?
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)

## Checklist
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [X] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)

## Documentation
I checked the documentation and it doesn't mention this bit of information.  We might consider adding a small note here as well:
https://www.rockrms.com/Rock/BookContent/29/118#registrationfinances

