### PR TITLE
Implement Parent Rosters in Group Toolbox for Children's Groups #2854

### DIFF
--- a/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
+++ b/RockWeb/Themes/Stark/Assets/Lava/GroupDetail.lava
@@ -15,7 +15,6 @@
 		{% endcase %}
 	{% endfor %}
 
-
 	{% for groupLocation in Group.GroupLocations %}
 		{% if groupLocation.Location.GeoPoint != '' %}
 
@@ -27,8 +26,6 @@
 
 		{% endif %}
 	{% endfor %}
-
-
 
 	<h1>{{ Group.Name }}</h1>
 
@@ -78,26 +75,36 @@
 	</div>
 	{% endif %}
 
-	{% if LinkedPages.RosterPage != '' and  (LinkedPages.AttendancePage != '' or Group.GroupType.TakesAttendance == 'False') %}
-		<ul class="nav nav-tabs margin-v-lg">
-			{% if LinkedPages.RosterPage != '' %}
-				{% if LinkedPages.RosterPage == CurrentPage.Path %}
-					<li role="presentation" class="active"><a href="{{ LinkedPages.RosterPage }}?GroupId={{ Group.Id }}">Roster</a></li>
-				{% else %}
-					<li role="presentation"><a href="{{ LinkedPages.RosterPage }}?GroupId={{ Group.Id }}">Roster</a></li>
-				{% endif %}
-			{% endif %}
+	{% if LinkedPages.RosterPage != '' or LinkedPages.ParentRosterPage != '' or (LinkedPages.AttendancePage != '' or Group.GroupType.TakesAttendance == 'False') %}
 
-			{% if LinkedPages.AttendancePage != '' and Group.GroupType.TakesAttendance == 'True' %}
-				{% if LinkedPages.AttendancePage == CurrentPage.Path %}
-					<li role="presentation" class="active"><a href="{{ LinkedPages.AttendancePage }}?GroupId={{ Group.Id }}">Attendance</a></li>
-				{% else %}
-					<li role="presentation"><a href="{{ LinkedPages.AttendancePage }}?GroupId={{ Group.Id }}">Attendance</a></li>
-				{% endif %}
-			{% endif %}
+		<ul class="nav nav-tabs margin-v-lg">
+		    {% if LinkedPages.RosterPage != '' %}
+			    {% if LinkedPages.RosterPage == CurrentPage.Path %}
+				    <li role="presentation" class="active"><a href="{{ LinkedPages.RosterPage }}?GroupId={{ Group.Id }}">Roster</a></li>
+			    {% else %}
+				    <li role="presentation"><a href="{{ LinkedPages.RosterPage }}?GroupId={{ Group.Id }}">Roster</a></li>
+			    {% endif %}
+		    {% endif %}
+
+		    {% if LinkedPages.ParentRosterPage != '' and Parents != null %}
+			    {% if LinkedPages.ParentRosterPage == CurrentPage.Path %}
+				    <li role="presentation" class="active"><a href="{{ LinkedPages.ParentRosterPage }}?GroupId={{ Group.Id }}">Parent Roster</a></li>
+			    {% else %}
+				    <li role="presentation"><a href="{{ LinkedPages.ParentRosterPage }}?GroupId={{ Group.Id }}">Parent Roster</a></li>
+			    {% endif %}
+		    {% endif %}
+
+		    {% if LinkedPages.AttendancePage != '' and Group.GroupType.TakesAttendance == 'True' %}
+			    {% if LinkedPages.AttendancePage == CurrentPage.Path %}
+				    <li role="presentation" class="active"><a href="{{ LinkedPages.AttendancePage }}?GroupId={{ Group.Id }}">Attendance</a></li>
+			    {% else %}
+				    <li role="presentation"><a href="{{ LinkedPages.AttendancePage }}?GroupId={{ Group.Id }}">Attendance</a></li>
+			    {% endif %}
+		    {% endif %}
 		</ul>
 	{% endif %}
 
+	{% comment %} Group Roster Tab {% endcomment %}
 	{% if LinkedPages.RosterPage == CurrentPage.Path %}
 
 		{% if countPending > -1 %}
@@ -140,7 +147,7 @@
 
 						{% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
 						<div class="pull-left rollover-item" style="position: absolute; right:0; top:0;">
-							<a href="#" onclick="{{ member.Id | Postback:'DeleteGroupMember' }}" >
+							<a href="#" onclick="{{ member.Id | Postback:'DeleteGroupMember' }}">
 							<i class="fa fa-times"></i>
 							</a>
 							<a href="#" onclick="{{ member.Id | Postback:'EditGroupMember' }}" class="margin-l-sm">
@@ -165,8 +172,6 @@
 			{% endfor %}
 				</div>
 		{% endif %}
-
-
 
 		{% if countActive > -1 %}
 			{% assign icountActive = 0 %}
@@ -207,7 +212,7 @@
 
 						{% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
 						<div class="pull-left rollover-item" style="position: absolute; right:0; top:0;">
-							<a href="#" onclick="{{ member.Id | Postback:'DeleteGroupMember' }}" >
+							<a href="#" onclick="{{ member.Id | Postback:'DeleteGroupMember' }}">
 							<i class="fa fa-times"></i>
 							</a>
 							<a href="#" onclick="{{ member.Id | Postback:'EditGroupMember' }}" class="margin-l-sm">
@@ -232,8 +237,6 @@
 			{% endfor %}
 
 		{% endif %}
-
-
 
 		{% if countInactive > -1 %}
 			{% assign icountInactive = 0 %}
@@ -274,7 +277,7 @@
 
 						{% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
 						<div class="pull-left rollover-item" style="position: absolute; right:0; top:0;">
-							<a href="#" onclick="{{ member.Id | Postback:'DeleteGroupMember' }}" >
+							<a href="#" onclick="{{ member.Id | Postback:'DeleteGroupMember' }}">
 							<i class="fa fa-times"></i>
 							</a>
 							<a href="#" onclick="{{ member.Id | Postback:'EditGroupMember' }}" class="margin-l-sm">
@@ -317,6 +320,93 @@
                 {% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
                 <a href="#" onclick="{{ '' | Postback:'SendAlternateCommunication' }}" class="btn btn-default btn-xs">
                     <i class="fa fa-mobile-phone"></i> Text Roster
+                </a>
+                {% endif %}
+            {% endif %}
+			{% if LinkedPages.CommunicationPage != '' and Parents != null %}
+				{% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
+					<a href="#" onclick="{{ 'Yes' | Postback:'SendCommunication' }}" class="btn btn-default btn-xs">
+						<i class="fa fa-envelope-o"></i> Email Parents
+					</a>
+				{% endif %}
+			{% endif %}
+            {% if LinkedPages.AlternateCommunicationPage %}
+                {% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
+                <a href="#" onclick="{{ 'Yes' | Postback:'SendAlternateCommunication' }}" class="btn btn-default btn-xs">
+                    <i class="fa fa-mobile-phone"></i> Text Parents
+                </a>
+                {% endif %}
+            {% endif %}
+		</div>
+		</p>
+	{% endif %}
+
+	{% comment %} Parent Roster Tab {% endcomment %}
+	{% if LinkedPages.ParentRosterPage == CurrentPage.Path %}
+
+		<div class="well">
+
+			{% for member in Group.Members %}
+
+				{% for kvpParents in Parents %}
+					{% assign memberId = kvpParents | Property:'Key' %}
+					{% assign memberParents = kvpParents | Property:'Value' %}
+					{% if memberId == member.PersonId and memberParents != empty %}
+
+						<h4><strong>{{ member.Person.FullName }}</strong></h4>
+						<div class="row">
+
+						    {% for parent in memberParents %}
+							    <div class="col-sm-6 margin-b-md rollover-container" style="overflow: hidden;">
+
+							    {% if LinkedPages.PersonDetailPage %}
+								    <a href="{{ LinkedPages.PersonDetailPage }}?PersonId={{ parent.Id }}">
+							    {% endif %}
+							    <img src="{{ parent.PhotoUrl }}&height=60&width=60&mode=crop&scale=both" height="60" class="pull-left margin-r-sm" alt="">
+                                <div class="pull-left">
+                                    {{ parent.FullName }}
+
+                                    {% for phone in parent.PhoneNumbers %}
+                                    <br />{% if phone.IsUnlisted != true %}<a href="tel:{{ phone.NumberFormatted }}">{{ phone.NumberFormatted }}</a>{% else %}Unlisted{% endif %}  <small>({{ phone.NumberTypeValue.Value }})</small>
+                                    {% endfor %}
+
+                                    {% assign parentAddress =  parent | Address:'Home' %}
+                                    {% if parentAddress != '' %}
+                                    <br />{{ parent | Address:'Home' }}
+                                    {% endif %}
+
+                                    <br />
+                                    <a href="mailto:{{ parent.Email }}">{{ parent.Email }}</a>
+                                    <br />
+                                </div>
+
+							    {% if LinkedPages.PersonDetailPage  %}
+								    </a>
+							    {% endif %}
+							    </div>
+
+						    {% endfor %}
+						</div>
+
+					{% endif %}
+
+				{% endfor %}
+
+			{% endfor %}
+		</div>
+
+		<div class="pull-right margin-b-md">
+			{% if LinkedPages.CommunicationPage != '' %}
+				{% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
+					<a href="#" onclick="{{ 'Yes' | Postback:'SendCommunication' }}" class="btn btn-default btn-xs">
+						<i class="fa fa-envelope-o"></i> Email Parents
+					</a>
+				{% endif %}
+			{% endif %}
+            {% if LinkedPages.AlternateCommunicationPage %}
+                {% if AllowedActions.Edit == true or AllowedActions.ManageMembers == true %}
+                <a href="#" onclick="{{ 'Yes' | Postback:'SendAlternateCommunication' }}" class="btn btn-default btn-xs">
+                    <i class="fa fa-mobile-phone"></i> Text Parents
                 </a>
                 {% endif %}
             {% endif %}


### PR DESCRIPTION
## Proposed Changes

This pull request is an updated version of https://github.com/SparkDevNetwork/Rock/pull/2855

This PR adds Parent Roster support for Children's Small Groups. This allows leaders to have access to parental information, not just information about the child they lead. See discussion, explanation and screenshots at #2854. 

This effort was sponsored by Fellowship Greenville again.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [X] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [X] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
The original request from David used the parent role, this one has been updated to use AgeClassification as suggested in the discussion.

## Documentation
https://community.rockrms.com/documentation/bookcontent/7/152#groupleadertoolbox doesn't have much more than a simple screenshot and paragraph, if there were setting descriptions than we would.

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

Enable Parent Support is off by default so I did not include a migration to add a new "Parent Roster" page. More details are in the corresponding issue.