### PR TITLE
Added previous metric date and value to metrics controller for comparisons/trends

### DIFF
--- a/Rock.Rest/Controllers/MetricsController.partial.cs
+++ b/Rock.Rest/Controllers/MetricsController.partial.cs
@@ -101,6 +101,17 @@ namespace Rock.Rest.Controllers
                         metricYTDData.LastValue = lastMetricCumulativeValues.Sum( a => a.YValue ).HasValue ? Math.Round( lastMetricCumulativeValues.Sum( a => a.YValue ).Value, roundYValues ? 0 : 2 ) : (decimal?)null;
                     }
 
+                    var previousMetricValue = qryMeasureValues.OrderByDescending(a => a.MetricValueDateTime).Skip(1).FirstOrDefault();
+                    if ( previousMetricValue != null )
+                    {
+                        metricYTDData.PreviousValueDate = previousMetricValue.MetricValueDateTime.HasValue ? previousMetricValue.MetricValueDateTime.Value.Date : DateTime.MinValue;
+
+                        // get a sum of the values that for whole 24 hour day of the previous Date
+                        DateTime previousValueDateEnd = metricYTDData.PreviousValueDate.AddDays(1);
+                        var previousMetricCumulativeValues = qryMeasureValues.Where(a => a.MetricValueDateTime.HasValue && a.MetricValueDateTime.Value >= metricYTDData.PreviousValueDate && a.MetricValueDateTime.Value < previousValueDateEnd);
+                        metricYTDData.PreviousValue = previousMetricCumulativeValues.Sum(a => a.YValue).HasValue ? Math.Round(previousMetricCumulativeValues.Sum(a => a.YValue).Value, roundYValues ? 0 : 2) : (decimal?)null;
+                    }
+
                     decimal? sum = qryMeasureValues.Sum( a => a.YValue );
                     metricYTDData.CumulativeValue = sum.HasValue ? Math.Round( sum.Value, roundYValues ? 0 : 2 ) : (decimal?)null;
 
@@ -186,6 +197,24 @@ namespace Rock.Rest.Controllers
         /// </value>
         [DataMember]
         public DateTime LastValueDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the previous value.
+        /// </summary>
+        /// <value>
+        /// The last value.
+        /// </value>
+        [DataMember]
+        public object PreviousValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last value date.
+        /// </summary>
+        /// <value>
+        /// The last value date.
+        /// </value>
+        [DataMember]
+        public DateTime PreviousValueDate { get; set; }
 
         /// <summary>
         /// Gets or sets the cumulative value.


### PR DESCRIPTION
## Proposed Changes

This change simply surfaces the value and date of the previous metric value to the lava of the liquid dashboard widget, for determining comparisons.

## Types of changes

What types of changes does your code introduce to Rock?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)