### PR TITLE
Adding multi-match (plus capture group) support to the Lava RegExMatchValue filter.

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -794,22 +794,35 @@ namespace Rock.Lava
         }
 
         /// <summary>
-        /// Returns matched RegEx string from inputted string
+        /// Returns matched RegEx string (or list of strings) from inputted string
         /// </summary>
         /// <param name="input">The input.</param>
         /// <param name="expression">The regex expression.</param>
         /// <returns></returns>
-        public static string RegExMatchValue( string input, string expression )
+        public static object RegExMatchValue( string input, string expression )
         {
-            if ( input == null )
+            if (input == null)
             {
                 return null;
             }
 
             Regex regex = new Regex( expression );
-            Match match = regex.Match( input );
+            var matches = regex.Matches( input );
 
-            return match.Success ? match.Value : null;
+            // Flatten all matches to single list
+            var captured = matches
+                .Cast<Match>()
+                .Where(m => m.Success == true)
+                .SelectMany( o =>
+                    o.Groups.Cast<Capture>()
+                        .Select( c => c.Value ) );
+            // If we only have 1 match then just return a string
+            if (captured.Count() == 1)
+            {
+                return captured.First();
+            }
+            return captured.ToList();
+
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes
The new RegexMatchValue Lava filter in v9 is really slick but it doesn't support multiple matches using capture groups.  This PR takes all capture groups, flattens it into a simple list of strings, and then returns that instead of just a string.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
This will handle multiple matches on the same string as well as match groups.  A good example of using both multi-match and match groups is as follows:

```
{% assign haystack = "red car blue car orange car" %}
{% assign matches = haystack | RegExMatchValue:'(\w+)\s+(car)' %}

<pre>
Whole Match: {{matches[0] }}
Group 1: {{matches[1] }}
Group 2: {{matches[2] }}

Whole Match: {{matches[3] }}
Group 1: {{matches[4] }}
Group 2: {{matches[5] }}

Whole Match: {{matches[6] }}
Group 1: {{matches[7] }}
Group 2: {{matches[8] }}
</pre>
```

This outputs the follow:

> Whole Match: red car
> Group 1: red
> Group 2: car
> 
> Whole Match: blue car
> Group 1: blue
> Group 2: car
> 
> Whole Match: orange car
> Group 1: orange
> Group 2: car

## Documentation
The documentation for the RegexMatchValue lava filter will need to be updated here:

https://community.rockrms.com/lava/filters/text-filters#regexmatchvalue