### PR TITLE
+ Added workflow action to check-in by data views

### DIFF
--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -2065,6 +2065,7 @@
     <Compile Include="Workflow\Action\CheckIn\FilterByGrade.cs" />
     <Compile Include="Workflow\Action\CheckIn\FilterGroupsByAbilityLevel.cs" />
     <Compile Include="Workflow\Action\CheckIn\FilterGroupsByAge.cs" />
+    <Compile Include="Workflow\Action\CheckIn\FilterGroupsByDataView.cs" />
     <Compile Include="Workflow\Action\CheckIn\FilterGroupsByGrade.cs" />
     <Compile Include="Workflow\Action\CheckIn\FilterGroupsByGradeAndAge.cs" />
     <Compile Include="Workflow\Action\CheckIn\FilterGroupsByGender.cs" />

--- a/Rock/Workflow/Action/CheckIn/FilterGroupsByDataView.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsByDataView.cs
@@ -1,0 +1,144 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Runtime.Caching;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace Rock.Workflow.Action.CheckIn
+{
+    /// <summary>
+    /// Removes or excludes checkin groups that require the member to be in a particular dataview
+    /// </summary>
+    [ActionCategory( "Check-In" )]
+    [Description( "Removes or excludes checkin groups that require the member to be in a data view" )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Filter Groups By Data View" )]
+    [AttributeField( Rock.SystemGuid.EntityType.GROUP, "DataView Group Attribute", "Select the attribute used to filter by DataView.", true, false, defaultValue: "E8F8498F-5C51-4216-AC81-875349D6C2D0", order: 0 )]
+    [BooleanField( "Remove", "Select 'Yes' if groups should be be removed.  Select 'No' if they should just be marked as excluded.", true, order: 1 )]
+    public class FilterGroupsByDataView : CheckInActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The workflow action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public override bool Execute( RockContext rockContext, Rock.Model.WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            var checkInState = GetCheckInState( entity, out errorMessages );
+            if ( checkInState == null )
+            {
+                return false;
+            }
+
+            var dataViewAttributeKey = string.Empty;
+            var dataViewAttributeGuid = GetAttributeValue( action, "DataViewGroupAttribute" ).AsGuid();
+            if ( dataViewAttributeGuid != Guid.Empty )
+            {
+                dataViewAttributeKey = AttributeCache.Get( dataViewAttributeGuid, rockContext ).Key;
+            }
+
+            var dataViewService = new DataViewService( rockContext );
+
+            var family = checkInState.CheckIn.CurrentFamily;
+            if ( family != null )
+            {
+                var remove = GetAttributeValue( action, "Remove" ).AsBoolean();
+
+                foreach ( var person in family.People )
+                {
+                    foreach ( var groupType in person.GroupTypes.ToList() )
+                    {
+                        foreach ( var group in groupType.Groups.ToList() )
+                        {
+                            if ( group.ExcludedByFilter == true )
+                            {
+                                continue;
+                            }
+
+                            var dataviewGuids = group.Group.GetAttributeValue( dataViewAttributeKey );
+                            if ( string.IsNullOrWhiteSpace( dataviewGuids ) )
+                            {
+                                continue;
+                            }
+
+                            foreach ( var dataviewGuid in dataviewGuids.SplitDelimitedValues() )
+                            {
+                                DataView dataview = dataViewService.Get( dataviewGuid.AsGuid() );
+                                if ( dataview == null )
+                                {
+                                    continue;
+                                }
+
+                                if ( dataview.PersistedScheduleIntervalMinutes.HasValue && dataview.PersistedLastRefreshDateTime.HasValue )
+                                {
+                                    //Get record from persisted.
+                                    var persistedValuesQuery = rockContext.DataViewPersistedValues.Where( a => a.DataViewId == dataview.Id );
+                                    if ( !persistedValuesQuery.Any( v => v.EntityId == person.Person.Id ) )
+                                    {
+                                        if ( remove )
+                                        {
+                                            groupType.Groups.Remove( group );
+                                        }
+                                        else
+                                        {
+                                            group.ExcludedByFilter = true;
+                                        }
+                                        break;
+                                    }
+                                }
+                                else
+                                {
+                                    //Qry dataview
+                                    var approvedPeopleQry = dataview.GetQuery( null, 30, out errorMessages );
+                                    if ( approvedPeopleQry != null )
+                                    {
+                                        var approvedPeopleList = approvedPeopleQry.Select( e => e.Id ).ToList();
+
+                                        if ( approvedPeopleList != null && !approvedPeopleList.Contains( person.Person.Id ) )
+                                        {
+                                            if ( remove )
+                                            {
+                                                groupType.Groups.Remove( group );
+                                            }
+                                            else
+                                            {
+                                                group.ExcludedByFilter = true;
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

At Southeast we have found that the standard check-in filters do not give us as much control over our check-in as we would like. About 2 years ago we created a way to use data views in our check-in system. We use check-in by data view more than any other type, and frequently have had requests for it. This is an improved version of what we have been running weekly at SECC.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments

I've promised to contribute this for over a year. This workflow supports multiple dataviews and persisted and non-persisted dataviews. This has overlap with check-in of group members. We generally prefer check in by data view because it allows us to keep our check-in configuration together in the same template, and we don't have to manage multiple group syncs.

**Migration:**
```
RockMigrationHelper.AddGroupType( "Check in by Data View", "", "Group", "Member", false, false, false, "", 0, "", 0, "6BCED84C-69AD-4F5A-9197-5C0F9C02DD34", "DC7ED2FD-5F88-4760-B3C8-494EDB1CFC06", true );
RockMigrationHelper.AddGroupTypeGroupAttribute( "DC7ED2FD-5F88-4760-B3C8-494EDB1CFC06", SystemGuid.FieldType.DATAVIEWS, "Data View", "Data view allowed to check into this group.", 0, "", "E8F8498F-5C51-4216-AC81-875349D6C2D0" );
RockMigrationHelper.AddAttributeQualifier( "E8F8498F-5C51-4216-AC81-875349D6C2D0", "entityTypeName", "Rock.Model.Person", "D59BAD04-4C23-497C-810A-328B760B7C6B" );

RockMigrationHelper.UpdateEntityType( "Rock.Workflow.Action.CheckIn.FilterGroupsByDataView", "E6490F9B-21C6-4D0F-AD15-9729AC22C094", false, true );
RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Active", "Active", "Should Service be used?", 0, @"False", "0B1FF2A0-D0CE-42A5-95BC-C65F02D14399" );
RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Order", "Order", "The order that this service should be used (priority)", 0, @"", "869473D0-AC93-4F8F-B164-2A332571E779" );
RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Remove", "Remove", "Select 'Yes' if groups should be be removed.  Select 'No' if they should just be marked as excluded.", 0, @"True", "5EE8CC8E-455D-4115-88F4-81D224A30A28" );

RockMigrationHelper.UpdateWorkflowActionType( "EB744DF1-E454-482C-B111-80A54EF8A674", "Filter Groups by DataView", 0, "E6490F9B-21C6-4D0F-AD15-9729AC22C094", true, false, "", "66EF6CB1-1A96-2F81-4534-3BCA5C33D4CD", 1, "False", "31F407AA-50BB-4915-BB22-7AF463989D98" );

Sql( @"
    -- Fix the ordering of the Unattended Check-in Id: 10 workflow activity so that the 'Filter By Data View' activity is immediately after 'Filter By Gender'
    DECLARE @ActivityTypeId int = ( SELECT TOP 1 [Id] FROM [WorkflowActivityType] WHERE [Guid] = 'EB744DF1-E454-482C-B111-80A54EF8A674' )
    DECLARE @EntityTypeId int = ( SELECT TOP 1 [Id] FROM [EntityType] WHERE [Name] = 'Rock.Workflow.Action.CheckIn.FilterGroupsByGender' )
    DECLARE @Order int = ISNULL( ( SELECT TOP 1 [Order] FROM [WorkflowActionType] WHERE [ActivityTypeId] = @ActivityTypeId AND [EntityTypeId] = @EntityTypeId ), 0)
    IF @Order IS NOT NULL AND @Order > 0
    BEGIN
        UPDATE [WorkflowActionType] SET [Order] = [Order] + 1 WHERE [ActivityTypeId] = @ActivityTypeId AND [Order] > @Order
        UPDATE [WorkflowActionType] SET [Order] = @Order + 1 WHERE [Guid] = '31F407AA-50BB-4915-BB22-7AF463989D98'
    END
" );
```

## Documentation
The migration will add a new check-in group type filter and update the basic check-in workflow. Select inherit from Check in By Data View in the area and select the data view(s) you wish to use in the group. I looked at the documentation for check-in and didn't see much documentation for the different filters so I'm not sure how much documentation would need to be changed.