### PR TITLE
+ Fixes incorrect sorting on Attribute Values in LinqExtensions (Fixes #4332)

### DIFF
--- a/Rock/Utility/ExtensionMethods/LinqExtensions.cs
+++ b/Rock/Utility/ExtensionMethods/LinqExtensions.cs
@@ -16,7 +16,6 @@
 //
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Data.Entity;
 using System.Linq;
 using System.Linq.Expressions;
@@ -360,27 +359,26 @@ namespace Rock
         /// <returns></returns>
         public static IOrderedQueryable<T> Sort<T>( this IQueryable<T> source, Rock.Web.UI.Controls.SortProperty sortProperty )
         {
-            if ( sortProperty.Property.StartsWith("attribute:") )
+            if ( sortProperty.Property.StartsWith( "attribute:" ) && source.Any() )
             {
-                var itemType = typeof(T);
-                var attributeCache = AttributeCache.Get(sortProperty.Property.Substring(10).AsInteger());
-                if ( attributeCache != null && typeof(IModel).IsAssignableFrom(typeof(T)) )
+                var itemType = typeof( T );
+                var attributeCache = AttributeCache.Get( sortProperty.Property.Substring( 10 ).AsInteger() );
+                if ( attributeCache != null && typeof( IModel ).IsAssignableFrom( typeof( T ) ) )
                 {
                     List<int> ids = new List<int>();
                     var models = new List<IModel>();
-                    source.ToList().ForEach(i => models.Add(i as IModel));
+                    source.ToList().ForEach( i => models.Add( i as IModel ) );
 
                     using ( var rockContext = new RockContext() )
                     {
                         //Check if Attribute Entity Type is same as Source Entity Type
                         var type = models.First().GetType();
-                        EntityType modelEntity = new EntityTypeService(rockContext).Queryable().FirstOrDefault(e => e.Name == type.BaseType.FullName);
+                        EntityTypeCache modelEntity = EntityTypeCache.Get( type );
                         PropertyInfo modelProperty = null;
-                        string modelPropPK = "";
                         //Same Entity Type
                         if ( modelEntity != null && modelEntity.Id == attributeCache.EntityTypeId )
                         {
-                            ids = models.Select(m => m.Id).ToList();
+                            ids = models.Select( m => m.Id ).ToList();
                         }
                         //Different Entity Types
                         else if ( modelEntity != null )
@@ -388,47 +386,41 @@ namespace Rock
                             //Search the entity properties for a matching entity and save the property information and primary key name
                             foreach ( var propertyInfo in type.GetProperties() )
                             {
-                                var propertyEntity = new EntityTypeService(rockContext).Queryable().FirstOrDefault(e => e.Name == propertyInfo.PropertyType.FullName);
+                                var propertyEntity = new EntityTypeService( rockContext ).Queryable().FirstOrDefault( e => e.Name == propertyInfo.PropertyType.FullName );
                                 if ( propertyEntity != null && propertyEntity.Id == attributeCache.EntityTypeId )
                                 {
-                                    Object obj = models.First().GetPropertyValue(propertyInfo.Name);
-                                    foreach ( var prop in obj.GetType().GetProperties() )
-                                    {
-                                        if ( prop.GetCustomAttribute(typeof(KeyAttribute)) != null )
-                                        {
-                                            modelProperty = propertyInfo;
-                                            modelPropPK = prop.Name;
-                                            ids = models.Select(m => Int32.Parse(prop.GetValue(m.GetPropertyValue(propertyInfo.Name)).ToString())).ToList();
-                                        }
-                                    }
+                                    Object obj = models.First().GetPropertyValue( propertyInfo.Name );
+                                    var prop = obj.GetType().GetProperty( "Id" );
+                                    modelProperty = propertyInfo;
+                                    ids = models.Select( m => Int32.Parse( prop.GetValue( m.GetPropertyValue( propertyInfo.Name ) ).ToString() ) ).ToList();
                                 }
                             }
                         }
                         var field = attributeCache.FieldType.Field;
 
-                        foreach ( var attributeValue in new AttributeValueService(rockContext)
+                        foreach ( var attributeValue in new AttributeValueService( rockContext )
                             .Queryable().AsNoTracking()
-                            .Where(v =>
-                               v.AttributeId == attributeCache.Id &&
-                               v.EntityId.HasValue &&
-                               ids.Contains(v.EntityId.Value))
+                            .Where( v =>
+                                v.AttributeId == attributeCache.Id &&
+                                v.EntityId.HasValue &&
+                                ids.Contains( v.EntityId.Value ) )
                             .ToList() )
                         {
                             IModel model = null;
                             if ( modelEntity != null && modelEntity.Id == attributeCache.EntityTypeId )
                             {
-                                model = models.FirstOrDefault(m => m.Id == attributeValue.EntityId.Value);
+                                model = models.FirstOrDefault( m => m.Id == attributeValue.EntityId.Value );
                             }
                             else if ( modelEntity != null )
                             {
                                 //Use the model property and primary key name to get the foreign key EntityId refers to
-                                model = models.FirstOrDefault(m =>
+                                model = models.FirstOrDefault( m =>
                                 {
-                                    var obj = m.GetPropertyValue(modelProperty.Name);
-                                    PropertyInfo prop = obj.GetType().GetProperty(modelPropPK);
-                                    string val = prop.GetValue(obj).ToString();
-                                    return Int32.Parse(val) == attributeValue.EntityId.Value;
-                                });
+                                    var obj = m.GetPropertyValue( modelProperty.Name );
+                                    PropertyInfo prop = obj.GetType().GetProperty( "Id" );
+                                    string val = prop.GetValue( obj ).ToString();
+                                    return Int32.Parse( val ) == attributeValue.EntityId.Value;
+                                } );
                             }
                             else
                             {
@@ -437,7 +429,7 @@ namespace Rock
                             }
                             if ( model != null )
                             {
-                                model.CustomSortValue = field.SortValue(null, attributeValue.Value, attributeCache.QualifierValues);
+                                model.CustomSortValue = field.SortValue( null, attributeValue.Value, attributeCache.QualifierValues );
                             }
                         }
                     }
@@ -445,18 +437,18 @@ namespace Rock
                     var result = new List<T>();
                     if ( sortProperty.Direction == SortDirection.Ascending )
                     {
-                        models.OrderBy(m => m.CustomSortValue).ToList().ForEach(m => result.Add((T)m));
+                        models.OrderBy( m => m.CustomSortValue ).ToList().ForEach( m => result.Add( (T)m ) );
                     }
                     else
                     {
-                        models.OrderByDescending(m => m.CustomSortValue).ToList().ForEach(m => result.Add((T)m));
+                        models.OrderByDescending( m => m.CustomSortValue ).ToList().ForEach( m => result.Add( (T)m ) );
                     }
 
-                    return result.AsQueryable().OrderBy(r => 0);
+                    return result.AsQueryable().OrderBy( r => 0 );
                 }
             }
 
-            string[] columns = sortProperty.Property.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] columns = sortProperty.Property.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries );
 
             IOrderedQueryable<T> qry = null;
 
@@ -465,19 +457,19 @@ namespace Rock
                 string column = columns[columnIndex].Trim();
 
                 var direction = sortProperty.Direction;
-                if ( column.ToLower().EndsWith(" desc") )
+                if ( column.ToLower().EndsWith( " desc" ) )
                 {
-                    column = column.Left(column.Length - 5);
+                    column = column.Left( column.Length - 5 );
                     direction = sortProperty.Direction == SortDirection.Ascending ? SortDirection.Descending : SortDirection.Ascending;
                 }
 
                 if ( direction == SortDirection.Ascending )
                 {
-                    qry = ( columnIndex == 0 ) ? source.OrderBy(column) : qry.ThenBy(column);
+                    qry = ( columnIndex == 0 ) ? source.OrderBy( column ) : qry.ThenBy( column );
                 }
                 else
                 {
-                    qry = ( columnIndex == 0 ) ? source.OrderByDescending(column) : qry.ThenByDescending(column);
+                    qry = ( columnIndex == 0 ) ? source.OrderByDescending( column ) : qry.ThenByDescending( column );
                 }
             }
 


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

Solution for #4332 where the attributeValue EntityId was trying to match on the wrong entity type. I added a check to see if the source entity and attribute entity type were the same, if they are not I search the source entity for property of the same type as the attribute entity type and same the property information as well as the property's primary key field. When matching the attributeValue.EntityId I use the correct property and primary key field to match against. 

Fixes: #

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.