### PR TITLE
Fixed Person Signals not respecting View security of parent SignalType

### DIFF
--- a/Rock/Model/PersonSignal.cs
+++ b/Rock/Model/PersonSignal.cs
@@ -18,7 +18,9 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity.ModelConfiguration;
 using System.Runtime.Serialization;
+
 using Rock.Data;
+using Rock.Web.Cache;
 
 namespace Rock.Model
 {
@@ -110,6 +112,21 @@ namespace Rock.Model
         /// </value>
         [DataMember]
         public virtual PersonAlias OwnerPersonAlias { get; set; }
+
+        /// <summary>
+        /// Gets the parent security authority of this PersonSignal. Where security is inherited from.
+        /// </summary>
+        /// <value>
+        /// The parent authority.
+        /// </value>
+        public override Security.ISecured ParentAuthority
+        {
+            get
+            {
+                var signalType = SignalTypeCache.Get( this.SignalTypeId );
+                return signalType ?? base.ParentAuthority;
+            }
+        }
 
         #endregion
 


### PR DESCRIPTION
## Proposed Changes

The Person Signal model should have been configured to have a Parent Authority back to the Signal Type. It didn't for some reason. Most likely due to my own stupidity when originally drafting the code.

The result was that anybody with access to the Person Signals List block could see the Note of the signal as well.

Fixes: #3576

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

> Note: This PR is based against the hotfix-1.8.8 branch.

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
