### PR TITLE
Enhancements to group type highlight label

### DIFF
--- a/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
@@ -1685,7 +1685,17 @@ namespace RockWeb.Blocks.Groups
             {
                 groupIconHtml = !string.IsNullOrWhiteSpace( groupType.IconCssClass ) ?
                     string.Format( "<i class='{0}' ></i>", groupType.IconCssClass ) : string.Empty;
-                hlType.Text = groupType.Name;
+
+                if ( groupType.IsAuthorized( Authorization.ADMINISTRATE, CurrentPerson ) )
+                {
+                    var groupTypeDetailPage = new PageReference( Rock.SystemGuid.Page.GROUP_TYPE_DETAIL ).BuildUrl();
+                    hlType.Text = string.Format( "<a href='{0}?groupTypeId={1}'>{2}</a>", groupTypeDetailPage, groupType.Id, groupType.Name );
+                }
+                else
+                {
+                    hlType.Text = groupType.Name;
+                }
+                hlType.ToolTip = groupType.Description;
             }
 
             hfGroupId.SetValue( group.Id );


### PR DESCRIPTION
## Proposed Changes

Our Rock admin has long wanted the ability to click on the Group Type label on the top of the group viewer page and be taken to the detail page for that group type. Additionally, having a tool tip with the description of the group type would be very helpful.

![image](https://user-images.githubusercontent.com/495787/47531507-d4f1e600-d87b-11e8-8a0b-64fb22a2d985.png)

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the [CONTRIBUTING](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [REQUIRED tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
- [ ] I have included necessary documentation (if appropriate)

## Further comments

This checks to see if the user can administrate the page before making the text clickable.

