### PR TITLE
Fixing the Merge Template functionality when executed from the failed communication list

### DIFF
--- a/Rock/Web/UI/Controls/Grid/Grid.cs
+++ b/Rock/Web/UI/Controls/Grid/Grid.cs
@@ -307,6 +307,18 @@ namespace Rock.Web.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether [merge template as person].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [merge template as person]; otherwise, <c>false</c>.
+        /// </value>
+        public virtual bool MergeTemplateAsPerson
+        {
+            get { return this.ViewState["MergeTemplateAsPerson"] as bool? ?? false; }
+            set { ViewState["MergeTemplateAsPerson"] = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the display type.
         /// </summary>
         /// <value>
@@ -1653,10 +1665,19 @@ $('#{this.ClientID} .grid-select-cell').on( 'click', function (event) {{
         /// <exception cref="System.NotImplementedException"></exception>
         protected void Actions_MergeTemplateClick( object sender, EventArgs e )
         {
-            // disable paging if no specific keys where selected (or if no select option is shown)
-            bool selectAll = !SelectedKeys.Any();
-            RebindGrid( e, selectAll, true, false );
-            int? entitySetId = GetEntitySetFromGrid( e );
+            int? entitySetId = null;
+            if ( MergeTemplateAsPerson && PersonIdField.IsNotNullOrWhiteSpace() )
+            {
+                entitySetId = GetPersonEntitySet( e );
+            }
+            else
+            {
+                // disable paging if no specific keys where selected (or if no select option is shown)
+                bool selectAll = !SelectedKeys.Any();
+                RebindGrid( e, selectAll, true, false );
+                entitySetId = GetEntitySetFromGrid( e );
+            }
+
             if ( entitySetId.HasValue )
             {
                 Page.Response.Redirect( string.Format( MergeTemplatePageRoute, entitySetId.Value ), false );

--- a/RockWeb/Blocks/Communication/CommunicationDetail.ascx
+++ b/RockWeb/Blocks/Communication/CommunicationDetail.ascx
@@ -101,7 +101,7 @@
                         <header class="panel-heading clearfix">Failed Recipients</header>
                         <div class="panel-body">
                             <div class="grid grid-panel">
-                                <Rock:Grid ID="gFailed" runat="server" AllowSorting="true">
+                                <Rock:Grid ID="gFailed" runat="server" AllowSorting="true" PersonIdField="PersonAlias.PersonId" MergeTemplateAsPerson="true">
                                     <Columns>
                                         <Rock:SelectField />
                                         <Rock:PersonField HeaderText="Name" DataField="PersonAlias.Person" SortExpression="PersonAlias.Person.LastName,PersonAlias.Person.NickName" />

--- a/RockWeb/Blocks/Communication/CommunicationDetail.ascx
+++ b/RockWeb/Blocks/Communication/CommunicationDetail.ascx
@@ -103,6 +103,7 @@
                             <div class="grid grid-panel">
                                 <Rock:Grid ID="gFailed" runat="server" AllowSorting="true">
                                     <Columns>
+                                        <Rock:SelectField />
                                         <Rock:PersonField HeaderText="Name" DataField="PersonAlias.Person" SortExpression="PersonAlias.Person.LastName,PersonAlias.Person.NickName" />
                                         <Rock:RockBoundField HeaderText="Note" DataField="StatusNote" SortExpression="StatusNote" />
                                     </Columns>

--- a/RockWeb/Blocks/Communication/CommunicationDetail.ascx.cs
+++ b/RockWeb/Blocks/Communication/CommunicationDetail.ascx.cs
@@ -84,7 +84,6 @@ namespace RockWeb.Blocks.Communication
             gPending.GridRebind += gRecipients_GridRebind;
             gDelivered.GridRebind += gRecipients_GridRebind;
             gFailed.GridRebind += gRecipients_GridRebind;
-            gFailed.Actions.MergeTemplateClick += gFailed_Actions_MergeTemplateClick;
             gCancelled.GridRebind += gRecipients_GridRebind;
             gOpened.GridRebind += gRecipients_GridRebind;
 
@@ -127,65 +126,6 @@ namespace RockWeb.Blocks.Communication
                 mdCreateTemplate.SaveClick += mdSaveTemplate_Click;
             }
 
-        }
-
-        private void gFailed_Actions_MergeTemplateClick( object sender, EventArgs e )
-        {
-            gFailed.AllowPaging = false;
-            gRecipients_GridRebind( sender, e );
-
-            var entitySet = new Rock.Model.EntitySet();
-            entitySet.EntityTypeId = EntityTypeCache.Get<Rock.Model.Person>().Id;
-            entitySet.ExpireDateTime = RockDateTime.Now.AddMinutes( 5 );
-            List<Rock.Model.EntitySetItem> entitySetItems = new List<Rock.Model.EntitySetItem>();
-
-            List<int> keys = new List<int>();
-            // Check to see if specific keys were selected
-            if ( !gFailed.SelectedKeys.Any() )
-            {
-                keys = gFailed.DataSourceAsList.OfType<CommunicationRecipient>().Select( a => a.PersonAlias.PersonId ).Distinct().ToList();
-            }
-            else
-            {
-                keys = gFailed.DataSourceAsList.OfType<CommunicationRecipient>().Where(cr => gFailed.SelectedKeys.Contains(cr.Id) ).Select( a => a.PersonAlias.PersonId ).Distinct().ToList();
-            }
-
-            int itemOrder = 0;
-            foreach(int key in keys)
-            {
-
-                var item = new Rock.Model.EntitySetItem();
-                item.EntityId = key;
-                item.Order = itemOrder++;
-                entitySetItems.Add( item );
-            }
-            int? entitySetId = new Nullable<int>();
-            if ( entitySetItems.Any() )
-            {
-                var rockContext = new RockContext();
-                var service = new Rock.Model.EntitySetService( rockContext );
-                service.Add( entitySet );
-                rockContext.SaveChanges();
-                entitySetItems.ForEach( a =>
-                {
-                    a.EntitySetId = entitySet.Id;
-                } );
-
-                rockContext.BulkInsert( entitySetItems );
-
-                entitySetId = entitySet.Id;
-            }
-
-            if ( entitySetId.HasValue )
-            {
-                Page.Response.Redirect( string.Format( gFailed.MergeTemplatePageRoute, entitySetId.Value ), false );
-                Context.ApplicationInstance.CompleteRequest();
-            }
-            else
-            {
-                // empty entityset ( probably because the list has 0 items)
-                gFailed.ShowModalAlertMessage( "Grid has no " + gFailed.RowItemText.Pluralize(), ModalAlertType.Warning );
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes
Updating the Failed grid on communication detail to convert communication recipients into people in order to create a merge document. Also, as a small bonus, you can now pick a sub-set of those people so you can pick and choose who you would like to merge.

Fixes: #3400 

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [x] I have read the [Contributing to Rock ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [x] Unit tests pass locally with my changes
* [ ] I have added [required tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
* [ ] I have included updated language for the [Rock Documentation ](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

## Documentation
