### PR TITLE
- Upped ImageResizer limits to 4,000x4,000 pixels. (Fixes #3430)

### DIFF
--- a/RockWeb/web.config
+++ b/RockWeb/web.config
@@ -16,7 +16,7 @@
     <add key="quartz.jobStore.type" value="Quartz.Simpl.RAMJobStore, Quartz" />
   </quartz>
   <resizer>
-    <sizelimits totalWidth="3600" totalHeight="3600" totalBehavior="throwexception" />
+    <sizelimits totalWidth="4000" totalHeight="4000" totalBehavior="throwexception" />
   </resizer>
   <rockConfig>
     <attributeValues>


### PR DESCRIPTION
## Proposed Changes

The ImageResizer settings are set to limit resizes to 3,600 x 3,600 pixels. This prevents sizing an image for a 4K display (3,840 x 2,160). This PR ups that limit to 4,000 x 4,000 pixels.

Fixes: #3430

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

This PR is a change to the web.config.

## Documentation
