### PR TITLE
Fixed check-in configuration getting out of sync when editing a check-in group in Group Details page.

### DIFF
--- a/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
@@ -518,6 +518,7 @@ namespace RockWeb.Blocks.Groups
             Group group;
             bool wasSecurityRole = false;
             bool triggersUpdated = false;
+            bool checkinDataUpdated = false;
 
             RockContext rockContext = new RockContext();
 
@@ -559,6 +560,7 @@ namespace RockWeb.Blocks.Groups
                 {
                     group.GroupLocations.Remove( groupLocation );
                     groupLocationService.Delete( groupLocation );
+                    checkinDataUpdated = true;
                 }
 
                 // remove any group requirements that removed in the UI
@@ -633,6 +635,8 @@ namespace RockWeb.Blocks.Groups
                         groupLocation.Schedules.Add( schedule );
                     }
                 }
+
+                checkinDataUpdated = true;
             }
 
             // Add/update GroupSyncs
@@ -894,6 +898,11 @@ namespace RockWeb.Blocks.Groups
             if ( triggersUpdated )
             {
                 GroupMemberWorkflowTriggerService.RemoveCachedTriggers();
+            }
+
+            if ( checkinDataUpdated )
+            {
+                Rock.CheckIn.KioskDevice.Clear();
             }
 
             var qryParams = new Dictionary<string, string>();


### PR DESCRIPTION
## Proposed Changes
If you have a Check-in Group type set to Show in Navigation, you are able to change that check-in group's schedule and location configuration from the Group Details page. Previously, this page did not flush the check-in cache which would leave the check-in state out of sync from the database.

If the group had GroupLocation data that has been modified then the check-in cache is emptied upon save. Used the `GroupMemberWorkflowTrigger` logic in the same method as a template for implementing conditional cache flushing so we don't flush the cache every time any group is saved.

Fixes: #2975

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [x] I have read the [Contributing to Rock ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [ ] Unit tests pass locally with my changes
* [ ] I have added [required tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
* [ ] I have included updated language for the [Rock Documentation ](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
n/a

## Documentation
n/a

