### PR TITLE
Fixed bug with pickers and collision of Id numbers

### DIFF
--- a/Rock/Web/UI/Controls/Pickers/CategoryPicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/CategoryPicker.cs
@@ -37,7 +37,7 @@ namespace Rock.Web.UI.Controls
         {
             SetExtraRestParams();
             this.IconCssClass = "fa fa-folder-open";
-            this.AllowCategorySelection = true;
+            this.UseCategorySelection = true;
             base.OnInit( e );
         }
 

--- a/Rock/Web/UI/Controls/Pickers/ItemPicker.cs
+++ b/Rock/Web/UI/Controls/Pickers/ItemPicker.cs
@@ -296,13 +296,26 @@ namespace Rock.Web.UI.Controls
                     _hfItemId.Value = Constants.None.IdValue;
                 }
 
+                if ( UseCategorySelection )
+                {
+                    return _hfItemId.Value.Replace( CategoryPrefix, string.Empty );
+                }
+
                 return _hfItemId.Value;
             }
 
             set
             {
                 EnsureChildControls();
-                _hfItemId.Value = value;
+
+                if ( UseCategorySelection )
+                {
+                    _hfItemId.Value = CategoryPrefix + value;
+                }
+                else
+                {
+                    _hfItemId.Value = value;
+                }
             }
         }
 
@@ -321,7 +334,14 @@ namespace Rock.Web.UI.Controls
 
                 if ( !string.IsNullOrWhiteSpace( _hfItemId.Value ) )
                 {
-                    ids.AddRange( _hfItemId.Value.Split( ',' ) );
+                    if ( UseCategorySelection )
+                    {
+                        ids.AddRange( _hfItemId.Value.Split( ',' ).Select( a => a.Replace( CategoryPrefix, string.Empty ) ) );
+                    }
+                    else
+                    {
+                        ids.AddRange( _hfItemId.Value.Split( ',' ) );
+                    }
                 }
 
                 return ids;
@@ -330,7 +350,15 @@ namespace Rock.Web.UI.Controls
             set
             {
                 EnsureChildControls();
-                _hfItemId.Value = string.Join( ",", value );
+
+                if ( UseCategorySelection )
+                {
+                    _hfItemId.Value = string.Join( ",", value.Select( a => CategoryPrefix + a ) );
+                }
+                else
+                {
+                    _hfItemId.Value = string.Join( ",", value );
+                }
             }
         }
 
@@ -461,7 +489,22 @@ namespace Rock.Web.UI.Controls
         /// <value>
         ///   <c>true</c> if [allow category selection]; otherwise, <c>false</c>.
         /// </value>
-        public bool AllowCategorySelection { get; set; } = false;
+        [RockObsolete( "1.11" )]
+        [Obsolete( "ItemPicker no longer supports selection of both items and categories concurrently.", false )]
+        public bool AllowCategorySelection
+        {
+            get => UseCategorySelection;
+            set => UseCategorySelection = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether category selection is used.
+        /// If set to true then the user will be allowed to select a Category but not Items.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if category selection is used; otherwise, <c>false</c>.
+        /// </value>
+        public bool UseCategorySelection { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether [show select children].
@@ -502,6 +545,15 @@ namespace Rock.Web.UI.Controls
         ///   <c>true</c> if [hide picker label]; otherwise, <c>false</c>.
         /// </value>
         public bool HidePickerLabel { get; set; }
+
+        #endregion
+
+        #region Fields
+
+        /// <summary>
+        /// The category prefix used when <see cref="UseCategorySelection"/> is true.
+        /// </summary>
+        private const string CategoryPrefix = "C";
 
         #endregion
 
@@ -558,7 +610,8 @@ $@"Rock.controls.itemPicker.initialize({{
     controlId: '{this.ClientID}',
     restUrl: '{this.ResolveUrl( ItemRestUrl )}',
     allowMultiSelect: {this.AllowMultiSelect.ToString().ToLower()},
-    allowCategorySelection: {this.AllowCategorySelection.ToString().ToLower()},
+    allowCategorySelection: {this.UseCategorySelection.ToString().ToLower()},
+    categoryPrefix: '{CategoryPrefix}',
     defaultText: '{this.DefaultText}',
     restParams: $('#{_hfItemRestUrlExtraParams.ClientID}').val(),
     expandedIds: [{this.InitialItemParentIds}],

--- a/RockWeb/Scripts/Rock/Controls/itemPicker.js
+++ b/RockWeb/Scripts/Rock/Controls/itemPicker.js
@@ -21,6 +21,7 @@
                     treeOptions = {
                         multiselect: this.options.allowMultiSelect,
                         categorySelection: this.options.allowCategorySelection,
+                        categoryPrefix: this.options.categoryPrefix,
                         restUrl: this.options.restUrl,
                         restParams: this.options.restParams,
                         expandedIds: this.options.expandedIds,
@@ -240,6 +241,7 @@
                 restUrl: null,
                 restParams: null,
                 allowCategorySelection: false,
+                categoryPrefix: '',
                 allowMultiSelect: false,
                 defaultText: '',
                 selectedIds: null,

--- a/RockWeb/Scripts/Rock/Extensions/rockTree.js
+++ b/RockWeb/Scripts/Rock/Extensions/rockTree.js
@@ -44,7 +44,7 @@
 
         // Default utility function to attempt to map a Rock.Web.UI.Controls.Pickers.TreeViewItem
         // to a more standard JS object.
-		_mapArrayDefault = function (arr) {
+		_mapArrayDefault = function (arr, treeView) {
 		    return $.map(arr, function (item) {
 		        var node = {
 		            id: item.Guid || item.Id,
@@ -58,8 +58,12 @@
 		        };
 
 		        if (item.Children && typeof item.Children.length === 'number') {
-		            node.children = _mapArrayDefault(item.Children);
-		        }
+		            node.children = _mapArrayDefault(item.Children, treeView);
+                }
+
+                if (node.isCategory) {
+                    node.id = treeView.options.categoryPrefix + node.id;
+                }
 
 		        return node;
 		    });
@@ -161,7 +165,8 @@
                     if (parentNode && parentNode.entityId) {
                         restUrl += parentNode.entityId;
                     } else {
-                        restUrl += parentId;
+                        var sanitizedId = parentId.toString().replace(self.options.categoryPrefix, '');
+                        restUrl += sanitizedId;
                     }
 
                     if (self.options.restParams) {
@@ -345,7 +350,7 @@
 
             // Call configured `mapData` function. If it wasn't overridden by the user,
             // `_mapArrayDefault` will be called.
-            nodeArray = this.options.mapping.mapData(data);
+            nodeArray = this.options.mapping.mapData(data, this);
 
             for (i = 0; i < nodeArray.length; i++) {
                 nodeArray[i].isOpen = false;
@@ -725,6 +730,7 @@
         local: null,
         multiselect: false,
         categorySelection: true,
+        categoryPrefix: '',
         showSelectChildren: false,
         loadingHtml: '<span class="rocktree-loading"><i class="fa fa-refresh fa-spin"></i></span>',
         iconClasses: {


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

Adds support to `treeView.js` for prefixing item Id numbers if they are categories. This allows the `ItemPicker` control to differentiate between selecting a category and selecting an item. See https://github.com/SparkDevNetwork/Rock/issues/1632#issuecomment-581580802 for full discussion of the exact changes.

Basically, `ItemPicker` will now cause categories to be prefixed with a `C` in their id number, but this will be handled behind the scenes. No change to user-code should be needed.

Fixes: #1632, #3942

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

I have tested this fix with the following items:

* Workflow Configuration screen to ensure the left-hand tree still works correctly.
* Category attribute
* Workflow Type attribute
* Page Picker
* Group Picker
* Location Picker
* Cms > Page Map
* Checkin > Named Locations
* Group Viewer

The following need final testing, but shouldn't have issues:

* HTML Editor File Browser (was unable to test due to #4097)
* Asset Manager tree browser

## Documentation

n/a

## Migrations

n/a