### PR TITLE
Fixed exception when running redis cache

### DIFF
--- a/RockWeb/Blocks/Utility/InternalCommunicationView.ascx.cs
+++ b/RockWeb/Blocks/Utility/InternalCommunicationView.ascx.cs
@@ -213,7 +213,13 @@ namespace RockWeb.Blocks.Utility
 
             if ( cacheDuration > 0 && _currentPage == 0 )
             {
-                cachedItem = RockCache.Get( cacheKey ) as CachedBlockData;
+                var serializedCachedItem = RockCache.Get( cacheKey );
+                if ( serializedCachedItem != null
+                    && serializedCachedItem is string
+                    && !string.IsNullOrWhiteSpace( ( string ) serializedCachedItem ) )
+                {
+                        cachedItem = ( ( string ) serializedCachedItem ).FromJsonOrNull<CachedBlockData>();
+                }
             }
 
             if ( cachedItem != null )
@@ -288,7 +294,7 @@ namespace RockWeb.Blocks.Utility
                     cachedData.Metrics = metrics;
 
                     var expiration = RockDateTime.Now.AddSeconds( cacheDuration );
-                    RockCache.AddOrUpdate( cacheKey, string.Empty, cachedData, expiration, cacheTags );
+                    RockCache.AddOrUpdate( cacheKey, string.Empty, cachedData.ToJson(), expiration, cacheTags );
                 }
             }
 


### PR DESCRIPTION
## Proposed Changes
The internal communication view block caches an object whose class is in the code behind for the block. Because this code is compiled as a different binary for each server, only the server that stored the cached item can retrieve it; any other server in a distributed solution would throw an exception. This PR serializes the data in JSON before caching.  

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
I haven't run across any other blocks that cache objects derived from classes in the code behind, but they would also have problems in a multi server environment.