### PR TITLE
Volunteer Scheduling: Make showing a schedule's name instead of time configurable in block settings in the toolbox

### DIFF
--- a/RockWeb/Blocks/GroupScheduling/GroupScheduleToolbox.ascx.cs
+++ b/RockWeb/Blocks/GroupScheduling/GroupScheduleToolbox.ascx.cs
@@ -84,7 +84,7 @@ namespace RockWeb.Blocks.GroupScheduling
      [BooleanField(
         "Show Names instead of Times on schedules?",
         Key = AttributeKey.ShowScheduleNames,
-        Description = "Set to false to show the time's instead.",
+        Description = "Set to true to show the Names's.",
         DefaultBooleanValue = false,
         Order = 3 )]
         

--- a/RockWeb/Blocks/GroupScheduling/GroupScheduleToolbox.ascx.cs
+++ b/RockWeb/Blocks/GroupScheduling/GroupScheduleToolbox.ascx.cs
@@ -80,6 +80,14 @@ namespace RockWeb.Blocks.GroupScheduling
 </div>",
         Order = 2
          )]
+         
+     [BooleanField(
+        "Show Names instead of Times on schedules?",
+        Key = AttributeKey.ShowScheduleNames,
+        Description = "Set to false to show the time's instead.",
+        DefaultBooleanValue = false,
+        Order = 3 )]
+        
     public partial class GroupScheduleToolbox : RockBlock
     {
         protected class AttributeKey
@@ -87,6 +95,7 @@ namespace RockWeb.Blocks.GroupScheduling
             public const string FutureWeeksToShow = "FutureWeeksToShow";
             public const string EnableSignup = "EnableSignup";
             public const string SignupInstructions = "SignupInstructions";
+            public const string ShowScheduleNames = "ShowScheduleNames";
         }
 
         protected const string ALL_GROUPS_STRING = "All Groups";
@@ -365,7 +374,14 @@ $('#{0}').tooltip();
         /// <returns></returns>
         protected string GetOccurrenceTime( Attendance attendance )
         {
-            return attendance.Occurrence.Schedule.GetCalendarEvent().DTStart.Value.TimeOfDay.ToTimeString();
+            if ( this.GetAttributeValue( AttributeKey.ShowScheduleNames ).AsBoolean() == true )
+            {
+                return attendance.Occurrence.Schedule.Name.ToString();
+            } 
+            else 
+            { 
+                return attendance.Occurrence.Schedule.GetCalendarEvent().DTStart.Value.TimeOfDay.ToTimeString();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added the ability to either display a Schedules Time or Name with a boolean block attribute.

In the rest of the scheduling process you deal with schedules by name this is also how we deal with them internally. A person rarely sees the actual time a schedule starts instead they see Sunday 1st, Sunday 2nd, Sunday 3rd etc... All of these schedules start at 5:30am, for us and for multiple reasons, which might be unique to us. This is the only place I have found where it's an actual time displayed and not the schedule name, and for us it's causing issues. This is Not a Bug, but when a volunteer looks at their schedule knowing that they've accepted for 3rd service and then they see 5:30 am they freak out.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

Fixes: #

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [ ] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [ ] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [ ] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
