### PR TITLE
MailgunHTTP: Fixed out of order setting and testing of from information

### DIFF
--- a/Rock.Mailgun/Communication/Transport/MailgunHttp.cs
+++ b/Rock.Mailgun/Communication/Transport/MailgunHttp.cs
@@ -106,15 +106,6 @@ namespace Rock.Communication.Transport
 
             var globalAttributes = GlobalAttributesCache.Get();
 
-            string fromAddress = emailMessage.FromEmail.IsNullOrWhiteSpace() ? globalAttributes.GetValue( "OrganizationEmail" ) : emailMessage.FromEmail;
-            string fromName = emailMessage.FromName.IsNullOrWhiteSpace() ? globalAttributes.GetValue( "OrganizationName" ) : emailMessage.FromName;
-
-            if ( fromAddress.IsNullOrWhiteSpace() )
-            {
-                errorMessages.Add( "A From address was not provided." );
-                return false;
-            }
-
             // Common Merge Field
             var mergeFields = Lava.LavaHelper.GetCommonMergeFields( null, rockMessage.CurrentPerson );
             foreach ( var mergeField in rockMessage.AdditionalMergeFields )
@@ -123,8 +114,18 @@ namespace Rock.Communication.Transport
             }
 
             // Resolve any possible merge fields in the from address
-            fromAddress = fromAddress.ResolveMergeFields( mergeFields, emailMessage.CurrentPerson, emailMessage.EnabledLavaCommands );
-            fromName = fromName.ResolveMergeFields( mergeFields, emailMessage.CurrentPerson, emailMessage.EnabledLavaCommands );
+            string fromAddress = emailMessage.FromEmail.ResolveMergeFields( mergeFields, emailMessage.CurrentPerson, emailMessage.EnabledLavaCommands );
+            string fromName = emailMessage.FromName.ResolveMergeFields( mergeFields, emailMessage.CurrentPerson, emailMessage.EnabledLavaCommands );
+
+            // Replace blank values with organizational defaults
+            fromAddress = fromAddress.IsNullOrWhiteSpace() ? globalAttributes.GetValue( "OrganizationEmail" ) : fromAddress;
+            fromName = fromName.IsNullOrWhiteSpace() ? globalAttributes.GetValue( "OrganizationName" ) : fromName;
+
+            if ( !fromAddress.IsValidEmail() )
+            {
+                errorMessages.Add( "A From address was not provided." );
+                return false;
+            }
 
             RestRequest restRequest = null;
             foreach ( var rockMessageRecipient in rockMessage.GetRecipients() )


### PR DESCRIPTION
## Proposed Changes
The MailgunHTTP transport has an issue due to it testing the FromAddress and FromName for null or empty _before_ it merges the lava. This means that if the lava is merged to be an empty string it will continue through and have no value. Later on this will throw an exception. We noticed this problem after forgetting to set the contact on a registration instance and registrants failed to receive their confirmations.

This change first renders the lava and then tests for blank values. 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)