### PR TITLE
Fixed data automation job to not update recently updated campuses

### DIFF
--- a/Rock/Jobs/DataAutomation.cs
+++ b/Rock/Jobs/DataAutomation.cs
@@ -569,15 +569,14 @@ Update Family Status: {updateFamilyStatus}
                         var startPeriod = RockDateTime.Now.AddDays( -settings.IgnoreIfManualUpdatePeriod );
 
                         // Find any families that has a campus manually added/updated within the configured number of days
-                        var personEntityTypeId = EntityTypeCache.Get( typeof( Person ) ).Id;
+                        var groupEntityTypeId = EntityTypeCache.Get( typeof( Group ) ).Id;
                         var familyIdsWithManualUpdate = new HistoryService( rockContext )
                             .Queryable().AsNoTracking()
                             .Where( m =>
                                 m.CreatedDateTime >= startPeriod &&
-                                m.EntityTypeId == personEntityTypeId &&
-                                m.RelatedEntityId.HasValue &&
+                                m.EntityTypeId == groupEntityTypeId &&
                                 m.ValueName == "Campus" )
-                            .Select( a => a.RelatedEntityId.Value )
+                            .Select( a => a.EntityId )
                             .ToList()
                             .Distinct();
 


### PR DESCRIPTION
## Proposed Changes
A fix to the data automation job so that it correctly calculates when a campus was manually updated recently. We found that the job wasn't observing the rule we set because it was misreading the history table. This mainly changes the entity type from person to group.
## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
Tested with real data to make sure it both updates and ignores according to the rules.