### PR TITLE
Properly close the modal backdrop if there is an owner

### DIFF
--- a/RockWeb/Scripts/Rock/Controls/modal.js
+++ b/RockWeb/Scripts/Rock/Controls/modal.js
@@ -131,7 +131,7 @@
                 $('.modal-backdrop').each(function () {
                     const $modalBackdrop = $(this);
                     var $owner = $('#' + $modalBackdrop.attr('data-modal-id'));
-                    var hasOwner = $owner.length > 0;
+                    var hasOwner = $owner.selector.length > 0;
 
                     if (hasOwner && !$owner.is(':visible')) {
                         $modalBackdrop.remove();


### PR DESCRIPTION
## Proposed Changes

We are experiencing problems with modals (particularly in Attended Checkin) where when the modal is closed the backdrop continues to stay active thereby making the page unusable until we refresh. What was happening is that a modal backdrop `<div>` was being added right before the end `</body>` tag and when the modal was closed the backdrop was not being removed.

This change looks at the `$owner.selector.length` (instead of `$owner.length`) to determine if there is an owner, which allows the modal backdrop to be correctly removed. 

Fixes: #

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)