### PR TITLE
Update 'Last Activity' column in the My Connection Opportunities to sort by date/time

### DIFF
--- a/RockWeb/Blocks/Connection/MyConnectionOpportunities.ascx.cs
+++ b/RockWeb/Blocks/Connection/MyConnectionOpportunities.ascx.cs
@@ -1043,6 +1043,7 @@ namespace RockWeb.Blocks.Connection
                         GroupRole = r.AssignedGroupMemberRoleId.HasValue ? roles[r.AssignedGroupMemberRoleId.Value] : "",
                         Connector = r.ConnectorPersonAlias != null ? r.ConnectorPersonAlias.Person.FullName : "",
                         LastActivity = FormatActivity( r.ConnectionRequestActivities.OrderByDescending( a => a.CreatedDateTime ).FirstOrDefault() ),
+                        LastActivityDateTime = r.ConnectionRequestActivities.OrderByDescending( a => a.CreatedDateTime ).Select( a => a.CreatedDateTime ).FirstOrDefault(),
                         LastActivityNote = lastActivityNoteBoundField != null && lastActivityNoteBoundField.Visible ? r.ConnectionRequestActivities.OrderByDescending(
                             a => a.CreatedDateTime ).Select( a => a.Note ).FirstOrDefault() : "",
                         Status = r.ConnectionStatus.Name,
@@ -1056,11 +1057,11 @@ namespace RockWeb.Blocks.Connection
                     {
                         if ( sortProperty.Direction == SortDirection.Descending )
                         {
-                            connectionRequests = connectionRequests.OrderByDescending( a => a.LastActivity ).ToList();
+                            connectionRequests = connectionRequests.OrderByDescending( a => a.LastActivityDateTime ).ToList();
                         }
                         else
                         {
-                            connectionRequests = connectionRequests.OrderBy( a => a.LastActivity ).ToList();
+                            connectionRequests = connectionRequests.OrderBy( a => a.LastActivityDateTime ).ToList();
                         }
                     }
                     gRequests.DataSource = connectionRequests;


### PR DESCRIPTION
## Proposed Changes

Currently the 'Last Activity' column in the My Connection Opportunities block will sort the requests by the name of the last activity when clicking the column header. It would be much more useful if this sorted the request by the date and time of the last activity rather than the name of the last activity.

![image](https://user-images.githubusercontent.com/548180/52374630-f33eb480-2a1a-11e9-8fcf-d94b3746e766.png)

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x ] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [ x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

