### PR TITLE
Improved error messages when compiling Themes.

### DIFF
--- a/Rock/Web/UI/RockTheme.cs
+++ b/Rock/Web/UI/RockTheme.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using System.Web;
 using dotless.Core;
 using dotless.Core.configuration;
+using dotless.Core.Loggers;
 
 namespace Rock.Web.UI
 {
@@ -123,6 +124,9 @@ namespace Rock.Web.UI
                     dotLessConfiguration.MinifyOutput = true;
                     dotLessConfiguration.DisableVariableRedefines = true;
                     //dotLessConfiguration.RootPath = themeDirectory.FullName;
+                    dotLessConfiguration.Logger = typeof( DotlessLogger );
+                    dotLessConfiguration.LogLevel = LogLevel.Warn;
+
                     var origDirectory = Directory.GetCurrentDirectory();
                     try
                     {
@@ -135,14 +139,27 @@ namespace Rock.Web.UI
                                 // don't compile files that start with an underscore
                                 foreach ( var file in files.Where( f => f.Name.EndsWith( ".less" ) && !f.Name.StartsWith( "_" ) ) )
                                 {
-                                    string cssSource = LessWeb.Parse( File.ReadAllText( file.FullName ), dotLessConfiguration );
-                                    File.WriteAllText( file.DirectoryName + @"\" + file.Name.Replace( ".less", ".css" ), cssSource );
 
-                                    // check for compile errors (an empty css source returned)
-                                    if ( cssSource == string.Empty )
+                                    ILessEngine lessEngine = new EngineFactory( dotLessConfiguration ).GetEngine( new AspNetContainerFactory() );
+
+                                    string cssSource = lessEngine.TransformToCss( File.ReadAllText( file.FullName ), null );
+
+                                    // Check for compile errors
+                                    if ( lessEngine.LastTransformationSuccessful )
+                                    {
+                                        File.WriteAllText( file.DirectoryName + @"\" + file.Name.Replace( ".less", ".css" ), cssSource );
+                                    }
+                                    else
                                     {
                                         messages += "A compile error occurred on " + file.Name;
                                         compiledSuccessfully = false;
+
+                                        // Try to get the logger instance fron the underlying engine
+                                        var loggerInstance = ( ( ( lessEngine as ParameterDecorator )?.Underlying as CacheDecorator )?.Underlying as LessEngine )?.Logger as DotlessLogger;
+                                        if ( loggerInstance != null )
+                                        {
+                                            messages += "\n" + string.Join( "\n", loggerInstance.LogLines ) + "\n";
+                                        }
                                     }
                                 }
                             }
@@ -361,6 +378,18 @@ namespace Rock.Web.UI
                 DirectoryInfo nextTargetSubDir =
                     target.CreateSubdirectory( diSourceSubDir.Name );
                 CopyAll( diSourceSubDir, nextTargetSubDir );
+            }
+        }
+        
+        private class DotlessLogger : Logger
+        {
+            public List<string> LogLines = new List<string>();
+
+            public DotlessLogger( LogLevel level ): base( level ) { }
+
+            protected override void Log( string message )
+            {
+                LogLines.Add( message );
             }
         }
     }

--- a/RockWeb/Blocks/Cms/ThemeList.ascx.cs
+++ b/RockWeb/Blocks/Cms/ThemeList.ascx.cs
@@ -188,7 +188,7 @@ namespace RockWeb.Blocks.Cms
             else
             {
                 nbMessages.NotificationBoxType = NotificationBoxType.Danger;
-                nbMessages.Text = string.Format( "An error occurred while compiling the {0} theme. Message: {1}", theme.Name, messages );
+                nbMessages.Text = string.Format( "An error occurred while compiling the {0} theme.\nMessage: <pre>{1}</pre>", theme.Name, messages );
             }
         }
 

--- a/RockWeb/Blocks/Cms/ThemeStyler.ascx.cs
+++ b/RockWeb/Blocks/Cms/ThemeStyler.ascx.cs
@@ -215,7 +215,8 @@ $('.js-panel-toggle').on('click', function (e) {
             var theme = new RockTheme( _themeName );
             if ( !theme.Compile( out messages ) )
             {
-                nbMessages.Text = "Unable to compile";
+                nbMessages.NotificationBoxType = NotificationBoxType.Danger;
+                nbMessages.Text = string.Format( "An error occurred while compiling the {0} theme.\nMessage: <pre>{1}</pre>", theme.Name, messages );;
                 nbMessages.Visible = true;
             }
             else
@@ -585,6 +586,7 @@ $('.js-panel-toggle').on('click', function (e) {
                 if ( phThemeControls.Controls.Count == 0 && !pnlFontAwesomeSettings.Visible )
                 {
                     btnSave.Visible = false;
+                    nbMessages.NotificationBoxType = NotificationBoxType.Warning;
                     nbMessages.Text = "This theme does not define any variables for editing.";
                 }
             }


### PR DESCRIPTION
## Proposed Changes
One of the challenges I've run into when developing a Rock Theme is the sparse error messages produced when Rock is unable to compile a .less file. This PR adds extra logging to the Less compilation process and tweaks the formatting where it's displayed to show exactly where the error is and what caused it.

Before:
![mstsc!UNITO-UNDERSCORE!2019-03-22!UNITO-UNDERSCORE!14-54-00](https://user-images.githubusercontent.com/2406499/54846658-c4bb2700-4cb2-11e9-8924-a305c16918f3.png)

After:
![mstsc!UNITO-UNDERSCORE!2019-03-22!UNITO-UNDERSCORE!14-33-44](https://user-images.githubusercontent.com/2406499/54846677-ca187180-4cb2-11e9-8091-43319b1c1d29.png)

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [X] Improvement to an existing feature

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [X] I have read the [Contributing to Rock ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [X] Unit tests pass locally with my changes
* [X] I have added [required tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
* [X] I have included updated language for the [Rock Documentation ](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
N/A

## Documentation
N/A

## Migrations
N/A

