### PR TITLE
Fixed Fundraising Matching to be better about not un-matching transactions accidentally

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionEntityMatching.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionEntityMatching.ascx.cs
@@ -634,6 +634,12 @@ namespace RockWeb.Blocks.Finance
             {
                 var financialTransactionDetailLookup = _financialTransactionDetailList.FirstOrDefault( a => a.Id == financialTransactionDetailId );
 
+                // An un-match operation is only allowed if the entity type is already our target entity type.
+                if ( financialTransactionDetailLookup.EntityTypeId != _transactionEntityType.Id && !entityId.HasValue )
+                {
+                    return;
+                }
+
                 if ( financialTransactionDetailLookup.EntityTypeId != _transactionEntityType.Id
                     || financialTransactionDetailLookup.EntityId != entityId
                     || _blockTransactionTypeId.HasValue && _blockTransactionTypeId != financialTransactionDetailLookup.Transaction.TransactionTypeValueId )


### PR DESCRIPTION
## Proposed Changes
When dealing with Fundraising matching, you often will only be matching a handful of transactions out of a batch. However, the code currently will _un-match_ a transaction if the Group Member is not set at all.

This becomes a problem when you have a batch with 10 transactions. Say this is a batch for a Event Registrations. One of those transactions needs to be moved to be a Fundraising payment because we realize we probably shouldn't have put a fee on that event. So we have all 10 transactions showing on our Fundraising Matching screen, all the drop downs are blank. We change the drop down for line item 3 to match a fundraising participant and click Save. The way things work prior to this patch, it will disassociate the other 9 transactions and leave them just floating out there not matched up with anything.

Now, with this patch, it will only perform the un-match operation if the transaction is already of the expected entity type. Meaning, If the transaction has an Entity Type of Event Registration and the block is configured for Group Member entity type, then leaving the group/member picker blank then it will ignore that transaction and move on.  If the transaction has already been matched and now has an Entity Type of Group Member and you change the group/member picker to be blank, then it will update the transaction and set the EntityId to null.

Hopefully that explanation makes sense. I think this logic is a more proper implementation of the un-matching ability.

Fixes: #3599

## Types of changes
What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [x] I have read the [Contributing to Rock ](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement ](https://www.rockrms.com/license)
* [x] Unit tests pass locally with my changes
* [ ] I have added [required tests ](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
* [ ] I have included updated language for the [Rock Documentation ](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
If your pull request requires a migration, please _exclude the migration from the Rock.Migration project_, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

