### PR TITLE
- Fixed bug that prevented proper selection of all stored values if they were delimited by more than just a single comma

### DIFF
--- a/Rock/Field/SelectFromListFieldType.cs
+++ b/Rock/Field/SelectFromListFieldType.cs
@@ -204,7 +204,7 @@ namespace Rock.Field.Types
             if ( value != null )
             {
                 List<string> values = new List<string>();
-                values.AddRange( value.Split( ',' ) );
+                values.AddRange( value.SplitDelimitedValues() );
 
                 if ( control != null && control is RockCheckBoxList )
                 {


### PR DESCRIPTION
## Proposed Changes

After updating from 8.9 to 9.3, I edited the rightmost badge block on the Person profile page and only one badge was checked in the block settings despite there being multiple badges displaying. When I hit save, all but that one disappeared.

It turned out that the attribute value had guids separated by a comma and space, but this control only allowed commas as delimiters.  At least one of these extraneous spaces was added by the migration to add the Assessments badge at this line:

https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Migrations/Migrations/Version%209.0/Version%201.9.0/201906192243232_Rollup_0618.cs#L267

I confirmed that the checkbox problem on that badge block was also happening on the demo site.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)


