### PR TITLE
Added ContentItemById and ContentItemByGuid lava filters

### DIFF
--- a/Rock/Lava/RockFilters.cs
+++ b/Rock/Lava/RockFilters.cs
@@ -2441,6 +2441,58 @@ namespace Rock.Lava
                 PersonService.DeleteUserPreference( person, settingKey );
             }
         }
+        
+        /// <summary>
+        /// Content Channel Item the by identifier.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="input">The input.</param>
+        /// <returns></returns>
+        public static object ContentItemById( DotLiquid.Context context, object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            int contentChannelItemId = -1;
+
+            if ( !Int32.TryParse( input.ToString(), out contentChannelItemId ) )
+            {
+                return null;
+            }
+
+            var rockContext = new RockContext();
+
+            return new ContentChannelItemService( rockContext ).Get( contentChannelItemId );
+        }
+
+        /// <summary>
+        /// Content Channel Item the by unique identifier.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="input">The input.</param>
+        /// <returns></returns>
+        public static object ContentItemByGuid( DotLiquid.Context context, object input )
+        {
+            if ( input == null )
+            {
+                return null;
+            }
+
+            Guid? contentChannelItemGuid = input.ToString().AsGuidOrNull();
+
+            if ( contentChannelItemGuid.HasValue )
+            {
+                var rockContext = new RockContext();
+
+                return new ContentChannelItemService( rockContext ).Get( contentChannelItemGuid.Value );
+            }
+            else
+            {
+                return null;
+            }
+        }
 
         /// <summary>
         /// Persons the by identifier.


### PR DESCRIPTION
## Proposed Changes

This PR adds two new lava filters for use around Content Channel Items. The `ContentItemByGuid` filter is especially useful when used in conjunction with the Content Channel Item attribute, as that attribute does not currently support returning the entire content item object.

The `ContentItemById` filter can be helpful when wanting to reference or use data from a specific content item within the static content of a page, without having to write out or use the full entity command.

Ex: 
`{{ item | Attribute:'ContentChannelItem','Object' }}`
does not work (currently).

So instead...
`{{ item | Attribute:'ContentChannelItem','RawValue' | ContentItemByGuid }}`
or

```
{% assign item = 1234 | ContentItemById %}
Check out this story from {{ item | Attribute:'Author' }}, called "{{ item.Title }}".
```

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Documentation
Assuming we could add a "Content Channel Item" section under filters in the lava docs, or just list these under "Other".

**ContentItemById**
Returns a full content channel item object from the Id of the content channel item.
Example: 
```
{% assign item = 1234 | ContentItemById %}
Check out this story from {{ item | Attribute:'Author' }}, called "{{ item.Title }}".
```

**ContentItemByGuid**
Returns a full content channel item object from the Guid of the content channel item.
Example: 
```
{% assign relatedItem = item | Attribute:'RelatedContentChannelItem','Guid' | ContentItemByGuid %}
Check out this related story, called "{{ relatedItem.Title }}".
```