### PR TITLE
Removed dataview filters related to archived group members

### DIFF
--- a/Rock/Model/GroupMember.cs
+++ b/Rock/Model/GroupMember.cs
@@ -160,6 +160,7 @@ namespace Rock.Model
         /// <value>
         ///   <c>true</c> if this instance is archived; otherwise, <c>false</c>.
         /// </value>
+        [HideFromReporting]
         [DataMember]
         public bool IsArchived { get; set; } = false;
 
@@ -169,6 +170,7 @@ namespace Rock.Model
         /// <value>
         /// The archived date time.
         /// </value>
+        [HideFromReporting]
         [DataMember]
         public DateTime? ArchivedDateTime { get; set; }
 
@@ -178,6 +180,7 @@ namespace Rock.Model
         /// <value>
         /// The archived by person alias identifier.
         /// </value>
+        [HideFromReporting]
         [DataMember]
         public int? ArchivedByPersonAliasId { get; set; }
 


### PR DESCRIPTION
## Proposed Changes

The `IsArchived`, `ArchivedDateTime`, and `ArchivedByAliasPersonId` filters didn't work as expected because archived group members are ignored in reporting. This PR hided the filters from reporting so that they don't confuse users as to why no results are returned.

Fixes: #3933

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)
