### PR TITLE
Fixed lava where filter to work with arbitrary data

### DIFF
--- a/Rock.Tests/Rock/Lava/RockFiltersTests.cs
+++ b/Rock.Tests/Rock/Lava/RockFiltersTests.cs
@@ -741,6 +741,58 @@ namespace Rock.Tests.Rock.Lava
 
         #endregion
 
+        #region Where
+
+        /// <summary>
+        /// For use in Lava -- should extract a single element form array
+        /// </summary>
+        [Fact]
+        public void Where_ByInt()
+        {
+            var input = new List<Dictionary<string, object>>
+            {
+               new Dictionary<string, object> { { "Id", (int)1 } },
+               new Dictionary<string, object> { { "Id", (int)2 } }
+            };
+            var output = RockFilters.Where( input, "Id", 1 );
+            Assert.Single( ( List<object> ) output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should extract a single element form array. Simulates a | FromJSON input.
+        /// </summary>
+        [Fact]
+        public void Where_ByLong()
+        {
+            var input = new List<Dictionary<string, object>>
+            {
+               new Dictionary<string, object> { { "Id", (long)1 } },
+               new Dictionary<string, object> { { "Id", (long)2 } }
+            };
+            var output = RockFilters.Where( input, "Id", (int)1 );
+            Assert.Single( ( List<object> ) output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should extract a single element form array
+        /// </summary>
+        [Fact]
+        public void Where_ByString()
+        {
+            var input = new List<Dictionary<string, object>>
+            {
+               new Dictionary<string, object> { { "Id", "1" } },
+               new Dictionary<string, object> { { "Id", "2" } }
+            };
+
+            var output = RockFilters.Where( input, "Id", "1" );
+            Assert.Single( ( List<object> ) output );
+        }
+
+
+
+        #endregion
+
         #endregion
 
         #region Date Filters

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -4332,7 +4332,7 @@ namespace Rock.Lava
                     else if (value is IDictionary<string, object>)
                     {
                         var dictionaryObject = value as IDictionary<string, object>;
-                        if ( dictionaryObject.ContainsKey( filterKey ) && dictionaryObject[filterKey].Equals( filterValue ) )
+                        if ( dictionaryObject.ContainsKey( filterKey ) && (dynamic) dictionaryObject[filterKey] == (dynamic) filterValue )
                         {
                             result.Add( dictionaryObject );
                         }


### PR DESCRIPTION
## Proposed Changes
When trying to sort a list of objects that came from a JSON source ( using `|FromJson`), `|Where` doesn't work if you are filtering by an integer.  This makes filtering by Id or some other number challenging. The reason is that JsonConvert.DeserializeObject converts all numbers as long and it doesn't match the provided int. I have changed the way the two objects are compared so that the expected outcome happens. Unit tests included.

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
* [x] I have read the [CONTRIBUTING ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [x] Unit tests pass locally with my changes
* [x] I have added [REQUIRED tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) to Rock.Tests that prove my fix is effective or that my feature works
* [ ] I have included necessary documentation (if appropriate)

## Further comments
Related StackOveflow: https://stackoverflow.com/questions/27972266/compare-numeric-types-when-types-are-unknown

I also considered `.ToString()`-ing both sides. This would have the added benefit of matching strings to integers, with the downside of it just not feeling right.

Additionally here is some test lava:

```
{% capture str %}
[
    {"Id": 1, "Name":"Chuck"},
    {"Id": 2, "Name":"Mark"}
    ]
{% endcapture %}

{% assign json = str | FromJSON | Where: "Id", 1 %}

<ul>
{% for item in json  %}
<li>{{item.Name}}</li>
{% endfor %}
</ul>
```

