### PR TITLE
Added job to inactivate phone numbers based on Twillo's deactivated numbers API

### DIFF
--- a/Rock/Jobs/ProcessTwilioDeactivatedNumbers.cs
+++ b/Rock/Jobs/ProcessTwilioDeactivatedNumbers.cs
@@ -1,0 +1,297 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.ComponentModel;
+using System.Data.Entity;
+using System.Linq;
+using System.Text;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+
+using Newtonsoft.Json;
+using Quartz;
+using RestSharp;
+using RestSharp.Authenticators;
+
+namespace Rock.Jobs
+{
+    /// <summary>
+    /// Compares phone numbers in your Rock database to Twilio's daily deactivated numbers list.
+    /// </summary>
+    /// <seealso cref="Quartz.IJob" />
+    [DisplayName( "Process Twilio Deactivated Numbers" )]
+    [Description( "Compares phone numbers in your Rock database to Twilio's daily deactivated numbers list." )]
+
+    [CustomRadioListField( "Deactivated Number Action",
+        Description = "What would you like to do with any matched numbers?",
+        ListSource = "Disable SMS,Delete Number",
+        IsRequired = true,
+        DefaultValue = "Disable SMS",
+        Order = 0,
+        Key = AttributeKey.MatchAction )]
+    [TextField( "Account SID",
+        Description = "Your Twilio Account SID (find at https://www.twilio.com/user/account)",
+        IsRequired = true,
+        Order = 1,
+        Key = AttributeKey.TwilioAccountSid )]
+    [TextField( "Auth Token",
+        Description = "Your Twilio Account Token",
+        IsRequired = true,
+        Order = 2,
+        Key = AttributeKey.TwilioAuthToken )]
+    [DisallowConcurrentExecution]
+    public class ProcessTwilioDeactivatedNumbers : IJob
+    {
+        /// <summary>
+        /// Keys for DataMap Field Attributes.
+        /// </summary>
+        private static class AttributeKey
+        {
+            public const string MatchAction = "MatchAction";
+            public const string TwilioAccountSid = "TwilioAccountSid";
+            public const string TwilioAuthToken = "TwilioAuthToken";
+        }
+
+        /// <summary>
+        /// How many numbers to process at a time
+        /// </summary>
+        private const int BATCH_SIZE = 500;
+
+        /// <summary>
+        /// Maximum number of days back to try for results before giving up
+        /// </summary>
+        private const int MAX_DAYS_BACK = 3;
+
+        /// <summary>
+        /// Empty constructor for job initialization
+        /// <para>
+        /// Jobs require a public empty constructor so that the
+        /// scheduler can instantiate the class whenever it needs.
+        /// </para>
+        /// </summary>
+        public ProcessTwilioDeactivatedNumbers()
+        {
+        }
+
+        /// <summary>
+        /// Executes the specified context.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public void Execute(IJobExecutionContext context)
+        {
+            JobDataMap dataMap = context.JobDetail.JobDataMap;
+            var accountSid = dataMap.GetString( AttributeKey.TwilioAccountSid );
+            var authToken = dataMap.GetString( AttributeKey.TwilioAuthToken );
+            var matchAction = dataMap.GetString( AttributeKey.MatchAction );
+
+            context.UpdateLastStatusMessage( "Connecting to Twilio API." );
+
+            var client = new RestClient
+            {
+                BaseUrl = new Uri( "https://messaging.twilio.com/v1" ),
+                Authenticator = new HttpBasicAuthenticator( accountSid, authToken ),
+                FollowRedirects = false
+            };
+
+            var daysBack = 1;
+            var downloadLink = string.Empty;
+
+            while ( daysBack <= MAX_DAYS_BACK && downloadLink.IsNullOrWhiteSpace() )
+            {
+                downloadLink = GetDownloadLink( client, RockDateTime.Today.AddDays( -1 * daysBack ), context.UpdateLastStatusMessage );
+                daysBack++;
+            }
+
+            if ( downloadLink.IsNullOrWhiteSpace() )
+            {
+                throw new JobExecutionException( $"Unable to get a deactivated number list from Twilio API for any of the past {daysBack} days." );
+            }
+
+            context.UpdateLastStatusMessage( "Downloading the deactivations list." );
+
+            var deactivatedNumbers = GetDeactivatedNumbers( downloadLink );
+
+            context.UpdateLastStatusMessage( "Download complete, beginning processing." );
+
+            var totalNumbers = deactivatedNumbers.Count();
+            var numbersProcessed = 0;
+            var numbersUpdated = 0;
+
+            using ( RockContext rockContext = new RockContext() )
+            {
+                var phoneNumberService = new PhoneNumberService( rockContext );
+
+                var numbersToCheck = deactivatedNumbers.Take( BATCH_SIZE );
+                while ( numbersToCheck.Any() )
+                {
+                    context.UpdateLastStatusMessage( string.Format(
+                        "Processing {0}-{1} of {2} deactivated numbers.",
+                        numbersProcessed,
+                        numbersProcessed + BATCH_SIZE,
+                        totalNumbers ) );
+
+                    ProcessPhoneNumbers( phoneNumberService, numbersToCheck, matchAction, out int updated );
+
+                    numbersUpdated += updated;
+                    numbersProcessed += BATCH_SIZE;
+                    numbersToCheck = deactivatedNumbers.Skip( numbersProcessed ).Take( BATCH_SIZE );
+                }
+
+                rockContext.SaveChanges();
+            }
+
+            context.UpdateLastStatusMessage( "Processing complete." );
+
+            context.Result = string.Format(
+                "{0} {1} deactivated {2}",
+                matchAction == "Delete Number" ? "Deleted" : "Disabled",
+                numbersUpdated,
+                "number".PluralizeIf( numbersUpdated != 1 ) );
+        }
+
+        /// <summary>
+        /// Using the provided <see cref="RestClient"/>, attempt to query the Twilio API
+        /// for a download link for the list of deactivated numbers on the provided <see cref="RockDateTime"/>.
+        /// </summary>
+        /// <param name="client">The rest client</param>
+        /// <param name="date">The date to download</param>
+        /// <param name="updateLastStatusMessage">A reference to context.UpdateStatusMessage so we can log progress</param>
+        /// <returns>If successful in getting a link, returns the link. Null otherwise.</returns>
+        private string GetDownloadLink(RestClient client, DateTime date, Action<string> updateLastStatusMessage)
+        {
+            string downloadLink;
+            var request = new RestRequest( "/Deactivations", Method.GET );
+            request.AddParameter( "Date", date.ToString( "yyyy-MM-dd" ), ParameterType.QueryString );
+
+            var response = client.Execute( request );
+
+            if ( response.ResponseStatus != ResponseStatus.Completed )
+            {
+                throw new JobExecutionException( $"Twilio API error: {response.ErrorMessage}" );
+            }
+
+            if ( response.StatusCode == System.Net.HttpStatusCode.TemporaryRedirect )
+            {
+                var downloadResponse = JsonConvert.DeserializeObject<TwilioDeactivationsResponse>( response.Content );
+                downloadLink = downloadResponse.DownloadLink;
+                updateLastStatusMessage( "Got download link from Twilio API." );
+                return downloadLink;
+            }
+            else if ( response.StatusCode == System.Net.HttpStatusCode.BadRequest )
+            {
+                var errorResponse = JsonConvert.DeserializeObject<TwilioErrorResponse>( response.Content );
+
+                if ( errorResponse.Code == 30113 )
+                {
+                    updateLastStatusMessage( $"Twilio doesn't have data for {date:MMM. d} yet." );
+                    return null;
+                }
+            }
+
+            updateLastStatusMessage( "Unexpected response from Twilio API." );
+            throw new JobExecutionException( string.Format( "Unexpected response from Twilio API: {0} => {1}", client.BuildUri( request ), response.Content ) );
+        }
+
+        /// <summary>
+        /// Download the list of deactivated phone numbers from the provided URL.
+        /// </summary>
+        /// <param name="downloadLink">Link to the file to download</param>
+        /// <returns>A queryable with 1 item per line of the file</returns>
+        private IQueryable<string> GetDeactivatedNumbers(string downloadLink)
+        {
+            var uri = new Uri( downloadLink );
+            var origin = uri.GetLeftPart( UriPartial.Authority );
+            var client = new RestClient( origin );
+            var request = new RestRequest( uri.PathAndQuery );
+
+            byte[] fileResponse = client.DownloadData( request );
+
+            if ( fileResponse.IsNull() || fileResponse.Length == 0 )
+            {
+                throw new JobExecutionException( "Error downloading the deactivated numbers list." );
+            }
+
+            var parsedList = Encoding.ASCII.GetString( fileResponse ).Split( '\n' ).AsQueryable<string>();
+
+            if ( parsedList.Count() == 1 )
+            {
+                throw new JobExecutionException( "Error parsing the deactivated numbers list." );
+            }
+
+            return parsedList;
+        }
+
+        /// <summary>
+        /// Using the provided <see cref="PhoneNumberService"/>, find any matching numbers
+        /// in <paramref name="numbersToCheck"/>, and apply <paramref name="matchAction"/> to them.
+        /// </summary>
+        /// <param name="phoneNumberService">The phone number service</param>
+        /// <param name="numbersToCheck">The numbers to check for</param>
+        /// <param name="matchAction">What to do with any matches</param>
+        /// <param name="updated">Out param for how many numbers were updated</param>
+        private void ProcessPhoneNumbers(PhoneNumberService phoneNumberService, IQueryable<string> numbersToCheck, string matchAction, out int updated)
+        {
+            updated = 0;
+            var matchingNumbers = phoneNumberService.Queryable().Where( pn => numbersToCheck.Contains( pn.FullNumber ) );
+
+            if ( matchingNumbers.Any() )
+            {
+                if ( matchAction == "Delete Number" )
+                {
+                    var numbersToUpdate = matchingNumbers.ToList();
+
+                    // Delete any matching numbers
+                    phoneNumberService.DeleteRange( numbersToUpdate );
+                    updated += numbersToUpdate.Count();
+                }
+                else
+                {
+                    var numbersToUpdate = matchingNumbers.Where( pn => pn.IsMessagingEnabled ).ToList();
+
+                    // Disable messaging on any matching numbers
+                    numbersToUpdate.ForEach( pn => pn.IsMessagingEnabled = false );
+                    updated += numbersToUpdate.Count();
+                }
+            }
+        }
+
+        private class TwilioDeactivationsResponse
+        {
+            // Twilio's API returns a signed link to download a .txt file from S3
+            [JsonProperty( PropertyName = "redirect_to", Required = Required.Always )]
+            public string DownloadLink { get; set; }
+        }
+
+        private class TwilioErrorResponse
+        {
+            [JsonProperty( PropertyName = "code", Required = Required.Always )]
+            public int Code { get; set; }
+
+            [JsonProperty( PropertyName = "status" )]
+            public int Status { get; set; }
+
+            [JsonProperty( PropertyName = "message" )]
+            public string Message { get; set; }
+
+            [JsonProperty( PropertyName = "more_info" )]
+            public string MoreInfo { get; set; }
+        }
+    }
+}

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -551,6 +551,7 @@
     <Compile Include="Jobs\PostV110DataMigrationsResponseCodeIndex.cs" />
     <Compile Include="Jobs\PostV110DataMigrationsUpdateRelatedDataViewId.cs" />
     <Compile Include="Jobs\PostV12DataMigrationsAddInteractionIndexes.cs" />
+    <Compile Include="Jobs\ProcessTwilioDeactivatedNumbers.cs" />
     <Compile Include="Jobs\RockJobWarningException.cs" />
     <Compile Include="Jobs\CampaignManager.cs" />
     <Compile Include="Jobs\SendGroupAttendanceDigest.cs" />


### PR DESCRIPTION
## Proposed Changes

Twilio recently released a new API to retrieve a list of deactivated phone numbers. This PR adds a job to retrieve this list of deactivated numbers, and use it to either inactivate or delete any matching numbers in Rock.

What is a deactivated phone number?

> This resource lets you retrieve a list of United States phone numbers that have been deactivated by mobile carriers. These phone numbers are no longer in service for the subscriber who used to own that number. Twilio will update the set of available reports every day. These should be used periodically to remove these phone numbers from your opted-in subscriber list.
(From https://www.twilio.com/docs/sms/deactivated-phone-numbers)

> When a mobile subscriber either terminates their service or transfers their number to a different wireless carrier, this phone number is "deactivated" on their wireless carrier. These numbers eventually get recycled and are assigned to new subscribers. What this means is that a number you believe had opted into your programs now belongs to a different end user who has not opted into your messaging campaign.
(From https://support.twilio.com/hc/en-us/articles/360042744973-Handling-Deactivated-Phone-Numbers)

Fixes: #N/A
Would close this /idea https://community.rockrms.com/ideas/1542/implement-twilio-deactivations-api

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, ~which has been approved by the core team~)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] * I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

*Because this job calls an API that requires authentication, I'm not sure how to write an automated test for it. However, I have manually tested it on v1.11.0.3, v1.11.1.1, and develop (v1.12.0.5).

## Further comments
Twilio's API provides a list of all the numbers that have been reported as deactivated on a specific day, therefore the job will have to run daily to ensure that all deactivated numbers are detected. 

I believe this API call is free. At least I haven't been able to find any mention of price in their documentation, and I don't see any charges on our bill from my past 2 weeks of testing it.

## Documentation
This job would need to be added to the table on [this page](https://community.rockrms.com/Rock/BookContent/9#jobs)

There should also be a section, either in the communications manual or the admin manual, mentioning what deactivated numbers are, that this job exists, and how to configure it.
<details>
<summary>Here is some rough copy for that section</summary>

## Deactivated Phone Numbers

### What is a deactivated phone number?

When a mobile subscriber either terminates their service or transfers their number to a different wireless carrier, this phone number is "deactivated" on their wireless carrier. These numbers eventually get recycled and are assigned to new subscribers. What this means is that a number you believe had opted into your programs now belongs to a different end user who has not opted into your messaging campaign. (See https://support.twilio.com/hc/en-us/articles/360042744973-Handling-Deactivated-Phone-Numbers for more information on deactivated numbers.)

### The Process Twilio Deactivated Numbers Job

Rock ships with a job to help you with this problem. Every day Twilio posts a list of all the numbers that have been reported as deactivated by wireless carriers that day. The `Process Twilio Deactivated Numbers` job retrieves that list, and searches your Rock database for any numbers that are on it. If it finds a match it will either disable SMS capabilities for that number or delete it completely (it is up to you which action you want to take).

This job is disabled out-of-the-box. To enable it, you will need to edit the job settings and provide your Twilio API information. (See [this section](https://community.rockrms.com/Rock/BookContent/9#configuringajob) for details on how to configure jobs)

*Note:* You do not have to use Twilio as your SMS Transport to be able to use this job. 
</details>

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

<details>
<summary>Migration to add job</summary>

```c#
public partial class AddProcessTwilioDeactivatedNumbersJob : Rock.Migrations.RockMigration
{
    public override void Up()
    {
        Sql( @"IF NOT EXISTS( SELECT [Id] FROM [ServiceJob] WHERE [Class] = 'Rock.Jobs.ProcessTwilioDeactivatedNumbers' AND [Guid] = '69377111-BFA3-4F39-9CBA-6F82032F157A' )
              BEGIN
                  INSERT INTO [ServiceJob] 
                      ( [IsSystem], [IsActive], [Name], [Description], [Class], [CronExpression], [NotificationStatus], [Guid] )
                   VALUES 
                      (0, 0, 'Process Twilio Deactivated Numbers', 'Compares phone numbers in your Rock database to Twilio''s daily deactivated numbers list.', 'Rock.Jobs.ProcessTwilioDeactivatedNumbers','0 0 5 1/1 * ? *', 1, '69377111-BFA3-4F39-9CBA-6F82032F157A')
               END" );
    }

    public override void Down()
    {
        Sql( @"IF EXISTS( SELECT [Id] FROM [ServiceJob] WHERE [Class] = 'Rock.Jobs.ProcessTwilioDeactivatedNumbers' AND [Guid] = '69377111-BFA3-4F39-9CBA-6F82032F157A' )
              BEGIN
                  DELETE [ServiceJob] WHERE [Guid] = '69377111-BFA3-4F39-9CBA-6F82032F157A';
              END" );
    }
}
```
</details>
 
This migration adds the job in a disabled state. If a user wants to use this feature, they will need to enable the job and provide their API access information.