### PR TITLE
Fixed issue where requesting oversized image return nothing Fixes: #3431

### DIFF
--- a/RockWeb/App_Code/GetImage.ashx.cs
+++ b/RockWeb/App_Code/GetImage.ashx.cs
@@ -411,8 +411,12 @@ namespace RockWeb
 
                 MemoryStream resizedStream = new MemoryStream();
 
-                ImageBuilder.Current.Build( fileContent, resizedStream, settings );
-                return resizedStream;
+                ImageBuilder.Current.Build( fileContent, resizedStream, settings, false );
+                if ( resizedStream.Length > 0 )
+                {
+                    return resizedStream;
+                }
+                return fileContent;
             }
             catch
             {


### PR DESCRIPTION
## Proposed Changes
Fix an issue where requesting than an image be resized larger than it's existing size can cause it to return nothing.

Fixes: #3431

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
I made the changes suggested by @cabal95 in not disposing the file stream. I added an additional check to make sure the returned stream had length before returning.

## Documentation
N/A