### PR TITLE
Fixed content channel item ordering. Fixes #2522

### DIFF
--- a/RockWeb/Blocks/Cms/ContentChannelItemDetail.ascx
+++ b/RockWeb/Blocks/Cms/ContentChannelItemDetail.ascx
@@ -175,7 +175,7 @@
                                 <Rock:RockBoundField DataField="Title" HeaderText="Title" SortExpression="Title" />
                                 <Rock:DateField DataField="StartDateTime" HeaderText="Start" SortExpression="StartDateTime" ColumnPriority="Desktop" ItemStyle-HorizontalAlign="Left" HeaderStyle-HorizontalAlign="Left" />
                                 <Rock:DateField DataField="ExpireDateTime" HeaderText="Expire" SortExpression="ExpireDateTime" ColumnPriority="Desktop" ItemStyle-HorizontalAlign="Left" HeaderStyle-HorizontalAlign="Left" />
-                                <Rock:RockBoundField DataField="Priority" HeaderText="Priority" SortExpression="Priority" DataFormatString="{0:N0}" ColumnPriority="Desktop" />
+                                <Rock:RockBoundField DataField="Order" HeaderText="Order" SortExpression="Order" DataFormatString="{0:N0}" ColumnPriority="Desktop" />
                                 <Rock:RockBoundField DataField="Status" HeaderText="Status" SortExpression="Status" HtmlEncode="false" ColumnPriority="Desktop" />
                                 <Rock:DeleteField OnClick="gChildItems_Delete" />
                             </Columns>
@@ -187,7 +187,7 @@
                                 <Rock:RockBoundField DataField="Title" HeaderText="Title" SortExpression="Title" />
                                 <Rock:DateField DataField="StartDateTime" HeaderText="Start" SortExpression="StartDateTime" ColumnPriority="Desktop" ItemStyle-HorizontalAlign="Left" HeaderStyle-HorizontalAlign="Left" />
                                 <Rock:DateField DataField="ExpireDateTime" HeaderText="Expire" SortExpression="ExpireDateTime" ColumnPriority="Desktop" ItemStyle-HorizontalAlign="Left" HeaderStyle-HorizontalAlign="Left" />
-                                <Rock:RockBoundField DataField="Priority" HeaderText="Priority" SortExpression="Priority" DataFormatString="{0:N0}" ColumnPriority="Desktop" />
+                                <Rock:RockBoundField DataField="Order" HeaderText="Order" SortExpression="Order" DataFormatString="{0:N0}" ColumnPriority="Desktop" />
                                 <Rock:RockBoundField DataField="Status" HeaderText="Status" SortExpression="Status" HtmlEncode="false" ColumnPriority="Desktop" />
                             </Columns>
                         </Rock:Grid>


### PR DESCRIPTION
## Proposed Changes

**The issue:** 
   When "Child Items Manually Ordered" is enabled (within Content Channels) the "Child Items" would not be sorted correctly when it was manually sorted. In other words, when a person tries to sort any "Child Items" (by click-drag-and-releasing the hamburger icons), then the child items on the site/client side of Rock would not reflect the order it was supposed to be in.

**What was expected instead:** 
  Content Channel "Child Items" that are manually sorted was supposed to be saved as sorted.

**The Solution:**
 The "Child Items" needed to be sorted by the "Order" through the Content Channel Item Association/join table; not by the "Priority" of the Content Channel Item itself.

**Here's what I did.**
As it turns out, the Child Items were sorted by the Content Channel Item itself - not the Content Channel Item Association table. I also noticed that the Content Channel Item Association table did not have a '_Priority_' column, but an 'Order' column instead. Hence, I updated the code to save as 'Order' instead of '_Priority_' when sorted, and to save it under the Content Channel Item Association table.

This worked, and here's a snippet of Lava I made to double-check the sorted items on the front-end site:
```
{%- contentchannelitem id:'1547' -%}
	{% assign childItemAssociations = contentchannelitem.ChildItems | Sort:'Order' %} 
{%- endcontentchannelitem -%}

{%- for association in childItemAssociations -%}
    {{ association.Order }}:
    {{ association.ChildContentChannelItem.Title }} ******* 
    {{ association.ChildContentChannelItem.Order }} - ({{ association.ChildContentChannelItem.StartDateTime | Date:'M/d/yyyy' }}) <br>
{%- endfor -%}
```

**Here are some other thoughts.**
 Should we really include the "Order/Priority" column to show for the administrators? It seems kinda odd and redundant since re-ordering the rows would visibly show the same thing - top to bottom, or vise-versa.

Fixes: #2522 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

-----
Assigned to JacobM for QA Testing