### PR TITLE
Added lava regex with multiple matches

### DIFF
--- a/Rock.Tests/Rock/Lava/RockFiltersTests.cs
+++ b/Rock.Tests/Rock/Lava/RockFiltersTests.cs
@@ -115,6 +115,26 @@ namespace Rock.Tests.Rock.Lava
         }
 
         /// <summary>
+        /// For use in Lava -- should return all matching patterns in the string.
+        /// </summary>
+        [Fact]
+        public void Text_RegExMatchValue_ShouldReturnMatchValues()
+        {
+            var output = RockFilters.RegExMatchValues( "Group 12345 has 54321 members", @"\d+" );
+            Assert.Equal( new List<string> { "12345", "54321" }, output );
+        }
+
+        /// <summary>
+        /// For use in Lava -- should not match and should return nothing.
+        /// </summary>
+        [Fact]
+        public void Text_RegExMatchValues_ShouldNotMatchValue()
+        {
+            var output = RockFilters.RegExMatchValues( "Group Decker has no members", @"\d+" );
+            Assert.Equal( new List<string>(), output );
+        }
+
+        /// <summary>
         /// Verfies that the StripHtml filter handles standard HTML tags.
         /// </summary>
         [Fact]

--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -951,6 +951,33 @@ namespace Rock.Lava
         }
 
         /// <summary>
+        /// Returns matched RegEx list of strings from inputted string
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="expression">The regex expression.</param>
+        /// <returns></returns>
+        public static List<string> RegExMatchValues( string input, string expression )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            Regex regex = new Regex( expression );
+            var matches = regex.Matches( input );
+
+            // Flatten all matches to single list
+            var captured = matches
+                .Cast<Match>()
+                .Where( m => m.Success == true )
+                .SelectMany( o =>
+                    o.Groups.Cast<Capture>()
+                        .Select( c => c.Value ) );
+
+            return captured.ToList();
+        }
+
+        /// <summary>
         /// The slice filter returns a substring, starting at the specified index.
         /// </summary>
         /// <param name="input">The input string.</param>


### PR DESCRIPTION
## Proposed Changes

Submitting this on behalf of @cbump.

This enhancement is to add the lava filter "RegExMatchValues". It works like "RegExMatchValue" except that instead of returning a string of the first match it returns all of the matches in a list. Originally, Chuck submitted this as a modification of "RegExMatchValue" and was asked to change it into a new tag.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Documentation
Tests the input against a Regular Expression and returns an array of the matching substrings.

Example:
{% assign days =  "Services on Saturday and Sunday" | RegExMatchValues:'\b\w+day\b' %}
{% for day in days %}
    {{day}} <br />
{% endfor %}

 Note:
When building expressions you might find the Regular Expressions 101 site helpful. Be sure to set the 'flavor' to javascript for best results.