### PR TITLE
- Fixed blank instruction page in Event Registration. (Fixes #3937)

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -3632,12 +3632,13 @@ namespace RockWeb.Blocks.Event
                 RegistrationTemplate.RegistrationInstructions :
                 RegistrationInstanceState.RegistrationInstructions;
 
-            if ( !string.IsNullOrEmpty( instructions ) )
+            // Sanitize for empty check catches things like empty paragraph tags.
+            if ( !string.IsNullOrEmpty( instructions.SanitizeHtml() ) )
             {
                 lInstructions.Text = string.Format( "<div class='text-left'>{0}</div>", instructions );
             }
 
-            return instructions.IsNotNullOrWhiteSpace();
+            return instructions.SanitizeHtml().IsNotNullOrWhiteSpace();
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes

Sanitize the HTML before doing a Empty/Null check on the instructions. This catches cases such as empty paragraph tags that creep into the HTML editor when attempting to delete the contents.

Fixes: #3937

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

For testing I created 3 registration instances. One with real content in the instructions, one with "psuedo" blank content (that is typed something, left field, went back to the field and erased - which left `<p><br></p>` in the raw instructions), and then one with truly blank instructions. Results before and after this PR are pictured below.

<img width="787" alt="Before" src="https://user-images.githubusercontent.com/1119863/67590878-e7159700-f710-11e9-91e0-a2247741e5b8.png">

<img width="794" alt="After" src="https://user-images.githubusercontent.com/1119863/67590894-eed53b80-f710-11e9-976e-5440198765e2.png">


## Documentation

No documentation changes required.

## Migrations

No migrations required.