### PR TITLE
Added ability to specify Entity Context URL values by Guid.

### DIFF
--- a/Rock/Data/Entity.cs
+++ b/Rock/Data/Entity.cs
@@ -576,12 +576,21 @@ namespace Rock.Data
     internal class KeyEntity
     {
         public string Key { get; set; }
-        public int Id { get; set; }
+
+        public int? Id { get; set; }
+
+        public Guid? Guid { get; set; }
+
         public IEntity Entity { get; set; }
 
         public KeyEntity( int id )
         {
             Id = id;
+        }
+
+        public KeyEntity( Guid guid )
+        {
+            Guid = guid;
         }
 
         public KeyEntity( string key )

--- a/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
+++ b/RockWeb/Blocks/Crm/PersonDetail/GroupMembers.ascx.cs
@@ -620,8 +620,15 @@ namespace RockWeb.Blocks.Crm.PersonDetail
         /// <returns>a link to the profile page of the given person</returns>
         protected string FormatPersonLink( string personId )
         {
+            var currentPersonId = Person.Id.ToString();
+
+            if ( PageCache.PageContexts.ContainsKey( Person.TypeName ) )
+            {
+                currentPersonId = PageParameter( PageCache.PageContexts[Person.TypeName] );
+            }
+
             // Look for a subpage route (anything after the "/Person/{id}" part of the URL)
-            var subpageRoute = Request.Url.AbsolutePath.Replace( ResolveRockUrl( string.Format( "~/Person/{0}", Person.Id ) ), "" );
+            var subpageRoute = Request.Url.AbsolutePath.Replace( ResolveRockUrl( string.Format( "~/Person/{0}", currentPersonId ) ), "" );
 
             // If the path is different, then append it onto the link
             if ( subpageRoute != Request.Url.AbsolutePath )


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

With security becoming more and more a concern these days, we wanted to stop using Id numbers for our Context URL values in certain places. For example, in our Small Group Locator pages, we want to use an HTML block to display additional information about the group passed in the URL. This is currently passed by Id number as that is what Context uses. But in this case, we don't want the user to be able to start passing in random Group Ids and potentially find sensitive information (since groups are used everywhere).

We could get around this by using entity commands as well, but thought this would be a feature that others would benefit from as well.

This is a bit security by obscurity since the same query string parameter accepts both Guid values as well as integer values. But our intention is to actually change the key name  to imply a Guid to make the user think they can't just easily change the value:

```
http://www.example.org/page/123?GroupGuid=07f063c0-0661-462e-971e-d67cd574d1a9
```

Instead of:

```
http://www.example.org/page/123?GroupId=47
```

To be clear about the above, if we decided to just use `Group` as the parameter name, then both of these would be valid:

```
http://www.example.org/page/123?Group=07f063c0-0661-462e-971e-d67cd574d1a9
http://www.example.org/page/123?Group=47
```

But as I said, in our hope is that the user sees a Guid value and doesn't bother to try changing it to an integer value.

Fixes: #

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, ~which has been approved by the core team~)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

Security could be improved by checking if the context key name ends in `Guid` and if so don't allow integer values - but that does have the potential of breaking existing pages where they accidentally used a query string parameter name ending in `Guid` even though they are passing integer values.

Another option would be to modify the Context Parameters UI and stored data to allow the user to select if they want to allow Integer Id values, Guid values, or both and then enforce those choices.

## Documentation

https://community.rockrms.com/documentation/bookcontent/14/206#usingcontext should probably be updated to mention that Guid values are allowed in addition to integer values.

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.