### PR TITLE
Set the Default Country for New Families

### DIFF
--- a/RockWeb/Blocks/Crm/PersonDetail/AddGroup.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/AddGroup.ascx.cs
@@ -687,6 +687,12 @@ namespace RockWeb.Blocks.Crm.PersonDetail
 
             var location = new Location();
             acAddress.GetValues( location );
+            if ( acAddress.Country.IsNullOrWhiteSpace() )
+            {
+                // Fetch the default country from the organization address
+                var orgCountry = GlobalAttributesCache.Get().OrganizationCountry;
+                acAddress.Country = orgCountry.IsNullOrWhiteSpace() ? "US" : orgCountry;
+            }
 
             var showTitle = this.GetAttributeValue( "ShowTitle" ).AsBoolean();
             var showMiddleName = this.GetAttributeValue( "ShowMiddleName" ).AsBoolean();


### PR DESCRIPTION
## Proposed Changes
When creating a new family in Rock, no country is set by default.  This PR updates the AddGroup CRM block to set the country code to the organization address's country code.

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [X] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [X] I have read the [Contributing to Rock ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [ ] Unit tests pass locally with my changes
* [ ] I have added [required tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
* [ ] I have included updated language for the [Rock Documentation ](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
This PR is pretty self-explanatory . . .

## Documentation
N/A

