### PR TITLE
Fix for #3893

### DIFF
--- a/Rock.Rest/Swagger/SwaggerConfig.cs
+++ b/Rock.Rest/Swagger/SwaggerConfig.cs
@@ -74,7 +74,18 @@ namespace Rock.Rest.Swagger
                          // However, there may be situations (e.g. proxy and load-balanced environments) where this does not
                          // resolve correctly. You can workaround this by providing your own code to determine the root URL.
                          //
-                         //c.RootUrl(req =>
+                         
+                         // when running behind nginx to provide ssl, the default RootUrl seems to get the scheme
+                         // from the external request, but the port from the internal request resulting in urls like:
+                         // https://server.tld:80/api...
+                         // this is my attempted workaround
+                         c.RootUrl( (req) {
+                             var uri = new Uri( request.Url.ToString() );
+                             if ( uri.IsDefaultPort ) {
+                                 return uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped );
+                             }
+                             return uri.Scheme + "://" + uri.GetComponents( UriComponents.HostAndPort, UriFormat.UriEscaped );
+                         });
 
                          // If schemes are not explicitly provided in a Swagger 2.0 document, then the scheme used to access
                          // the docs is taken as the default. If your API supports multiple schemes and you want to be explicit

--- a/Rock/Net/RockRequestContext.cs
+++ b/Rock/Net/RockRequestContext.cs
@@ -119,8 +119,15 @@ namespace Rock.Net
         internal RockRequestContext( HttpRequest request )
         {
             CurrentUser = UserLoginService.GetCurrentUser( false );
-
+            
+            // when running behind nginx to provide ssl, the default RootUrlPath seems to get the scheme
+            // from the external request, but the port from the internal request resulting in urls like:
+            // https://server.tld:80/api...
+            // this is my attempted workaround
             var uri = new Uri( request.Url.ToString() );
+            if ( uri.IsDefaultPort ) {
+              RootUrlPath = uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped ) + request.ApplicationPath;
+            }
             RootUrlPath = uri.Scheme + "://" + uri.GetComponents( UriComponents.HostAndPort, UriFormat.UriEscaped ) + request.ApplicationPath;
 
             ClientInformation = new ClientInformation( request );
@@ -159,8 +166,15 @@ namespace Rock.Net
         internal RockRequestContext( HttpRequestMessage request )
         {
             CurrentUser = UserLoginService.GetCurrentUser( false );
-
+            
+            // when running behind nginx to provide ssl, the default RootUrlPath seems to get the scheme
+            // from the external request, but the port from the internal request resulting in urls like:
+            // https://server.tld:80/api...
+            // this is my attempted workaround
             var uri = request.RequestUri;
+            if ( uri.IsDefaultPort ) {
+              RootUrlPath = uri.Scheme + "://" + uri.GetComponents( UriComponents.Host, UriFormat.UriEscaped );
+            }
             RootUrlPath = uri.Scheme + "://" + uri.GetComponents( UriComponents.HostAndPort, UriFormat.UriEscaped );
 
             ClientInformation = new ClientInformation( request );


### PR DESCRIPTION
closing #3893 

Swagger RootUrl seems to pick up the scheme from the request url, but then generates a port based on the internal (behind the proxy) url resulting in urls like this:

`https://rockserver.example.com:80`