### PR TITLE
Added option to make personal device badge show even if there are no …

### DIFF
--- a/Rock/PersonProfile/Badge/PersonalDevice.cs
+++ b/Rock/PersonProfile/Badge/PersonalDevice.cs
@@ -17,11 +17,10 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
-
 using Rock.Attribute;
-using Rock.Web.Cache;
 using Rock.Model;
 using Rock.Web;
+using Rock.Web.Cache;
 
 namespace Rock.PersonProfile.Badge
 {
@@ -33,6 +32,7 @@ namespace Rock.PersonProfile.Badge
     [ExportMetadata( "ComponentName", "Personal Device" )]
 
     [LinkedPage( "Personal Devices Detail", "Page to show the details of the personal devices added.", false, order: 1 )]
+    [BooleanField( "Hide If None", "Should the badge be hidden if there are no devices registered to this person?", true, order: 2 )]
     public class PersonalDevice : BadgeComponent
     {
         /// <summary>
@@ -46,6 +46,8 @@ namespace Rock.PersonProfile.Badge
             {
                 //  create url for link to details
                 string detailPageUrl = new PageReference( GetAttributeValue( badge, "PersonalDevicesDetail" ), new Dictionary<string, string> { { "PersonGuid", Person.Guid.ToString() } } ).BuildUrl();
+
+                string noneCss = GetAttributeValue( badge, "HideIfNone" ).AsBoolean() ? "none" : "";
 
                 writer.Write( $"<div class='badge badge-personaldevice badge-id-{badge.Id}' data-toggle='tooltip' data-original-title=''>" );
 
@@ -66,28 +68,28 @@ namespace Rock.PersonProfile.Badge
                                         var linkUrl = '{detailPageUrl}';
                                         var badgeContent = '';
                                         var labelContent = '';
+                                        var badgeClass = 'badge-disabled';
 
-                                        if (devicesNumber > 0) {{
-        
-                                            if ( devicesNumber > 1 ) {{
-                                                labelContent = 'There are ' + devicesNumber + ' devices linked to this individual.';                                 
-                                            }} else {{
-                                                labelContent = 'There is 1 device linked to this individual.';
-                                            }}
-        
-                                            if (linkUrl != '') {{
-                                                badgeContent = '<a href=\'' + linkUrl + '\'><div class=\'badge-content \'><i class=\'fa fa-mobile badge-icon\'></i><span class=\'deviceCount\'>' + devicesNumber + '</span></div></a>';
-                                            }} else {{
-                                                badgeContent = '<div class=\'badge-content \'><i class=\'fa fa-mobile badge-icon\'></i><span class=\'deviceCount\'>' + devicesNumber + '</span></div>';
-                                            }}
-
-                                            $('.badge-personaldevice.badge-id-{badge.Id}').html(badgeContent);
-                                            $('.badge-personaldevice.badge-id-{badge.Id}').attr('data-original-title', labelContent);
-                                            
+                                        if (devicesNumber > 0){{
+                                            badgeClass=''
                                         }}
-                                        else {{
-                                            $('.badge-personaldevice.badge-id-{badge.Id}').css('display', 'none');
-                                            $('.badge-personaldevice.badge-id-{badge.Id}').html('');
+
+                                        if ( devicesNumber !=1 ) {{
+                                            labelContent = 'There are ' + devicesNumber + ' devices linked to this individual.';                                 
+                                        }} else {{
+                                            labelContent = 'There is 1 device linked to this individual.';
+                                        }}
+        
+                                        if (linkUrl != '') {{
+                                            badgeContent = '<a href=\'' + linkUrl + '\'><div class=\'badge-content \'><i class=\''+ badgeClass +' fa fa-mobile badge-icon\'></i><span class=\'deviceCount badge-icon '+ badgeClass +'\'>' + devicesNumber + '</span></div></a>';
+                                        }} else {{
+                                            badgeContent = '<div class=\'badge-content \'><i class=\''+ badgeClass +' fa  fa-mobile badge-icon\'></i><span class=\'deviceCount badge-icon '+ badgeClass +'\'>' + devicesNumber + '</span></div>';
+                                        }}
+                                        $('.badge-personaldevice.badge-id-{badge.Id}').html(badgeContent);
+                                        $('.badge-personaldevice.badge-id-{badge.Id}').attr('data-original-title', labelContent);
+
+                                        if (devicesNumber < 1) {{
+                                            $('.badge-personaldevice.badge-id-{badge.Id}').css('display', '{noneCss}');
                                         }}
                                         
                                     }}
@@ -100,4 +102,3 @@ namespace Rock.PersonProfile.Badge
         }
     }
 }
-


### PR DESCRIPTION
…devices associated with a person

## Proposed Changes
We would like to be able to go to the personal device page for a person even if they have no device. (We are working on the ability to add a device to a person if they are unable to use FrontPorch to add their device). This change adds a boolean field to the badge to allow it to show or not if they have no devices. The default is current behavior .

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)