### PR TITLE
Fixed incorrect data source for grouptype drop down list

### DIFF
--- a/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
+++ b/RockWeb/Blocks/Groups/GroupDetail.ascx.cs
@@ -1284,7 +1284,7 @@ namespace RockWeb.Blocks.Groups
             int? parentGroupGroupTypeId = null;
             if ( parentGroupId.HasValue )
             {
-                parentGroupGroupTypeId = new GroupService( rockContext ).GetSelect( parentGroupId.Value, s => ( int? ) s.ParentGroup.GroupTypeId );
+                parentGroupGroupTypeId = new GroupService( rockContext ).GetSelect( parentGroupId.Value, s => ( int? ) s.GroupTypeId );
             }
 
             var groupTypeQry = GetAllowedGroupTypes( GroupTypeCache.Get( parentGroupGroupTypeId ?? 0 ), rockContext );


### PR DESCRIPTION
## Proposed Changes
In the Rock 1.10.3 version of the group detail block the group type drop down list currently shows the applicable group types children of the parent's parent instead of children of the parent. (That's a mouth full.) We noticed this AFTER we pulled in the fix for #4217. This fixes the typo that fixed the typo.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)