### PR TITLE
Added data automation option, move adult children - This checkbox if …

### DIFF
--- a/Rock/Jobs/DataAutomation.cs
+++ b/Rock/Jobs/DataAutomation.cs
@@ -890,8 +890,13 @@ Update Family Status: {updateFamilyStatus}
                             m.Person.BirthDate.HasValue &&
                             m.Person.BirthDate <= adultBirthdate &&
                             m.Person.RecordStatusValue != null &&
-                            m.Person.RecordStatusValue.Guid == activeRecordStatusGuid &&
                             !m.Person.IsLockedAsChild );
+
+                    if ( settings.IsOnlyMoveActive )
+                    {
+                        // Children with Active Status Only
+                        qry = qry.Where( p => p.Person.RecordStatusValue.Guid == activeRecordStatusGuid );
+                    }
 
                     if ( settings.IsOnlyMoveGraduated )
                     {

--- a/Rock/Utility/Settings/DataAutomation/MoveAdultChildren.cs
+++ b/Rock/Utility/Settings/DataAutomation/MoveAdultChildren.cs
@@ -36,6 +36,7 @@ namespace Rock.Utility.Settings.DataAutomation
             UseSameHomeAddress = true;
             UseSameHomePhone = true;
             IsOnlyMoveGraduated = false;
+            IsOnlyMoveActive = true;
             MaximumRecords = 200;
             var knownRelGroupType = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_KNOWN_RELATIONSHIPS.AsGuid() );
             if ( knownRelGroupType != null )
@@ -64,6 +65,15 @@ namespace Rock.Utility.Settings.DataAutomation
         public bool IsOnlyMoveGraduated { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to only move children who are active
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the data automation job should only move active children; otherwise, if children should be moved regardless of if they've active <c>false</c>.
+        /// </value>
+        public bool IsOnlyMoveActive { get; set; }
+
+
+        /// <summary>        
         /// Gets or sets the adult age.
         /// </summary>
         /// <value>

--- a/RockWeb/Blocks/Administration/DataAutomationSettings.ascx
+++ b/RockWeb/Blocks/Administration/DataAutomationSettings.ascx
@@ -339,6 +339,7 @@
                         <hr />
 
                         <asp:Panel ID="pnlAdultChildren" runat="server" Enabled="false" CssClass="data-integrity-options">
+                            <Rock:RockCheckBox ID="cbisOnlyMoveActive" runat="server" Label="Should only active children be moved?" Text="Yes" />
                             <Rock:RockCheckBox ID="cbisMoveGraduated" runat="server" Label="Should children only be moved if they have graduated?" Text="Yes" />
                             <Rock:NumberBox ID="nbAdultAge" runat="server" Label="The age a child should be considered an adult" AppendText="years" CssClass="input-width-md" />
                             <Rock:GroupRolePicker ID="rpParentRelationship" runat="server" Label="An optional known relationship that should be added between the new adult and their parent(s)" />

--- a/RockWeb/Blocks/Administration/DataAutomationSettings.ascx.cs
+++ b/RockWeb/Blocks/Administration/DataAutomationSettings.ascx.cs
@@ -432,6 +432,7 @@ namespace RockWeb.Blocks.Administration
 
             // Adult Children
             cbAdultChildren.Checked = _adultChildrenSettings.IsEnabled;
+            cbisOnlyMoveActive.Checked = _adultChildrenSettings.IsOnlyMoveActive;
             cbisMoveGraduated.Checked = _adultChildrenSettings.IsOnlyMoveGraduated;
             pnlAdultChildren.Enabled = _adultChildrenSettings.IsEnabled;
             nbAdultAge.Text = _adultChildrenSettings.AdultAge.ToString();
@@ -520,7 +521,7 @@ namespace RockWeb.Blocks.Administration
                     NumberBox lastInteractionDays = rItem.FindControl( "nbInteractionDays" ) as NumberBox;
                     var item = new InteractionItem( interactionTypeId.Value.AsGuid(), string.Empty )
                     {
-                        IsInteractionTypeEnabled = true,
+                        IsInteractionTypeEnabled = isInterationTypeEnabled.Checked,
                         LastInteractionDays = lastInteractionDays.Text.AsInteger()
                     };
                     _reactivateSettings.Interactions.Add( item );
@@ -554,19 +555,17 @@ namespace RockWeb.Blocks.Administration
             foreach ( RepeaterItem rItem in rNoInteractions.Items )
             {
                 RockCheckBox isInterationTypeEnabled = rItem.FindControl( "cbInterationType" ) as RockCheckBox;
-                if ( isInterationTypeEnabled.Checked )
-                {
                     _inactivateSettings.NoInteractions = _inactivateSettings.NoInteractions ?? new List<InteractionItem>();
                     HiddenField interactionTypeId = rItem.FindControl( "hfInteractionTypeId" ) as HiddenField;
                     NumberBox lastInteractionDays = rItem.FindControl( "nbNoInteractionDays" ) as NumberBox;
                     var item = new InteractionItem( interactionTypeId.Value.AsGuid(), string.Empty )
                     {
-                        IsInteractionTypeEnabled = true,
+                    IsInteractionTypeEnabled =  isInterationTypeEnabled.Checked,
                         LastInteractionDays = lastInteractionDays.Text.AsInteger()
                     };
 
                     _inactivateSettings.NoInteractions.Add( item );
-                }
+ 
             }
 
             // Campus Update
@@ -597,6 +596,7 @@ namespace RockWeb.Blocks.Administration
 
             // Adult Children
             _adultChildrenSettings.IsEnabled = cbAdultChildren.Checked;
+            _adultChildrenSettings.IsOnlyMoveActive = cbisOnlyMoveActive.Checked;
             _adultChildrenSettings.IsOnlyMoveGraduated = cbisMoveGraduated.Checked;
             _adultChildrenSettings.AdultAge = nbAdultAge.Text.AsIntegerOrNull() ?? 18;
             _adultChildrenSettings.ParentRelationshipId = rpParentRelationship.GroupRoleId;


### PR DESCRIPTION
…not checked will move adult children into their own household from an inactive household. The default is to only move from active households.

## Proposed Changes

Home > Data Integrity > Data Automation > Move Adult Children.
 
This enhancement adds a checkbox option (Should only active children be moved?) under Move Adult Children to move adult children from active or inactive households. the default is for the box to be checked and therefore to only move active household children.
![dataautomationsettingActiveChildren](https://user-images.githubusercontent.com/26330312/62568499-52ab3f00-b85b-11e9-9786-c07cde72dbc9.JPG)

This is needed to allow the proactive moving of adult children from inactive households to their own household.  


Fixes: #

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [X] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [X] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)



## Documentation
Should only active children be moved?: If this option is checked (default), it will only include active households.
If this option is not checked inactive households will be included also.

-----
Assigned to DavidT for QA Testing