### PR TITLE
Update Email Preference Entry

### DIFF
--- a/RockWeb/Blocks/Communication/EmailPreferenceEntry.ascx.cs
+++ b/RockWeb/Blocks/Communication/EmailPreferenceEntry.ascx.cs
@@ -45,6 +45,7 @@ namespace RockWeb.Blocks.Communication
     [MemoField( "No Mass Emails Text", "Text to display for the 'No Mass Emails' option.", false, "I am still involved with {{ 'Global' | Attribute:'OrganizationName' }}, but do not wish to receive mass emails (personal emails are fine).", "", 3, null, 3, true )]
     [MemoField( "No Emails Text", "Text to display for the 'No Emails' option.", false, "I am still involved with {{ 'Global' | Attribute:'OrganizationName' }}, but do not want to receive emails of ANY kind.", "", 4, null, 3, true )]
     [MemoField( "Not Involved Text", "Text to display for the 'Not Involved' option.", false, " I am no longer involved with {{ 'Global' | Attribute:'OrganizationName' }}.", "", 5, null, 3, true )]
+    [WorkflowTypeField( "Unsubscribe Workflow", "The workflow type to launch for person who wants to unsubscribe.", false, required: false )]
     [MemoField( "Success Text", "Text to display after user submits selection.", false, "<h4>Thank You</h4>We have saved your email preference.", "", 6, null, 3, true )]
     [CodeEditorField( "Unsubscribe Success Text", "Text to display after user unsubscribes from communication lists.", CodeEditorMode.Lava, CodeEditorTheme.Rock, 200, false, UNSUBSCRIBE_SUCCESS_TEXT_DEFAULT_VALUE, order: 7 )]
     [TextField( "Reasons to Exclude", "A delimited list of the Inactive Reasons to exclude from Reason list", false, "No Activity,Deceased", "", 8 )]
@@ -227,11 +228,27 @@ We have unsubscribed you from the following lists:
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnSubmit_Click( object sender, EventArgs e )
         {
+            var rockContext = new RockContext();
             nbUnsubscribeSuccessMessage.Visible = false;
             nbEmailPreferenceSuccessMessage.Visible = false;
 
             if ( rbUnsubscribe.Checked && rbUnsubscribe.Visible )
             {
+                Guid? workflowGuid = GetAttributeValue( "UnsubscribeWorkflow" ).AsGuidOrNull();
+                WorkflowTypeCache workflowType = null;
+                var workflowService = new WorkflowService( rockContext );
+
+                if (workflowGuid != null)
+                {
+                    workflowType = WorkflowTypeCache.Get( workflowGuid.Value );
+                }
+
+                // Start workflow for this person
+                if (workflowType != null)
+                {
+                    Dictionary<string, string> attributes = new Dictionary<string, string>();
+                    StartWorkflow( workflowService, workflowType, attributes, string.Format( "{0}", _person.FullName ), _person );
+                }
                 UnsubscribeFromLists();
                 return;
             }
@@ -253,7 +270,6 @@ We have unsubscribed you from the following lists:
 
             if ( _person != null )
             {
-                var rockContext = new RockContext();
                 var service = new PersonService( rockContext );
                 var person = service.Get( _person.Id );
                 if ( person != null )
@@ -535,6 +551,24 @@ We have unsubscribed you from the following lists:
             ddlInactiveReason.DataTextField = "Name";
             ddlInactiveReason.DataValueField = "Id";
             ddlInactiveReason.DataBind();
+        }
+
+        protected void StartWorkflow( WorkflowService workflowService, WorkflowTypeCache workflowType, Dictionary<string, string> attributes, string workflowNameSuffix, Person p )
+        {
+            // launch workflow if configured
+            if (workflowType != null && (workflowType.IsActive ?? true))
+            {
+                var workflow = Rock.Model.Workflow.Activate( workflowType, "UnsubscribeNotice " + workflowNameSuffix );
+
+                // set attributes
+                foreach (KeyValuePair<string, string> attribute in attributes)
+                {
+                    workflow.SetAttributeValue( attribute.Key, attribute.Value );
+                }
+                // launch workflow
+                List<string> workflowErrors;
+                workflowService.Process( workflow, p, out workflowErrors );
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Proposed Changes

We wanted an ability to launch a workflow whenever a person unsubscribes from a list.  We wanted to be able to alert the staff and take the appropriate actions automatically whenever a person unsubscribes.  This PR will add a workflow type field to the block settings that isn't required.  After the communication lists to unsubscribe from are chosen and the submit button is clicked on, the workflow type if chosen will be used to get the workflow and launch it.

**Here's what I did:**
I updated the EmailPreferenceEntry.ascx.cs code to include a workflow type field block attribute and used its guid in the click event of the submit button only if the unsubscribe radio button is checked.  The guid is used to get the workflow type cache that is passed to a method I called StartWorkflow that launches the workflow associated with the workflow type cache.  The method StartWorkflow uses a workflow service, the workflow type cache, a dictionary of attributes, and a workflow name suffix.

This worked, and here's a snippet of some of the C# code I added:

                Guid? workflowGuid = GetAttributeValue( "UnsubscribeWorkflow" ).AsGuidOrNull();
                WorkflowTypeCache workflowType = null;
                var workflowService = new WorkflowService( rockContext );

                if (workflowGuid != null)
                {
                    workflowType = WorkflowTypeCache.Get( workflowGuid.Value );
                }

                // Start workflow for this person
                if (workflowType != null)
                {
                    Dictionary<string, string> attributes = new Dictionary<string, string>();
                    StartWorkflow( workflowService, workflowType, attributes, string.Format( "{0}", _person.FullName ), _person );
                }
## Types of changes

New feature (non-breaking change which adds functionality, which has been approved by the core team)

## Checklist

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the Contributing to Rock doc
- [x] By contributing code, I agree to license my contribution under the Rock Community License Agreement
- [x] Unit tests pass locally with my changes

## Further Comments

Tested to make sure it launches a workflow without messing up when a workflow type is chosen.

-----
Assigned to JacobM for QA Testing