### PR TITLE
Exception handling for situations where Cookies already exist.

### DIFF
--- a/RockWeb/Webhooks/Lava.ashx
+++ b/RockWeb/Webhooks/Lava.ashx
@@ -239,7 +239,13 @@ public class Lava : IHttpHandler
         dictionary.Add( "Headers", headers );
 
         // Add the cookies
-        dictionary.Add( "Cookies", request.Cookies.Cast<string>().ToDictionary( q => q, q => request.Cookies[q].Value ) );
+        try
+        {
+			dictionary.Add( "Cookies", request.Cookies.Cast<string>().ToDictionary( q => q, q => request.Cookies[q].Value ) );
+        }
+        catch
+        {
+        }
 
         return dictionary;
     }


### PR DESCRIPTION
## Proposed Changes
This is just adding a try/catch for situations where a Cookies parameter might already exist in the lava merge dictionary.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
This probably doesn't occur for most other churches in other hosting environments but in our situation,, for some reason in some situations, the Cookies key already existed in the dictionary so it was throwing an error that we were logging.

## Documentation
N/A