### PR TITLE
Fixed PowerBiReportViewer not respecting settings for hiding panes

### DIFF
--- a/RockWeb/Blocks/Reporting/PowerBiReportViewer.ascx.cs
+++ b/RockWeb/Blocks/Reporting/PowerBiReportViewer.ascx.cs
@@ -219,18 +219,23 @@ namespace RockWeb.Blocks.Reporting
 
             fullsizer.Visible = GetAttributeValue( "ShowFullsizeBtn" ).AsBoolean();
 
-            nbError.Text = string.Empty;
-            hfReportEmbedUrl.Value = GetAttributeValue( "ReportUrl" ) +
-                ( cbSettingPowerBIRightPane.Checked ? "" : "&filterPaneEnabled=false" ) +
-                ( cbSettingPowerBINavPane.Checked ? "" : "&navContentPaneEnabled=false" );
+            string reportUrl = GetAttributeValue( "ReportUrl" );
+            bool showRightPane = GetAttributeValue( "ShowRightPane" ).AsBoolean();
+            bool showNavPane = GetAttributeValue( "ShowNavPane" ).AsBoolean();
 
-            if ( hfReportEmbedUrl.Value.IsNullOrWhiteSpace() )
+            nbError.Text = string.Empty;
+
+            if ( reportUrl.IsNullOrWhiteSpace() )
             {
                 pnlView.Visible = false;
                 nbError.NotificationBoxType = NotificationBoxType.Warning;
                 nbError.Text = "No report has been configured.";
                 return;
             }
+
+            hfReportEmbedUrl.Value = reportUrl +
+                ( showRightPane ? "" : "&filterPaneEnabled=false" ) +
+                ( showNavPane ? "" : "&navContentPaneEnabled=false" );
 
             if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "PowerBiAccount" ) ) )
             {


### PR DESCRIPTION
## Proposed Changes

The block settings for what panes to show were not being read until the settings page was opened. That was causing the block to always use the defaults (false).

Fixes: #3887 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

I am fairly certain that this PR will fix the issue and have no negative side effects. However, I do not have access to PowerBi server to test against. I did test with a dummy report, and the resulting urls are in the expected format.