### PR TITLE
- Modified Excel export to use table styles (Fixes #3267)

### DIFF
--- a/Rock/Utility/ExcelHelper.cs
+++ b/Rock/Utility/ExcelHelper.cs
@@ -162,12 +162,6 @@ namespace Rock.Utility
             // align text to the top of the cell
             range.Style.VerticalAlignment = OfficeOpenXml.Style.ExcelVerticalAlignment.Top;
 
-            // use conditionalFormatting to create the alternate row style
-            var conditionalFormatting = range.ConditionalFormatting.AddExpression();
-            conditionalFormatting.Formula = "MOD(ROW()+1,2)=0";
-            conditionalFormatting.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
-            conditionalFormatting.Style.Fill.BackgroundColor.Color = Color.FromArgb( 240, 240, 240 );
-
             // Remove paces and line breaks. Replace worksheet title unallowed characters with '_'.
             var tableTitle = title
                 .Replace( " ", "" )
@@ -203,7 +197,7 @@ namespace Rock.Utility
 
             table.ShowHeader = true;
             table.ShowFilter = true;
-            table.TableStyle = OfficeOpenXml.Table.TableStyles.None;
+            table.TableStyle = OfficeOpenXml.Table.TableStyles.Medium4;
 
             // Format header range
             using ( ExcelRange r = worksheet.Cells[headerRows, 1, headerRows, columns] )


### PR DESCRIPTION
## Proposed Changes

Modified the excel export to use table styles instead of conditional formatting to create the banded rows. I chose "Medium4" as the table style because it is the closest visually to the current look.

Fixes: #3267 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments


## Documentation


## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
