### PR TITLE
Automatically inactivate all Connection Requests for a person when they are marked inactive and deceased.

### DIFF
--- a/Rock/Model/Person.cs
+++ b/Rock/Model/Person.cs
@@ -1867,10 +1867,10 @@ namespace Rock.Model
 
                 if ( isInactive )
                 {
-                    // If person was just inactivated, update the group member status for all their group memberships to be inactive
                     var dbPropertyEntry = entry.Property( "RecordStatusValueId" );
                     if ( dbPropertyEntry != null && dbPropertyEntry.IsModified )
-                    {
+                    {   
+                        // If person was just inactivated, update the group member status for all their group memberships to be inactive
                         foreach ( var groupMember in new GroupMemberService( rockContext )
                             .Queryable()
                             .Where( m =>
@@ -1880,7 +1880,20 @@ namespace Rock.Model
                         {
                             groupMember.GroupMemberStatus = GroupMemberStatus.Inactive;
                         }
+                        // Also update the person's connection requests
+                        int[] aliasIds = Aliases.Select( a => a.Id ).ToArray();
+                        foreach (var connectionRequest in new ConnectionRequestService(rockContext)
+                            .Queryable()
+                            .Where(c =>
+                                aliasIds.Contains(c.PersonAliasId) &&
+                                c.ConnectionState != ConnectionState.Inactive && 
+                                c.ConnectionState != ConnectionState.Connected ) )
+                        {
+                            connectionRequest.ConnectionState = ConnectionState.Inactive;
+                        }
                     }
+
+
                 }
             }
 


### PR DESCRIPTION
## Proposed Changes

The PreSaveChanges on a person previously inactivated the person in all groups when that person was inactivated.  Now it will also inactivate all connection requests.  This is a change that is consistent with existing functionality.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [x] I have included necessary documentation (if appropriate)

## Further comments
This is a pretty simple change.  It mirrors the functionality directly before it in the GroupMember section.

## Documentation
I'm not sure any documentation needs to be updated.  I reviewed some of the documentation surrounding when a person is marked as inactive/deceased and it doesn't mention that it automatically deactivates them in all groups.  Maybe that should be added somewhere: https://www.rockrms.com/Rock/BookContent/5/125#recommendationsforlifeevents
