### PR TITLE
Fixed StripHtml Lava filter to properly handle HTML comments.

### DIFF
--- a/DotLiquid/StandardFilters.cs
+++ b/DotLiquid/StandardFilters.cs
@@ -207,7 +207,7 @@ namespace DotLiquid
 		{
 			return input.IsNullOrWhiteSpace()
 				? input
-				: Regex.Replace(input, @"<.*?>", string.Empty);
+				: Regex.Replace(input, @"<.*?>|<!--(.|\r|\n)*?-->", string.Empty);
 		}
 
 		/// <summary>

--- a/Rock.Tests/Rock/Lava/RockFiltersTests.cs
+++ b/Rock.Tests/Rock/Lava/RockFiltersTests.cs
@@ -114,6 +114,30 @@ namespace Rock.Tests.Rock.Lava
             Assert.Null( output );
         }
 
+        /// <summary>
+        /// Verfies that the StripHtml filter handles standard HTML tags.
+        /// </summary>
+        [Fact]
+        public void StripHtml_ShouldStripStandardTags()
+        {
+            var html = "<p>Lorem <a href=\"#\">ipsum</a> <b>dolor</b> sit amet, <strong>consectetur</strong> adipiscing <t>elit</t>.</p>";
+            var text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+            Assert.Equal( text, DotLiquid.StandardFilters.StripHtml( html ) );
+        }
+
+        /// <summary>
+        /// Verifies that the StripHtml filter handles multi-line HTML comments.
+        /// </summary>
+        [Fact]
+        public void StripHtml_ShouldStripHtmlComments()
+        {
+            var html = @"<p>Lorem ipsum <!-- this is
+a comment --> sit amet</p>";
+            var text = @"Lorem ipsum  sit amet";
+
+            Assert.Equal( text, StandardFilters.StripHtml( html ) );
+        }
 
         #endregion
 


### PR DESCRIPTION
## Proposed Changes

The `StripHtml` filter currently does not recognize multi-line HTML comments. This fixes that and adds two unit tests.

Fixes: #3548

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

n/a

## Documentation

n/a