### PR TITLE
Added missing new lines in excel cells. 

### DIFF
--- a/Rock/Web/UI/Controls/Grid/RockLiteralField.cs
+++ b/Rock/Web/UI/Controls/Grid/RockLiteralField.cs
@@ -63,7 +63,7 @@ namespace Rock.Web.UI.Controls
         public override object GetExportValue( GridViewRow row, DataControlFieldCell dataControlFieldCell )
         {
             var literal = dataControlFieldCell.FindControl( this.ID ) as Literal;
-            return literal?.Text.StripHtml();
+            return literal?.Text.ConvertBrToCrLf().StripHtml();
         }
 
         /// <summary>

--- a/Rock/Web/UI/Controls/Grid/RockTemplateField.cs
+++ b/Rock/Web/UI/Controls/Grid/RockTemplateField.cs
@@ -103,7 +103,7 @@ namespace Rock.Web.UI.Controls
             var textControls = dataControlFieldCell.ControlsOfTypeRecursive<Control>().OfType<ITextControl>();
             if ( textControls.Any() )
             {
-                return textControls.Select( a => a.Text.StripHtml() ).Where( t => !string.IsNullOrWhiteSpace( t ) ).ToList().AsDelimited( string.Empty ).ReverseCurrencyFormatting();
+                return textControls.Select( a => a.Text.ConvertBrToCrLf().StripHtml() ).Where( t => !string.IsNullOrWhiteSpace( t ) ).ToList().AsDelimited( string.Empty ).ReverseCurrencyFormatting();
             }
 
             return null;


### PR DESCRIPTION
## Proposed Changes
This changes the GetExportValue method of the Rock Literal Field and the Rock Template Field to turn `<br>'s` to `\r\n` before stripping the HTML. The intention is to fix the issue with addresses and other html formatted content to export values more similarly to what is expected.
Fixes: #4226

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
I opted to insert .ConvertBrToCrLf() before the .StripHtml(). This was as drastic as I wanted to get in this PR.