### PR TITLE
+ Added new Allow Donations Until date on fundraising opportunities. (Fixes #3438)

### DIFF
--- a/Rock.Migrations/Migrations/202002111831294_AddFundraisingAllowDonationsUntil.cs
+++ b/Rock.Migrations/Migrations/202002111831294_AddFundraisingAllowDonationsUntil.cs
@@ -1,0 +1,64 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+namespace Rock.Migrations
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public partial class AddFundraisingAllowDonationsUntil : Rock.Migrations.RockMigration
+    {
+        private const string AllowDonationsUntilGuid = "73AA96AC-BD64-4655-947D-AF6144F143CC";
+
+        /// <summary>
+        /// Operations to be performed during the upgrade process.
+        /// </summary>
+        public override void Up()
+        {
+            RockMigrationHelper.AddGroupTypeGroupAttribute( 
+                SystemGuid.GroupType.GROUPTYPE_FUNDRAISINGOPPORTUNITY,
+                SystemGuid.FieldType.DATE,
+                "Allow Donations Until",
+                "Donations to members of this group will be allowed up to and including the date specified.",
+                0,
+                string.Empty,
+                AllowDonationsUntilGuid,
+                false );
+
+            Sql( $@"
+DECLARE @Order int = (SELECT [Order] + 1 FROM [Attribute] WHERE [Guid] = '7C6FF01B-F68E-4A83-A96D-85071A92AAF1')
+
+-- Update Order on the new attribute
+UPDATE [Attribute]
+    SET [Order] = @Order
+WHERE [Guid] = '{AllowDonationsUntilGuid}'
+
+-- Update Order on the Show Public and Registration Notes attributes
+UPDATE [Attribute]
+    SET [Order] = [Order] + 1
+WHERE [Guid] IN ('BBD6C818-765C-43FB-AA72-5AF66F91B499', '7360CF56-7DF5-42E9-AD2B-AD839E0D4EDB') AND [Order] >= @Order
+" );
+        }
+        
+        /// <summary>
+        /// Operations to be performed during the downgrade process.
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( AllowDonationsUntilGuid );
+        }
+    }
+}

--- a/RockWeb/Blocks/Fundraising/FundraisingDonationEntry.ascx.cs
+++ b/RockWeb/Blocks/Fundraising/FundraisingDonationEntry.ascx.cs
@@ -185,7 +185,9 @@ namespace RockWeb.Blocks.Fundraising
             {
                 fundraisingOpportunity.LoadAttributes( rockContext );
                 var dateRange = DateRangePicker.CalculateDateRangeFromDelimitedValues( fundraisingOpportunity.GetAttributeValue( "OpportunityDateRange" ) );
-                if ( RockDateTime.Now <= ( dateRange.End ?? DateTime.MaxValue ) )
+                var allowDonationsUntil = fundraisingOpportunity.GetAttributeValue( "AllowDonationsUntil" ).AsDateTime();
+                var untilDate = allowDonationsUntil ?? dateRange.End ?? DateTime.MaxValue;
+                if ( RockDateTime.Now <= untilDate )
                 {
                     var listItem = new ListItem( fundraisingOpportunity.GetAttributeValue( "OpportunityTitle" ), fundraisingOpportunity.Id.ToString() );
                     if ( listItem.Text.IsNullOrWhiteSpace() )

--- a/RockWeb/Blocks/Fundraising/FundraisingOpportunityView.ascx.cs
+++ b/RockWeb/Blocks/Fundraising/FundraisingOpportunityView.ascx.cs
@@ -178,8 +178,17 @@ namespace RockWeb.Blocks.Fundraising
                 gm.LoadAttributes( rockContext );
             }
 
-            // only show the 'Donate to a Participant' button if there are participants that are taking contribution requests
-            btnDonateToParticipant.Visible = groupMembers.Where( a => !a.GetAttributeValue( "DisablePublicContributionRequests" ).AsBoolean() ).Any();
+            //
+            // Only show the 'Donate to a Participant' button if there are
+            // participants that are taking contribution requests and the
+            // cutoff date has not been reached.
+            //
+            var allowDonationsUntil = group.GetAttributeValue( "AllowDonationsUntil" )
+                .AsDateTime() ?? DateTime.MaxValue;
+            var donationsAllowed = RockDateTime.Now <= allowDonationsUntil;
+            var anyMemberAllowsDonations = groupMembers
+                .Any( a => !a.GetAttributeValue( "DisablePublicContributionRequests" ).AsBoolean() );
+            btnDonateToParticipant.Visible = donationsAllowed && anyMemberAllowsDonations;
             if ( !string.IsNullOrWhiteSpace( opportunityType.GetAttributeValue( "core_DonateButtonText" ) ) )
             {
                 btnDonateToParticipant.Text = opportunityType.GetAttributeValue( "core_DonateButtonText" );


### PR DESCRIPTION
## Proposed Changes

This PR replaces #3674.

Adjusts the Fundraising Donation Entry block to use a new `Allow Donations Until` attribute value which specifies the last day to accept donations towards group members.

Adjusts the Fundraising Opportunity View block to use a new `Allow Donations Until` attribute value which specifies the last day to accept donations towards group members.

IMPORTANT: The above two statements are slightly misleading, but there is a reason for explained below in further comments.

Included migration (not referenced in project file) to perform the following steps:

1. Add new Group attribute `Allow Donations Until` to Fundraising Opportunity group type.
2. Set order on `Allow Donations Until` to make it appear directly after `Financial Account`.
3. Set order on subsequent attributes so they appear after the new attribute.

Fixes: #3438

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [X] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

Note about end dates. The original implementation used `DateRange.End`, whose documentation states that the value is one day **later** than what is seen in the UI.  That is **not** correct. I tested and verified that the UI showed "Feb 1 - Feb 11, 2019" as the opportunity date range and the value of `dateRange.End` was still `Feb 11, 2019 midnight`. This means if I had tried to donate towards the trip at 8am on Feb 11, 2019 it would not allow it. I don't know if this was changed recently and is a bug or has been that way for a long time and the docs just never got updated.

Either way, I setup the new `Allow Donations Until` functionality to be the same way. Meaning, if you enter a date of `Feb 11, 2019` and try to give on Feb 11, 2019 at 8am, it will not allow you to give. I don't know if that is intended behavior or not, but that is outside the scope of this PR. But I wanted to make sure the core team was aware of the exact functionality.

----

The below image is correct, except that it shows a required marker that doesn't exist. I forgot to take a new screenshot before reverting my database. The new attribute is indeed optional.

![image](https://user-images.githubusercontent.com/1119863/57045725-63786300-6c23-11e9-95ca-10421374067e.png)

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

https://community.rockrms.com/documentation/book/7/129/content#fundraisingopportunityconfiguration

The above documentation should be updated to include a mention of the new attribute (to appear after the Financial Account):

* `Allow Donations Until` - An inclusive date that specifies how long to allow donations to participants. Once this date passes no more donations will be accepted by Rock.

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

**MIGRATION EXISTS** - 202002111831294_AddFundraisingAllowDonationsUntil.cs

The contents of this file will need to be moved into a full migration and then deleted.