### PR TITLE
Added a filter control for the Schedules FieldType

### DIFF
--- a/Rock/Field/Types/SchedulesFieldType.cs
+++ b/Rock/Field/Types/SchedulesFieldType.cs
@@ -21,6 +21,7 @@ using System.Web.UI;
 
 using Rock.Data;
 using Rock.Model;
+using Rock.Reporting;
 using Rock.Web.UI.Controls;
 
 namespace Rock.Field.Types
@@ -161,8 +162,7 @@ namespace Rock.Field.Types
         /// <returns></returns>
         public override System.Web.UI.Control FilterControl( System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues, string id, bool required, Rock.Reporting.FilterMode filterMode )
         {
-            // This field type does not support filtering
-            return null;
+            return base.FilterControl( configurationValues, id, required, filterMode );
         }
 
         /// <summary>
@@ -171,7 +171,21 @@ namespace Rock.Field.Types
         /// <returns></returns>
         public override bool HasFilterControl()
         {
-            return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the type of the filter comparison.
+        /// </summary>
+        /// <value>
+        /// The type of the filter comparison.
+        /// </value>
+        public override ComparisonType FilterComparisonType
+        {
+            get
+            {
+                return ComparisonHelper.ContainsFilterComparisonTypes;
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Proposed Changes
We have several volunteer groups with member attributes of type Schedules that we want to be able to filter on when in the Group Viewer. This code would enable a filter control for Schedules that matches results that contain one of the selected schedules, drawing from the Schedule and Categories (for the 'contains' feature) Field Types.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
None