### PR TITLE
Removed Unnecessary Merge Field Loading

### DIFF
--- a/RockWeb/Blocks/Connection/MyConnectionOpportunities.ascx.cs
+++ b/RockWeb/Blocks/Connection/MyConnectionOpportunities.ascx.cs
@@ -307,7 +307,6 @@ namespace RockWeb.Blocks.Connection
             {
                 var connectionOpportunity = new ConnectionOpportunityService( rockContext ).Queryable().AsNoTracking().FirstOrDefault( a => a.Id == opportunitySummary.Id );
                 mergeFields.Add( "ConnectionOpportunity", connectionOpportunity );
-                mergeFields.Add( "ConnectionRequests", connectionOpportunity.ConnectionRequests );
 
                 result = template.ResolveMergeFields( mergeFields );
             }


### PR DESCRIPTION
By removing the loading of the ConnectionRequests from the block code, you can speed up the loading of the block without changing what you can accomplish with the Lava.

## Proposed Changes
I removed the code loading the Connection Requests to the Opportunity Summary Template.  This dramatically speeds up load times when there's a high number of Connection Requests.


Fixes: #3397 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
This can only cause an issue in the unlikely case where someone uses `{{ ConnectionRequests . . . ` in the Opportunity Summary Template area of the My Connection Opportunities block.  This can be remedied by using `{{ ConnectionOpportunity.ConnectionRequests . . . ` to get the same data, but not force the loading of all Connection Requests on the block's loading.

With a large amount of data, this change fixed a page that had been giving a 502 error because of trying to load this data, and ramping the web server to 100% CPU load while doing so.

This code was used successfully on a sandbox environment.  I tested block functionality and evaluated the Lava in the default block settings and couldn't find any problems.

## Documentation
