### PR TITLE
Fixed null reference in cache

### DIFF
--- a/Rock/Web/Cache/RockCache.cs
+++ b/Rock/Web/Cache/RockCache.cs
@@ -325,7 +325,7 @@ namespace Rock.Web.Cache
                     }
 
                     var value = RockCacheManager<List<string>>.Instance.Cache.Get( cacheTag, CACHE_TAG_REGION_NAME ) ?? new List<string>();
-                    if ( value.FirstOrDefault( v => v.Contains( key ) ) == null )
+                    if ( !value.Contains(key) )
                     {
                         value.Add( key );
                         RockCacheManager<List<string>>.Instance.AddOrUpdate( cacheTag, CACHE_TAG_REGION_NAME, value );


### PR DESCRIPTION
## Proposed Changes
A couple weeks ago we ran into an issue where our check-in went down on a Sunday morning due to some issues with cache throwing errors (screenshot below.) It turns out the reason was one of our cache tags had a null cache key in its list of cache keys. I've spent the morning trying to figure out how we managed to generate a null cache key and I have no idea. But we did, and it broke everything. Thankfully clearing all cache fixed the issue. 

This PR is a small change to RockCache to be tolerant of null strings in the list.

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [x] I have read the [Contributing to Rock ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [x] Unit tests pass locally with my changes
* [ ] I have added [required tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
* [ ] I have included updated language for the [Rock Documentation ](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
![20190127!UNITO-UNDERSCORE!073157](https://user-images.githubusercontent.com/495787/52878808-8d91ad00-312b-11e9-830d-284608ec6c0a.jpg)

