### PR TITLE
- The Communication Detail screen will no longer fail to load if the recipient list times out.

### DIFF
--- a/RockWeb/Blocks/Communication/CommunicationDetail.ascx.cs
+++ b/RockWeb/Blocks/Communication/CommunicationDetail.ascx.cs
@@ -1718,7 +1718,10 @@ namespace RockWeb.Blocks.Communication
             }
             catch ( Exception ex )
             {
-                throw new Exception( "An unexpected error occurred while building the Recipients List.", ex );
+                ExceptionLogService.LogException( ex );
+                nbAnalyticsNotAvailable.Visible = true;
+                nbAnalyticsNotAvailable.Text = "An unexpected error occurred while building the Recipients List.";
+                return;
             }
 
             // If the grid is sorted by a communication-specific column, apply the sort now.


### PR DESCRIPTION
## Proposed Changes

Before 10.2 fixed the slow load times of the recipient list, that list timing out prevented a large communication from being approved for sending. Although timeouts are less likely now, the error should still be handled.

This change will allow a message with a large recipient list to still be approved even if it times out when loading.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)