### PR TITLE
Added history to userlogins Fixes #2936

### DIFF
--- a/Rock/Model/History.cs
+++ b/Rock/Model/History.cs
@@ -298,7 +298,7 @@ namespace Rock.Model
                                 {
                                     if ( this.IsSensitive == true )
                                     {
-                                        return $"Added <span class='field-name'>{this.ValueName}</span> value (Sensitive attribute values are not logged in history).";
+                                        return $"Added <span class='field-name'>{this.ValueName}</span> value (Sensitive values are not logged in history).";
                                     }
                                     else
                                     {
@@ -317,7 +317,7 @@ namespace Rock.Model
                                 {
                                     if ( this.IsSensitive == true )
                                     {
-                                        return $"Modified <span class='field-name'>{this.ValueName}</span> value (Sensitive attribute values are not logged in history).";
+                                        return $"Modified <span class='field-name'>{this.ValueName}</span> value (Sensitive values are not logged in history).";
                                     }
                                     else
                                     {


### PR DESCRIPTION
## Proposed Changes
We wanted to have user login information logged to History. So I added logging to the pre and post save to the Entity table.

Fixes: #2936 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
![image](https://user-images.githubusercontent.com/495787/58831508-d9a12880-861a-11e9-9906-15dfaa2c2f5c.png)

