### PR TITLE
Added timing information to Sql Command block.

### DIFF
--- a/RockWeb/Blocks/Reporting/SqlCommand.ascx
+++ b/RockWeb/Blocks/Reporting/SqlCommand.ascx
@@ -20,7 +20,7 @@
                     </div>
 
                     <div class="margin-t-md">
-                        <Rock:NotificationBox ID="nbSuccess" runat="server" Heading="Success" Title="Command run successfully!" NotificationBoxType="Success" Visible="false" />
+                        <Rock:NotificationBox ID="nbSuccess" runat="server" Heading="Success" Title="Command completed successfully!" NotificationBoxType="Success" Visible="false" />
                         <Rock:NotificationBox ID="nbError" runat="server" Heading="Error" Title="SQL Error!" NotificationBoxType="Danger" Visible="false" />
                     </div>
                 </div>
@@ -28,6 +28,8 @@
                 <div class="grid">
                     <Rock:Grid ID="gReport" runat="server" AllowSorting="true" EmptyDataText="No Results" Visible="false" />
                 </div>
+
+                <p id="pQueryTime" runat="server" class="text-right margin-r-md" visible="false" />
             </div>
 
     </ContentTemplate>

--- a/RockWeb/Blocks/Reporting/SqlCommand.ascx
+++ b/RockWeb/Blocks/Reporting/SqlCommand.ascx
@@ -20,7 +20,7 @@
                     </div>
 
                     <div class="margin-t-md">
-                        <Rock:NotificationBox ID="nbSuccess" runat="server" Heading="Success" Title="Command completed successfully!" NotificationBoxType="Success" Visible="false" />
+                        <Rock:NotificationBox ID="nbSuccess" runat="server" Heading="Success" Title="Command completed successfully." NotificationBoxType="Success" Visible="false" />
                         <Rock:NotificationBox ID="nbError" runat="server" Heading="Error" Title="SQL Error!" NotificationBoxType="Danger" Visible="false" />
                     </div>
                 </div>

--- a/RockWeb/Blocks/Reporting/SqlCommand.ascx.cs
+++ b/RockWeb/Blocks/Reporting/SqlCommand.ascx.cs
@@ -100,6 +100,7 @@ FROM
             nbSuccess.Visible = false;
             nbError.Visible = false;
             gReport.Visible = false;
+            pQueryTime.Visible = false;
 
             string query = tbQuery.Text;
             if ( !string.IsNullOrWhiteSpace( query ) )
@@ -110,7 +111,10 @@ FROM
                     {
                         gReport.Visible = true;
 
+                        var sw = System.Diagnostics.Stopwatch.StartNew();
                         DataSet dataSet = DbService.GetDataSet( query, CommandType.Text, null, GetAttributeValue( "DatabaseTimeout" ).AsIntegerOrNull() ?? 180 );
+                        sw.Stop();
+
                         if ( dataSet.Tables.Count > 0 )
                         {
                             var dataTable = dataSet.Tables[0];
@@ -120,15 +124,22 @@ FROM
                             gReport.DataSource = GetSortedView( dataTable );
                             gReport.DataBind();
                         }
+
+                        pQueryTime.InnerText = string.Format( "Query completed in {0:N0}ms", sw.ElapsedMilliseconds );
+                        pQueryTime.Visible = true;
                     }
                     else
                     {
+                        var sw = System.Diagnostics.Stopwatch.StartNew();
                         int rows = DbService.ExecuteCommand( query, commandTimeout: GetAttributeValue( "DatabaseTimeout" ).AsIntegerOrNull() ?? 180 );
+                        sw.Stop();
+
                         if ( rows < 0 )
                         {
                             rows = 0;
                         }
 
+                        nbSuccess.Title = string.Format( "Command completed successfully in {0:N0}ms!", sw.ElapsedMilliseconds );
                         nbSuccess.Text = string.Format( "Row(s) affected: {0}", rows );
                         nbSuccess.Visible = true;
                     }

--- a/RockWeb/Blocks/Reporting/SqlCommand.ascx.cs
+++ b/RockWeb/Blocks/Reporting/SqlCommand.ascx.cs
@@ -139,7 +139,7 @@ FROM
                             rows = 0;
                         }
 
-                        nbSuccess.Title = string.Format( "Command completed successfully in {0:N0}ms!", sw.ElapsedMilliseconds );
+                        nbSuccess.Title = string.Format( "Command completed successfully in {0:N0}ms.", sw.ElapsedMilliseconds );
                         nbSuccess.Text = string.Format( "Row(s) affected: {0}", rows );
                         nbSuccess.Visible = true;
                     }


### PR DESCRIPTION
## Proposed Changes

When I am building a custom SQL query for a Dynamic Report block or something, I often use the Sql Command block/page to build the actual query first. It's faster, I don't have to go in and out of edit mode etc. while getting the query itself to work.

Many times while doing this I also want to know how long the query takes. Primarily for performance reasons, I want to make sure I'm not building a query that is taking 3 seconds when I'm expecting it to only take a few milliseconds. Because of postback overhead, it's often hard to tell how long the query itself is taking.

This adds new UI elements to the Sql Command block that informs the user how long the query or command took to execute.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

(new feature, not pre-approved)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

Screenshots of a query and command with the new UI.

<img alt="2019-11-08 10_09_47-VirtualBoxVM" src="https://user-images.githubusercontent.com/1119863/68500701-2fed4580-0211-11ea-8328-4de682b5899b.png">

<img alt="2019-11-08 10_10_01-VirtualBoxVM" src="https://user-images.githubusercontent.com/1119863/68500708-32e83600-0211-11ea-82a5-0df11ceffec0.png">

## Documentation

No documentation changes needed.

## Migrations

No migrations needed.