### PR TITLE
Added field type for email address that requires retyping for confirmation

### DIFF
--- a/Rock/Field/Types/EmailConfirmFieldType.cs
+++ b/Rock/Field/Types/EmailConfirmFieldType.cs
@@ -1,0 +1,236 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Web.UI;
+
+using Rock.Reporting;
+using Rock.Web.UI.Controls;
+
+namespace Rock.Field.Types
+{
+    /// <summary>
+    /// Field used to save and display an email address with required confirmation
+    /// </summary>
+    [Serializable]
+    public class EmailConfirmFieldType : FieldType
+    {
+        #region Formatting
+
+        /// <summary>
+        /// Formats the value as HTML.
+        /// </summary>
+        /// <param name="parentControl">The parent control.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="condensed">if set to <c>true</c> [condensed].</param>
+        /// <returns></returns>
+        public override string FormatValueAsHtml( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed = false )
+        {
+            return HtmlFormat( FormatValue( parentControl, value, configurationValues, condensed ) );
+        }
+
+        /// <summary>
+        /// Formats the value as HTML.
+        /// </summary>
+        /// <param name="parentControl">The parent control.</param>
+        /// <param name="entityTypeId">The entity type identifier.</param>
+        /// <param name="entityId">The entity identifier.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="condensed">if set to <c>true</c> [condensed].</param>
+        /// <returns></returns>
+        public override string FormatValueAsHtml( Control parentControl, int? entityTypeId, int? entityId, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed = false )
+        {
+            return HtmlFormat( FormatValue( parentControl, entityTypeId, entityId, value, configurationValues, condensed ) );
+        }
+
+        /// <summary>
+        /// HTMLs the format.
+        /// </summary>
+        /// <param name="formattedValue">The formatted value.</param>
+        /// <returns></returns>
+        private string HtmlFormat( string formattedValue )
+        {
+            if ( string.IsNullOrWhiteSpace( formattedValue ) )
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return string.Format( "<a href='mailto:{0}'>{0}</a>", formattedValue );
+            }
+        }
+
+        /// <summary>
+        /// Returns the field's current value(s)
+        /// </summary>
+        /// <param name="parentControl">The parent control.</param>
+        /// <param name="value">Information about the value</param>
+        /// <param name="configurationValues"></param>
+        /// <param name="condensed">Flag indicating if the value should be condensed (i.e. for use in a grid column)</param>
+        /// <returns></returns>
+        public override string FormatValue( System.Web.UI.Control parentControl, string value, System.Collections.Generic.Dictionary<string, ConfigurationValue> configurationValues, bool condensed )
+        {
+            if ( string.IsNullOrWhiteSpace( value ) )
+            {
+                return string.Empty;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Returns the value that should be used for sorting, using the most appropriate datatype
+        /// </summary>
+        /// <param name="parentControl">The parent control.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <returns></returns>
+        public override object SortValue( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues )
+        {
+            // use the plain email address as the sort value
+            return value;
+        }
+
+        #endregion
+
+        #region Edit Control
+
+        /// <summary>
+        /// Creates the control(s) necessary for prompting user for a new value
+        /// </summary>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="id"></param>
+        /// <returns>
+        /// The control
+        /// </returns>
+        public override Control EditControl( Dictionary<string, ConfigurationValue> configurationValues, string id )
+        {
+            return new EmailConfirmBox { ID = id };
+        }
+
+        /// <summary>
+        /// Reads new values entered by the user for the field
+        /// </summary>
+        /// <param name="control">Parent control that controls were added to in the CreateEditControl() method</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <returns></returns>
+        public override string GetEditValue(Control control, Dictionary<string, ConfigurationValue> configurationValues)
+        {
+            return ( ( EmailConfirmBox ) control ).Text;
+        }
+
+        /// <summary>
+        /// Sets the value.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="value">The value.</param>
+        public override void SetEditValue(Control control, Dictionary<string, ConfigurationValue> configurationValues, string value)
+        {
+            ( ( EmailConfirmBox ) control ).Text = value;
+        }
+
+        /// <summary>
+        /// Tests the value to ensure that it is a valid value.  If not, message will indicate why
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="required"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public override bool IsValid( string value, bool required, out string message )
+        {
+            if ( !string.IsNullOrWhiteSpace( value ) )
+            {
+                Match match = Regex.Match( value, @"\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*" );
+
+                if ( !match.Success )
+                {
+                    message = "The email address provided is not valid.";
+                    return false;
+                }
+            }
+
+            return base.IsValid( value, required, out message );
+        }
+
+        #endregion
+
+        #region Filter Control
+
+        /// <summary>
+        /// Gets the filter value control with the specified FilterMode
+        /// </summary>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="id">The identifier.</param>
+        /// <param name="required">if set to <c>true</c> [required].</param>
+        /// <param name="filterMode">The filter mode.</param>
+        /// <returns></returns>
+        public override Control FilterValueControl( Dictionary<string, ConfigurationValue> configurationValues, string id, bool required, FilterMode filterMode )
+        {
+            var control = new RockTextBox {
+                ID = string.Format( "{0}_ctlCompareValue", id )
+            };
+            control.AddCssClass( "js-filter-control" );
+            return control;
+        }
+
+        /// <summary>
+        /// Gets the filter value value.
+        /// </summary>
+        /// <param name="control">The filter value control.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <returns></returns>
+        public override string GetFilterValueValue(Control control, Dictionary<string, ConfigurationValue> configurationValues)
+        {
+            if ( control is RockTextBox )
+            {
+                var tb = control as RockTextBox;
+                return tb.Text;
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Sets the filter value value.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="value">The value.</param>
+        public override void SetFilterValueValue(Control control, Dictionary<string, ConfigurationValue> configurationValues, string value)
+        {
+            if ( control is RockTextBox )
+            {
+                var tb = control as RockTextBox;
+                tb.Text = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the type of the filter comparison.
+        /// </summary>
+        /// <value>
+        /// The type of the filter comparison.
+        /// </value>
+        public override Model.ComparisonType FilterComparisonType => ComparisonHelper.StringFilterComparisonTypes;
+
+        #endregion
+    }
+}

--- a/Rock/Model/RegistrationTemplateFormField.cs
+++ b/Rock/Model/RegistrationTemplateFormField.cs
@@ -363,7 +363,7 @@ namespace Rock.Model
                     break;
 
                 case RegistrationPersonFieldType.Email:
-                    var tbEmail = new EmailBox
+                    var tbEmail = new EmailConfirmBox
                     {
                         ID = "tbEmail",
                         Label = "Email",

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -545,6 +545,7 @@
     <Compile Include="Data\SaveChangesResult.cs" />
     <Compile Include="Data\SaveChangesArgs.cs" />
     <Compile Include="Field\Types\ConnectionRequestActivityFieldType.cs" />
+    <Compile Include="Field\Types\EmailConfirmFieldType.cs" />
     <Compile Include="Field\Types\LocationListFieldType.cs" />
     <Compile Include="Field\Types\StepFieldType.cs" />
     <Compile Include="Field\Types\InteractionChannelInteractionComponentFieldType.cs" />
@@ -687,6 +688,7 @@
     <Compile Include="Logging\RockLoggerSerilog.cs" />
     <Compile Include="Logging\RockLogger.cs" />
     <Compile Include="Logging\RockLogConfiguration.cs" />
+    <Compile Include="Web\UI\Controls\EmailConfirmBox.cs" />
     <Compile Include="Web\UI\Controls\PageNavButtons.cs" />
     <Compile Include="Web\UI\Controls\Grid\PersonProfileLinkField.cs" />
     <Compile Include="Web\UI\Controls\LocationList.cs" />

--- a/Rock/Web/UI/Controls/EmailConfirmBox.cs
+++ b/Rock/Web/UI/Controls/EmailConfirmBox.cs
@@ -1,0 +1,391 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.ComponentModel;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+
+using Rock;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace Rock.Web.UI.Controls
+{
+    /// <summary>
+    /// 2 email fields that must match to be valid.
+    /// </summary>
+    /// <seealso cref="System.Web.UI.WebControls.CompositeControl" />
+    /// <seealso cref="Rock.Web.UI.Controls.IRockControl" />
+    [ToolboxData( "<{0}:EmailConfirmBox runat=server></{0}:EmailConfirmBox>" )]
+    public class EmailConfirmBox : CompositeControl, IRockControl
+    {
+        #region IRockControl Implementation
+
+        /// <summary>
+        /// Gets or sets the label text.
+        /// </summary>
+        /// <value>
+        /// The label text.
+        /// </value>
+        [Bindable( true )]
+        [Category( "Appearance" )]
+        [DefaultValue( "" )]
+        [Description( "The text for the label." )]
+        public virtual string Label
+        {
+            get
+            {
+                // Suppress this control's label,
+                // since the EmailBoxes have their own labels.
+                return string.Empty;
+            }
+
+            set
+            {
+                EnsureChildControls();
+                _ebPrimary.Label = value;
+                _ebConfirm.Label = "Confirm " + value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the help text.
+        /// </summary>
+        /// <value>
+        /// The help text.
+        /// </value>
+        [Bindable( true )]
+        [Category( "Appearance" )]
+        [DefaultValue( "" )]
+        [Description( "The help block." )]
+        public virtual string Help
+        {
+            get
+            {
+                return HelpBlock != null ? HelpBlock.Text : string.Empty;
+            }
+
+            set
+            {
+                if ( HelpBlock != null )
+                {
+                    HelpBlock.Text = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the warning text.
+        /// </summary>
+        /// <value>
+        /// The warning text.
+        /// </value>
+        [Bindable( true )]
+        [Category( "Appearance" )]
+        [DefaultValue( "" )]
+        [Description( "The warning block." )]
+        public virtual string Warning
+        {
+            get
+            {
+                return WarningBlock != null ? WarningBlock.Text : string.Empty;
+            }
+
+            set
+            {
+                if ( WarningBlock != null )
+                {
+                    WarningBlock.Text = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this is required.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if required; otherwise, <c>false</c>.
+        /// </value>
+        [Bindable( true )]
+        [Category( "Behavior" )]
+        [DefaultValue( "false" )]
+        [Description( "Is the value required?" )]
+        public virtual bool Required
+        {
+            get
+            {
+                return ViewState["Required"] as bool? ?? false;
+            }
+
+            set
+            {
+                ViewState["Required"] = value;
+                EnsureChildControls();
+                _ebPrimary.Required = value;
+                _ebConfirm.Required = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the required error message.  If blank, the LabelName name will be used
+        /// </summary>
+        /// <value>The required error message.</value>
+        public virtual string RequiredErrorMessage
+        {
+            get
+            {
+                return RequiredFieldValidator != null ? RequiredFieldValidator.ErrorMessage : string.Empty;
+            }
+
+            set
+            {
+                if ( RequiredFieldValidator != null )
+                {
+                    RequiredFieldValidator.ErrorMessage = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if ... is valid.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is valid; otherwise, <c>false</c>.</value>
+        public virtual bool IsValid
+        {
+            get
+            {
+                EnsureChildControls();
+                return ( !Required || RequiredFieldValidator == null || RequiredFieldValidator.IsValid ) &&
+                       ( CustomValidator == null || CustomValidator.IsValid ) &&
+                       _ebPrimary.IsValid && _ebConfirm.IsValid;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the form group class.
+        /// </summary>
+        /// <value>
+        /// The form group class.
+        /// </value>
+        public virtual string FormGroupCssClass
+        {
+            get
+            {
+                return ViewState["FormGroupCssClass"] as string ?? string.Empty;
+            }
+
+            set
+            {
+                ViewState["FormGroupCssClass"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the help block.
+        /// </summary>
+        /// <value>
+        /// The help block.
+        /// </value>
+        public virtual HelpBlock HelpBlock { get; set; }
+
+        /// <summary>
+        /// Gets the warning block.
+        /// </summary>
+        /// <value>
+        /// The warning block.
+        /// </value>
+        public virtual WarningBlock WarningBlock { get; set; }
+
+        /// <summary>
+        /// Gets the required field validator.
+        /// </summary>
+        /// <value>
+        /// The required field validator.
+        /// </value>
+        public virtual RequiredFieldValidator RequiredFieldValidator { get; set; }
+
+        /// <summary>
+        /// Gets the compare validator.
+        /// </summary>
+        /// <value>
+        /// The compare validator.
+        /// </value>
+        public virtual CustomValidator CustomValidator { get; set; }
+
+        /// <summary>
+        /// Gets or sets the validation group.
+        /// </summary>
+        /// <value>
+        /// The validation group.
+        /// </value>
+        public virtual string ValidationGroup
+        {
+            get
+            {
+                return ViewState["ValidationGroup"] as string;
+            }
+
+            set
+            {
+                ViewState["ValidationGroup"] = value;
+                EnsureChildControls();
+                _ebPrimary.ValidationGroup = value;
+                _ebConfirm.ValidationGroup = value;
+                CustomValidator.ValidationGroup = value;
+            }
+        }
+
+        /// <summary>
+        /// This is where you implement the simple aspects of rendering your control.  The rest
+        /// will be handled by calling RenderControlHelper's RenderControl() method.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        public virtual void RenderBaseControl(HtmlTextWriter writer)
+        {
+            writer.AddAttribute( "id", this.ClientID );
+            writer.AddAttribute( "class", "js-emailConfirmControl " + this.CssClass );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            _ebPrimary.RenderControl( writer );
+            CustomValidator.RenderControl( writer );
+            _ebConfirm.RenderControl( writer );
+
+            writer.RenderEndTag();
+        }
+
+        #endregion IRockControl Implementation
+
+        #region Constructors
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="EmailConfirmBox"/> class.
+        /// </summary>
+        public EmailConfirmBox() : base()
+        {
+            CustomValidator = new CustomValidator();
+            CustomValidator.ValidationGroup = this.ValidationGroup;
+
+            HelpBlock = new HelpBlock();
+            WarningBlock = new WarningBlock();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The message to show if validation fails
+        /// </summary>
+        public string ValidationMessage { get; set; }
+
+        /// <summary>
+        /// The value of the text 
+        /// </summary>
+        public string Text {
+            get
+            {
+                EnsureChildControls();
+                return _ebPrimary.Text ?? string.Empty;
+            }
+
+            set
+            {
+                EnsureChildControls();
+                _ebPrimary.Text = value;
+                _ebConfirm.Text = value;
+            }
+        }
+
+        private EmailBox _ebPrimary;
+        private EmailBox _ebConfirm;
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad( e );
+
+            EnsureChildControls();
+        }
+
+        /// <summary>
+        /// Called just before rendering begins on the page.
+        /// </summary>
+        /// <param name="e">The EventArgs that describe this event.</param>
+        protected override void OnPreRender(EventArgs e)
+        {
+            base.OnPreRender( e );
+        }
+
+        /// <summary>
+        /// Outputs server control content to a provided <see cref="T:System.Web.UI.HtmlTextWriter" /> object and stores tracing information about the control if tracing is enabled.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:System.Web.UI.HtmlTextWriter" /> object that receives the control content.</param>
+        public override void RenderControl(HtmlTextWriter writer)
+        {
+            if ( this.Visible )
+            {
+                RockControlHelper.RenderControl( this, writer );
+            }
+        }
+
+        /// <summary>
+        /// Called by the ASP.NET page framework to notify server controls that use composition-based implementation to create any child controls they contain in preparation for posting back or rendering.
+        /// </summary>
+        protected override void CreateChildControls()
+        {
+            base.CreateChildControls();
+            Controls.Clear();
+            RockControlHelper.CreateChildControls( this, Controls );
+
+            _ebPrimary = new EmailBox
+            {
+                ID = "ebPrimary",
+                AllowLava = false,
+                AllowMultiple = false,
+                CssClass = "js-primary",
+                Required = Required,
+                ValidationGroup = ValidationGroup
+            };
+            Controls.Add( _ebPrimary );
+
+            _ebConfirm = new EmailBox
+            {
+                ID = "ebConfirm",
+                AllowLava = false,
+                AllowMultiple = false,
+                CssClass = "js-confirm",
+                Required = Required,
+                ValidationGroup = ValidationGroup
+            };
+            Controls.Add( _ebConfirm );
+
+            CustomValidator = new CustomValidator
+            {
+                ID = "cv",
+                ClientValidationFunction = "Rock.controls.emailConfirmControl.clientValidate",
+                ErrorMessage = "Email and confirmation do not match.",
+                CssClass = "validation-error help-inline",
+                Enabled = true,
+                Display = ValidatorDisplay.Dynamic,
+                ValidationGroup = ValidationGroup
+            };
+            Controls.Add( CustomValidator );
+        }
+    }
+}

--- a/Rock/Web/UI/Controls/PreRegistration/ChildRow.cs
+++ b/Rock/Web/UI/Controls/PreRegistration/ChildRow.cs
@@ -38,7 +38,7 @@ namespace Rock.Web.UI.Controls
         private DatePicker _dpBirthdate;
         private GradePicker _ddlGradePicker;
         private PhoneNumberBox _pnbMobile;
-        private EmailBox _ebEmail;
+        private EmailConfirmBox _ebEmail;
         private RockDropDownList _ddlRelationshipType;
         private PlaceHolder _phAttributes;
 
@@ -686,7 +686,7 @@ namespace Rock.Web.UI.Controls
             _ddlGradePicker = new GradePicker { UseAbbreviation = true, UseGradeOffsetAsValue = true };
             _ddlGradePicker.Label = string.Empty;
             _pnbMobile = new PhoneNumberBox();
-            _ebEmail = new EmailBox();
+            _ebEmail = new EmailConfirmBox();
             _ddlRelationshipType = new RockDropDownList();
             _phAttributes = new PlaceHolder();
             _lbDelete = new LinkButton();

--- a/RockWeb/Blocks/CheckIn/AttendanceSelfEntry.ascx
+++ b/RockWeb/Blocks/CheckIn/AttendanceSelfEntry.ascx
@@ -26,7 +26,7 @@
                             <fieldset>
                                 <Rock:RockTextBox ID="tbFirstName" runat="server" Label="First Name" Required="true" ValidationGroup="vgPrimary" />
                                 <Rock:RockTextBox ID="tbLastName" runat="server" Label="Last Name" Required="true" ValidationGroup="vgPrimary" />
-                                <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" Required="false" ValidationGroup="vgPrimary" />
+                                <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" Required="false" ValidationGroup="vgPrimary" />
                                 <Rock:BirthdayPicker ID="bpBirthDay" runat="server" Label="Birthday" ValidationGroup="vgPrimary" />
                                 <asp:Panel ID="pnlPhone" runat="server" CssClass="margin-b-lg">
                                     <Rock:PhoneNumberBox ID="pnbPhone" runat="server" Label="Mobile Phone" ValidationGroup="vgPrimary" />
@@ -55,7 +55,7 @@
                                 <Rock:RockDropDownList ID="ddlRelation" runat="server" Label="Relation" ValidationGroup="vgOther" OnSelectedIndexChanged="ddlRelation_SelectedIndexChanged" AutoPostBack="true" />
                                 <Rock:RockTextBox ID="tbOtherFirstName" runat="server" Label="First Name" Required="true" ValidationGroup="vgOther" />
                                 <Rock:RockTextBox ID="tbOtherLastName" runat="server" Label="Last Name" Required="true" ValidationGroup="vgOther" />
-                                <Rock:EmailBox ID="tbOtherEmail" runat="server" Label="Email" Required="false" ValidationGroup="vgOther" />
+                                <Rock:EmailConfirmBox ID="tbOtherEmail" runat="server" Label="Email" Required="false" ValidationGroup="vgOther" />
                                 <Rock:BirthdayPicker ID="bpOtherBirthDay" runat="server" Label="Birthday" ValidationGroup="vgOther" />
                                 <asp:Panel ID="pnlOtherPhone" runat="server" CssClass="margin-b-lg">
                                     <Rock:PhoneNumberBox ID="pnOtherMobile" runat="server" Label="Mobile Phone" ValidationGroup="vgOther" />

--- a/RockWeb/Blocks/Connection/ConnectionOpportunitySignup.ascx
+++ b/RockWeb/Blocks/Connection/ConnectionOpportunitySignup.ascx
@@ -29,7 +29,7 @@
 
                 <div class="row">
                     <div class="col-md-6">
-                        <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" Required="true" />
+                        <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" Required="true" />
                     </div>
                     <div class="col-md-6">
                         <Rock:CampusPicker ID="cpCampus" runat="server" Label="Campus" Required="true" />

--- a/RockWeb/Blocks/Crm/FamilyPreRegistration.ascx
+++ b/RockWeb/Blocks/Crm/FamilyPreRegistration.ascx
@@ -66,7 +66,7 @@
                                 <Rock:PhoneNumberBox ID="pnMobilePhone1" runat="server" Label="Mobile Phone" />
                             </asp:Panel>
                             <asp:Panel CssClass="col-sm-6" runat="server" ID="pnlEmail1">
-                                <Rock:EmailBox ID="tbEmail1" runat="server" Label="Email" />
+                                <Rock:EmailConfirmBox ID="tbEmail1" runat="server" Label="Email" />
                             </asp:Panel>
                             <Rock:DynamicPlaceholder ID="phAttributes1" runat="server" />
                         </div>
@@ -108,7 +108,7 @@
                                     <Rock:PhoneNumberBox ID="pnMobilePhone2" runat="server" Label="Mobile Phone" />
                                 </asp:Panel>
                                 <asp:Panel CssClass="col-sm-6 js-Adult2Required" runat="server" ID="pnlEmail2">
-                                    <Rock:EmailBox ID="tbEmail2" runat="server" Label="Email" />
+                                    <Rock:EmailConfirmBox ID="tbEmail2" runat="server" Label="Email" />
                                 </asp:Panel>
                                 <Rock:DynamicPlaceholder ID="phAttributes2" runat="server" />
                             </div>

--- a/RockWeb/Blocks/Crm/FamilyPreRegistration.ascx.cs
+++ b/RockWeb/Blocks/Crm/FamilyPreRegistration.ascx.cs
@@ -1549,7 +1549,7 @@ ORDER BY [Text]";
             RockDropDownList ddlGender,
             DatePicker dpBirthDate,
             DefinedValuePicker dvpMaritalStatus,
-            EmailBox tbEmail,
+            EmailConfirmBox tbEmail,
             PhoneNumberBox pnMobilePhone,
             DynamicPlaceholder phAttributes )
         {

--- a/RockWeb/Blocks/Crm/PersonUpdate.Kiosk.ascx
+++ b/RockWeb/Blocks/Crm/PersonUpdate.Kiosk.ascx
@@ -148,7 +148,7 @@
 
                         <div class="row">
                             <div class="col-md-8">
-                                <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" />
+                                <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" />
                             </div>
                             <div class="col-md-4">
                                 <Rock:DatePicker ID="dpBirthdate" runat="server" AllowFutureDateSelection="false"  Label="Birthdate" />

--- a/RockWeb/Blocks/Event/EventCalendarItemPersonalizedRegistration.ascx
+++ b/RockWeb/Blocks/Event/EventCalendarItemPersonalizedRegistration.ascx
@@ -67,7 +67,7 @@
                             <Rock:RockCheckBoxList ID="cblRegistrants" runat="server" Label="Register" RepeatDirection="Horizontal" />
                         </div>
                         <div class="col-md-6">
-                            <Rock:EmailBox ID="ebEmailReminder" runat="server" Label="Email Reminder Address" />
+                            <Rock:EmailConfirmBox ID="ebEmailReminder" runat="server" Label="Email Reminder Address" />
                         </div>
                     </div>
 

--- a/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationEntry.ascx.cs
@@ -5049,7 +5049,7 @@ namespace RockWeb.Blocks.Event
                     break;
 
                 case RegistrationPersonFieldType.Email:
-                    var tbEmail = phRegistrantControls.FindControl( "tbEmail" ) as EmailBox;
+                    var tbEmail = phRegistrantControls.FindControl( "tbEmail" ) as EmailConfirmBox;
                     string email = tbEmail != null ? tbEmail.Text : null;
                     return string.IsNullOrWhiteSpace( email ) ? null : email;
 

--- a/RockWeb/Blocks/Finance/PledgeEntry.ascx
+++ b/RockWeb/Blocks/Finance/PledgeEntry.ascx
@@ -20,7 +20,7 @@
 
                     <Rock:RockTextBox ID="tbFirstName" runat="server" Label="First Name" />
                     <Rock:RockTextBox ID="tbLastName" runat="server" Label="Last Name" />
-                    <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" Required="true" />
+                    <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" Required="true" />
 
                     <Rock:DateRangePicker ID="drpDateRange" runat="server" Label="Date Range" />
                     <Rock:CurrencyBox ID="tbTotalAmount" runat="server" Label="Total Pledge Amount" MinimumValue="0" Required="true" Help="The total amount that you are pledging. If you intend to give $100 monthly for one year, enter $1,200." />

--- a/RockWeb/Blocks/Finance/TransactionEntry.Kiosk.ascx
+++ b/RockWeb/Blocks/Finance/TransactionEntry.Kiosk.ascx
@@ -219,7 +219,7 @@
                         <Rock:RockTextBox ID="tbLastName" Label="Last Name" runat="server" Required="true" />
                         <Rock:PhoneNumberBox ID="pnbHomePhone" Label="Home Phone" runat="server" Required="true" />
                         <Rock:AddressControl ID="acAddress" ShowAddressLine2="false" runat="server" Required="true"/>
-                        <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" Required="true" />
+                        <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" Required="true" />
                     </div>
                     <div class="col-md-4">
                         <asp:LinkButton ID="lbRegisterNext" runat="server" OnClick="lbRegisterNext_Click" CssClass="btn btn-primary btn-kiosk btn-kiosk-lg">Next</asp:LinkButton>

--- a/RockWeb/Blocks/Finance/TransactionEntry.ascx
+++ b/RockWeb/Blocks/Finance/TransactionEntry.ascx
@@ -91,7 +91,7 @@
                                         </asp:PlaceHolder>
                                         <Rock:AddressControl ID="acAddress" runat="server" UseStateAbbreviation="true" UseCountryAbbreviation="false" Label="Address" />
                                         <Rock:PhoneNumberBox ID="pnbPhone" runat="server" Label="Phone"></Rock:PhoneNumberBox>
-                                        <Rock:EmailBox ID="txtEmail" runat="server" Label="Email"></Rock:EmailBox>
+                                        <Rock:EmailConfirmBox ID="txtEmail" runat="server" Label="Email"></Rock:EmailConfirmBox>
                                         <Rock:RockCheckBox ID="cbGiveAnonymously" runat="server" Text="Give Anonymously" />
                                         <asp:PlaceHolder ID="phBusinessContact" runat="server" Visible="false">
                                             <hr />

--- a/RockWeb/Blocks/Finance/TransactionEntryV2.ascx
+++ b/RockWeb/Blocks/Finance/TransactionEntryV2.ascx
@@ -121,7 +121,7 @@
                                 <Rock:AddressControl ID="acAddressIndividual" runat="server" UseStateAbbreviation="true" UseCountryAbbreviation="false" Label="" ShowAddressLine2="false" Required="true" />
 
                                 <Rock:PhoneNumberBox ID="pnbPhoneIndividual" runat="server" Placeholder="Phone" CssClass="margin-b-sm" />
-                                <Rock:EmailBox ID="tbEmailIndividual" runat="server" Placeholder="Email" CssClass="margin-b-sm" />
+                                <Rock:EmailConfirmBox ID="tbEmailIndividual" runat="server" Placeholder="Email" CssClass="margin-b-sm" />
                                 <Rock:RockCheckBox ID="cbGiveAnonymouslyIndividual" runat="server" Text="Give Anonymously" />
                             </asp:Panel>
 
@@ -134,7 +134,7 @@
 
                                 <Rock:AddressControl ID="acAddressBusiness" runat="server" UseStateAbbreviation="true" UseCountryAbbreviation="false" Label="" ShowAddressLine2="false" Required="true" />
                                 <Rock:PhoneNumberBox ID="pnbPhoneBusiness" runat="server" Placeholder="Business Phone" CssClass="margin-b-sm" />
-                                <Rock:EmailBox ID="tbEmailBusiness" runat="server" Placeholder="Business Email" CssClass="margin-b-sm" />
+                                <Rock:EmailConfirmBox ID="tbEmailBusiness" runat="server" Placeholder="Business Email" CssClass="margin-b-sm" />
                                 <Rock:RockCheckBox ID="cbGiveAnonymouslyBusiness" runat="server" Text="Give Anonymously" />
 
                                 <%-- If anonymous and giving as a new business, prompt for Contact information --%>
@@ -148,7 +148,7 @@
                                         <Rock:RockTextBox ID="tbBusinessContactLastName" runat="server" Placeholder="Last Name" CssClass="margin-b-sm" Required="true" />
                                     </div>
                                     <Rock:PhoneNumberBox ID="pnbBusinessContactPhone" runat="server" Placeholder="Phone" CssClass="margin-b-sm" />
-                                    <Rock:EmailBox ID="tbBusinessContactEmail" runat="server" Placeholder="Email" CssClass="margin-b-sm" />
+                                    <Rock:EmailConfirmBox ID="tbBusinessContactEmail" runat="server" Placeholder="Email" CssClass="margin-b-sm" />
                                 </asp:Panel>
                             </asp:Panel>
 

--- a/RockWeb/Blocks/Finance/TransactionEntryV2.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionEntryV2.ascx.cs
@@ -2076,7 +2076,7 @@ mission. We are so grateful for your commitment.</p>
             var promptForEmail = this.GetAttributeValue( AttributeKey.PromptForEmail ).AsBoolean();
             var promptForPhone = this.GetAttributeValue( AttributeKey.PromptForPhone ).AsBoolean();
             PhoneNumberBox pnbPhone;
-            EmailBox tbEmail;
+            EmailConfirmBox tbEmail;
             int numberTypeId;
             Guid locationTypeGuid;
             AddressControl acAddress;

--- a/RockWeb/Blocks/Groups/GroupRegistration.ascx
+++ b/RockWeb/Blocks/Groups/GroupRegistration.ascx
@@ -32,7 +32,7 @@
                             <Rock:RockCheckBox ID="cbSms"  runat="server" Label="&nbsp;" Text="Enable SMS" />
                         </div>
                     </asp:Panel>
-                    <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" ></Rock:EmailBox>
+                    <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" ></Rock:EmailConfirmBox>
                     <Rock:AddressControl ID="acAddress" runat="server" Label="Address" />
                 </asp:Panel>
 
@@ -47,7 +47,7 @@
                             <Rock:RockCheckBox ID="cbSpouseSms"  runat="server" Label="&nbsp;" Text="Enable SMS" />
                         </div>
                     </div>
-                    <Rock:EmailBox ID="tbSpouseEmail" runat="server" Label="Spouse Email" />
+                    <Rock:EmailConfirmBox ID="tbSpouseEmail" runat="server" Label="Spouse Email" />
                 </asp:Panel>
 
             </div>

--- a/RockWeb/Blocks/Groups/GroupSimpleRegister.ascx
+++ b/RockWeb/Blocks/Groups/GroupSimpleRegister.ascx
@@ -9,7 +9,7 @@
                 <fieldset>
                     <Rock:RockTextBox ID="txtFirstName" runat="server" Placeholder="First Name" />
                     <Rock:RockTextBox ID="txtLastName" runat="server" Placeholder="Last Name" />
-                    <Rock:EmailBox ID="txtEmail" runat="server" Placeholder="Email" />
+                    <Rock:EmailConfirmBox ID="txtEmail" runat="server" Placeholder="Email" />
                 </fieldset>
 
                 <Rock:NotificationBox ID="nbError" runat="server" Visible="false" NotificationBoxType="Danger"></Rock:NotificationBox>

--- a/RockWeb/Blocks/Prayer/PrayerRequestEntry.ascx
+++ b/RockWeb/Blocks/Prayer/PrayerRequestEntry.ascx
@@ -15,7 +15,7 @@
                     <asp:Panel ID="pnlRequester" CssClass="prayer-requester" runat="server">
                         <Rock:RockTextBox ID="tbFirstName" runat="server" Label="First Name" Required="true" />
                         <Rock:RockTextBox ID="tbLastName" runat="server" Label="Last Name" Required="false" />
-                        <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" Required="false" />
+                        <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" Required="false" />
                         <Rock:PhoneNumberBox ID="pnbPhone" runat="server" Label="Mobile Phone" />
                         <Rock:CampusPicker ID="cpCampus" runat="server" Label="Campus" />
                     </asp:Panel>

--- a/RockWeb/Blocks/Security/AccountEntry.ascx
+++ b/RockWeb/Blocks/Security/AccountEntry.ascx
@@ -89,7 +89,7 @@
                     <legend>Your Information</legend>
                     <Rock:RockTextBox ID="tbFirstName" runat="server" Label="First Name" Required="true" />
                     <Rock:RockTextBox ID="tbLastName" runat="server" Label="Last Name" Required="true" />
-                    <Rock:EmailBox ID="tbEmail" runat="server" Label="Email" Required="true" />
+                    <Rock:EmailConfirmBox ID="tbEmail" runat="server" Label="Email" Required="true" />
                     <Rock:RockDropDownList ID="ddlGender" runat="server" Label="Gender">
                         <asp:ListItem Text="" Value="U"></asp:ListItem>
                         <asp:ListItem Text="Male" Value="M"></asp:ListItem>

--- a/RockWeb/Scripts/Rock/Controls/emalConfirmControl.js
+++ b/RockWeb/Scripts/Rock/Controls/emalConfirmControl.js
@@ -1,0 +1,35 @@
+﻿(function ($) {
+    'use strict';
+    window.Rock = window.Rock || {};
+    Rock.controls = Rock.controls || {};
+
+    Rock.controls.emailConfirmControl = (function () {
+        var exports = {
+            initialize: function (options) {
+                if (!options.id) {
+                    throw 'id is required';
+                }
+            },
+            clientValidate: function (validator, args) {
+                var $emailConfirmControl = $(validator).closest('.js-emailConfirmControl');
+                var isValid = true;
+
+                var primaryEmail = $emailConfirmControl.find('.js-primary input').val().trim().toLowerCase();
+                var confirmEmail = $emailConfirmControl.find('.js-confirm input').val().trim().toLowerCase();
+
+                if (primaryEmail.length > 0 && primaryEmail !== confirmEmail) {
+                    isValid = false;
+                    validator.errormessage = "Email and confirmation do not match.";
+                    $emailConfirmControl.find('.js-confirm').closest('.form-group').addClass('has-error');
+                }
+                else {
+                    $emailConfirmControl.find('.js-confirm').closest('.form-group').removeClass('has-error');
+                }
+
+                args.IsValid = isValid;
+            }
+        };
+
+        return exports;
+    }());
+}(jQuery));


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

This PR adds a new field type `EmailConfirmField` that prompts for an email address and a confirmation. It will only validate if both emails match. It also updates most public facing blocks that were asking for an email address to also ask for a confirmation.

See [this idea](https://community.rockrms.com/ideas/1467/prompt-to-confirm-email-address-on-public-facing-blocks) for more explanation of the issue this is trying to solve.

>We are seeing a constant (now magnified since people are interacting with us more online) issue where people enter their email address wrong, causing all sorts of data integrity issues.
>
>The core issue is that people often do not enter their email address correctly (especially on mobile) and while mis-spelling a name or phone might not be ideal, misspelling an *email* address means we cannot contact them at all (especially if we're not getting a phone number, too). For years the industry standard to work around this has been to solicit the email address TWICE, and only let the form submit if they match. This gives the user a chance to fix a mistake they didn't realize they made.

*Note: If this isn't something that we want on all the public blocks, I can resubmit with just the new field type. I think it still would be valuable to have this as an option for workflows.*

Fixes: #N/A

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, ~which has been approved by the core team~)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

I went through and tested every block that is modified by this PR and they all correctly reject bad emails, and accept matching emails. The only block I was not able to test is `Transaction Entry v2` since it doesn't work with the Test Gatweay. However, I don't see a reason it should have an issue based on reading through the code.

## Documentation
N/A

## Migrations
N/A