### PR TITLE
Added block setting that allows sorting of Locations

### DIFF
--- a/RockWeb/Blocks/CheckIn/LocationSelect.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/LocationSelect.ascx.cs
@@ -42,6 +42,8 @@ namespace RockWeb.Blocks.CheckIn
     [TextField( "No Option After Select Message", "Message to display when there are not any options available after location is selected. Use {0} for person's name", false,
         "Sorry, based on your selection, there are currently not any available times that {0} can check into.", "Text", 12 )]
 
+    [CustomDropdownListField( "Sort By", "", "0^Location Name,1^Check-In Group Location Order", false, "0", order: 13 )]
+
     public partial class LocationSelect : CheckInBlockMultiPerson
     {
         /// <summary>
@@ -206,9 +208,21 @@ namespace RockWeb.Blocks.CheckIn
                         }
                         else
                         {
-                            rSelection.DataSource = availLocations
-                                .OrderBy( l => l.Location.Name )
-                                .ToList();
+                            var locations = new List<CheckInLocation>();
+                            int sortBy = GetAttributeValue( "SortBy" ).AsInteger();
+                            switch ( sortBy )
+                            {
+                                case 0: locations = availLocations.OrderBy( l => l.Location.Name ).ToList();
+                                    break;
+
+                                case 1: locations = availLocations.OrderBy( l => l.Order ).ToList();
+                                    break;
+
+                                default: locations = availLocations.OrderBy( l => l.Location.Name ).ToList();
+                                    break;
+                            }
+
+                            rSelection.DataSource = locations;
 
                             rSelection.DataBind();
                         }


### PR DESCRIPTION
## Proposed Changes

This allows the Location Select block to display the list of Locations by the `Order` property instead of `Name` (defaults to `Name`).

Fixes: #3278

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
