### PR TITLE
Workflow.Action.Utility.SetEntityProperty: Set Nullable Enum

### DIFF
--- a/Rock/Workflow/Action/Utility/SetEntityProperty.cs
+++ b/Rock/Workflow/Action/Utility/SetEntityProperty.cs
@@ -175,6 +175,12 @@ namespace Rock.Workflow.Action
             {
                 return null;
             }
+            
+            if ( underType.IsEnum )
+            {
+                return string.IsNullOrWhiteSpace( theObject ) ? null : Enum.Parse( underType, theObject, true );
+            }
+
             return Convert.ChangeType( theObject, underType );
         }
     }


### PR DESCRIPTION
Extend SetEntityProperty to enable it to set entity properties that are nullable enums (like ConnectionRequest.AssignedGroupMemberStatus).


## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
The workflow action SetEntityProperty cannot currently set an entity property that is of a nullable enum type. It throws a conversion exception because there is no conversion available from string to enum. The current implementation provides a special case for enum types that uses Enum.Parse to perform the conversion, but this case is not evaluated if the base object type is nullable.

The proposed change should not impact other conversions. and has no impact on UI.
-->

Fixes: #

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x ] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [ x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x ] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
This change is necessary to enable the AssignedGroupMemberStatus property to be set on a ConnectionRequest from a workflow. If that property is not set, the Connection Detail UI will not display the AssignedGroupMemberAttributeValues unless someone manually edits and saves the detail first (at which time that code will force a default value for the group member status).
-->

## Documentation
<!--
Not applicable.
-->

## Migrations
Not Applicable.