### PR TITLE
Changed complete workflow job to only close active workflows

### DIFF
--- a/Rock/Jobs/CompleteWorkflows.cs
+++ b/Rock/Jobs/CompleteWorkflows.cs
@@ -68,7 +68,9 @@ namespace Rock.Jobs
             var workflowService = new WorkflowService( rockContext );
 
             var qry = workflowService.Queryable().AsNoTracking()
-                        .Where( w => workflowTypeGuids.Contains( w.WorkflowType.Guid ) );
+                        .Where( w => workflowTypeGuids.Contains( w.WorkflowType.Guid )
+                                     && w.ActivatedDateTime.HasValue
+                                     && !w.CompletedDateTime.HasValue );
 
             if ( expirationAge.HasValue )
             {


### PR DESCRIPTION
## Proposed Changes
We noticed that our complete workflow jobs were taking longer and longer to run each night. On investigation it turns out that the Complete Workflow job completes all workflows and actions instead of just the active ones. This PR is to change this to only select active workflows to complete. I used the same logic used in `Workflow.IsActive`.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)