### PR TITLE
Fixed Lucene path mapping to work with virtual directories

### DIFF
--- a/Rock/UniversalSearch/IndexComponents/Lucene.cs
+++ b/Rock/UniversalSearch/IndexComponents/Lucene.cs
@@ -66,7 +66,7 @@ namespace Rock.UniversalSearch.IndexComponents
         private static IndexSearcher _indexSearcher = null;
         private static FSDirectory _directory;
         private static Timer _timer = null;
-        private static readonly string _path = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, "App_Data", "LuceneSearchIndex" );
+        private static readonly string _path = System.Web.Hosting.HostingEnvironment.MapPath( "~/App_Data/LuceneSearchIndex" );
         private static readonly object _lockWriter = new object();
         #endregion
 


### PR DESCRIPTION
## Proposed Changes
We are working on moving to a clustered environment. As part of that we came up with the solution of using virtual directories for App_Data and Content. This works correctly with most things, however Lucene only places files on the absolute directory and not on the virtual. This change switches methods for mapping the file location so it is compatible with absolute and virtual directories.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
![image](https://user-images.githubusercontent.com/495787/68978820-ddd89100-07c9-11ea-9635-0ddbec67296e.png)
