### PR TITLE
- Fixed Public Profile Edit block to only allow one "Mapped" address …

### DIFF
--- a/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
+++ b/RockWeb/Blocks/Cms/PublicProfileEdit.ascx.cs
@@ -662,6 +662,18 @@ namespace RockWeb.Blocks.Cms
 
                                                         familyAddress.Location = new LocationService( rockContext ).Get(
                                                             loc.Street1, loc.Street2, loc.City, loc.State, loc.PostalCode, loc.Country, familyGroup, true );
+                                                        
+                                                        // since there can only be one mapped location, set the other locations to not mapped
+                                                        if ( familyAddress.IsMappedLocation )
+                                                        {
+                                                            var groupLocations = groupLocationService.Queryable()
+                                                                .Where( l => l.GroupId == familyGroup.Id && l.Id != familyAddress.Id ).ToList();
+
+                                                            foreach ( var groupLocation in groupLocations )
+                                                            {
+                                                                groupLocation.IsMappedLocation = false;
+                                                            }
+                                                        }
 
                                                         rockContext.SaveChanges();
                                                     }


### PR DESCRIPTION
…for a family when saving a new address.

## Proposed Changes
This fixes an issue with the Public Profile Edit block where adding an address would sometimes cause the family to have two "Mapped" addresses.

To Reproduce the bug:
- Find a family that already has a "Mapped" address that is a different location type than "Home". 
- Log in as one of the family members and then use the Public Profile Edit block to add a new address.  (Assuming they are using the default block setting of "Home" location type.)
- When adding an address, make sure to check the box "This is my physical address".
- Save the changes and then look at the family on the Edit Family page.  You will see that the family now has two mapped locations.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [X] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
