### PR TITLE
Added confirmation before restarting Rock.

### DIFF
--- a/RockWeb/Blocks/Administration/SystemInfo.ascx
+++ b/RockWeb/Blocks/Administration/SystemInfo.ascx
@@ -56,7 +56,8 @@
 
         <div class="actions margin-t-xl">
             <Rock:BootstrapButton runat="server" ID="btnFlushCache" CssClass="btn btn-primary" Text="Clear Cache" OnClick="btnClearCache_Click" DataLoadingText="Clearing..." ToolTip="Flushes all cached items from the Rock cache (e.g. Pages, BlockTypes, Blocks, Attributes, etc." />
-            <asp:Button runat="server" ID="btnRestart" CssClass="btn btn-link js-restart" Text="Restart Rock" OnClick="btnRestart_Click" ToolTip="Restarts the Application." />
+            <a href="#" Class="btn btn-link js-restart" title="Restarts the Application.">Restart Rock</a>
+            <asp:Button runat="server" ID="btnRestart" OnClick="btnRestart_Click" CssClass="hidden" />
         </div>
     </div>
 
@@ -150,7 +151,12 @@
 
     <script>
         $(".js-restart").on("click", function () {
-            bootbox.alert("The Rock application will be restarted. You will need to reload this page to continue.")
+            Rock.dialogs.confirm('Are you sure you want to restart Rock?', function (result) {
+                if (result) {
+                    bootbox.alert("The Rock application will be restarted. You will need to reload this page to continue.")
+                    __doPostBack('<%= btnRestart.UniqueID %>', '');
+                }
+            });
         });
     </script>
 


### PR DESCRIPTION
## Proposed Changes
The Clear Cache button is very close to the Restart Rock button. Sometimes while clearing cache I maybe click a little too hastily. This makes everyone sad. So, I added a confirmation before restarting.

I added a new link and used CSS to hide the normal asp button. Then updated the javascript to request a confirmation before manually performing a postback on the original now hidden button.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Coffee induced miss-clicking prevention

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comm