### PR TITLE
Added ui for benevolence result attributes and other fixes

### DIFF
--- a/RockWeb/Blocks/Finance/BenevolenceRequestDetail.ascx
+++ b/RockWeb/Blocks/Finance/BenevolenceRequestDetail.ascx
@@ -106,12 +106,11 @@
                         </div>
                     </div>
                 
-                    <Rock:Grid ID="gResults" runat="server" DisplayType="Light" AllowSorting="true" ShowActionRow="true" RowItemText="Result" AllowPaging="false" OnRowSelected="gResults_RowSelected">
+                    <Rock:Grid ID="gResults" runat="server" DisplayType="Light" AllowSorting="false" ShowActionRow="true" RowItemText="Result" AllowPaging="false" OnRowSelected="gResults_RowSelected">
                         <Columns>
                             <Rock:RockBoundField DataField="ResultTypeName" HeaderText="Result Type" SortExpression="ResultType" />
                             <Rock:CurrencyField DataField="Amount" HeaderText="Amount" SortExpression="Amount" />
                             <Rock:RockBoundField DataField="ResultSummary" HeaderText="Details" SortExpression="Details" />
-                            <Rock:DeleteField OnClick="gResults_DeleteClick" />
                         </Columns>
                     </Rock:Grid>
                 </Rock:PanelWidget>
@@ -137,6 +136,8 @@
                 </div>
 
                 <Rock:DataTextBox ID="dtbResultSummary" runat="server" Label="Details" ValidationGroup="valResult" SourceTypeName="Rock.Model.BenevolenceResult, Rock" TextMode="MultiLine" Rows="3" PropertyName="ResultSummary" />
+
+                <Rock:DynamicPlaceholder id="phResultAttributes" runat="server" />
             </Content>
         </Rock:ModalDialog>
 

--- a/RockWeb/Blocks/Finance/BenevolenceRequestDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/BenevolenceRequestDetail.ascx.cs
@@ -36,19 +36,62 @@ namespace RockWeb.Blocks.Finance
     [DisplayName( "Benevolence Request Detail" )]
     [Category( "Finance" )]
     [Description( "Block for users to create, edit, and view benevolence requests." )]
-    [SecurityRoleField( "Case Worker Role", "The security role to draw case workers from", false, "", "", 0 )]
-    [LinkedPage("Benevolence Request Statement Page", "The page which summarizes a benevolence request for printing", true)]
+
+    [SecurityRoleField( "Case Worker Role",
+        Description = "The security role to draw case workers from",
+        IsRequired = false,
+        Key = AttributeKey.CaseWorkerRole,
+        Order = 0 )]
+
+    [LinkedPage( "Benevolence Request Statement Page",
+        Description = "The page which summarizes a benevolence request for printing",
+        IsRequired = true,
+        Key = AttributeKey.BenevolenceRequestStatementPage,
+        Order = 1 )]
     public partial class BenevolenceRequestDetail : Rock.Web.UI.RockBlock
     {
+        #region Attribute Keys
+
+        private static class AttributeKey
+        {
+            public const string CaseWorkerRole = "CaseWorkerRole";
+            public const string BenevolenceRequestStatementPage = "BenevolenceRequestStatementPage";
+        }
+
+        #endregion Attribute Keys
+
+        #region PageParameterKeys
+
+        private static class PageParameterKey
+        {
+            public const string BenevolenceRequestId = "BenevolenceRequestId";
+        }
+
+        #endregion PageParameterKeys
+
         #region Fields 
 
         private Guid? _caseWorkerGroupGuid = null;
+        private BenevolenceResult _mocBenevolenceResult;
 
         #endregion
 
         #region Properties
 
         private List<int> DocumentsState { get; set; }
+
+        private BenevolenceResult MockBenevolenceResult
+        {
+            get
+            {
+                if ( _mocBenevolenceResult == null )
+                {
+                    _mocBenevolenceResult = new BenevolenceResult();
+                    _mocBenevolenceResult.LoadAttributes();
+                }
+                return _mocBenevolenceResult;
+            }
+        }
 
         #endregion
 
@@ -79,6 +122,39 @@ namespace RockWeb.Blocks.Finance
             }
         }
 
+        /// <summary>
+        /// Adds columns to the results grid 
+        /// </summary>
+        private void AddDynamicColumns()
+        {
+            var attributes = MockBenevolenceResult.Attributes.Select( a => a.Value ).Where( a => a.IsGridColumn ).ToList();
+
+            foreach ( var attribute in attributes )
+            {
+                bool columnExists = gResults.Columns.OfType<AttributeField>().FirstOrDefault( a => a.AttributeId == attribute.Id ) != null;
+                if ( !columnExists )
+                {
+                    AttributeField boundField = new AttributeField();
+                    boundField.DataField = attribute.Key;
+                    boundField.AttributeId = attribute.Id;
+                    boundField.HeaderText = attribute.Name;
+
+                    var attributeCache = Rock.Web.Cache.AttributeCache.Get( attribute.Id );
+                    if ( attributeCache != null )
+                    {
+                        boundField.ItemStyle.HorizontalAlign = attributeCache.FieldType.Field.AlignValue;
+                    }
+
+                    gResults.Columns.Add( boundField );
+                }
+            }
+
+            // Add delete column
+            var deleteField = new DeleteField();
+            gResults.Columns.Add( deleteField );
+            deleteField.Click += gResults_Delete;
+        }
+
         #endregion
 
         #region Base Control Methods
@@ -101,7 +177,7 @@ namespace RockWeb.Blocks.Finance
 
             // Gets any existing results and places them into the ViewState
             BenevolenceRequest benevolenceRequest = null;
-            int benevolenceRequestId = PageParameter( "BenevolenceRequestId" ).AsInteger();
+            int benevolenceRequestId = PageParameter( PageParameterKey.BenevolenceRequestId ).AsInteger();
             if ( !benevolenceRequestId.Equals( 0 ) )
             {
                 benevolenceRequest = new BenevolenceRequestService( new RockContext() ).Get( benevolenceRequestId );
@@ -124,6 +200,9 @@ namespace RockWeb.Blocks.Finance
                     benevolenceResultInfo.ResultSummary = benevolenceResult.ResultSummary;
                     benevolenceResultInfo.ResultTypeValueId = benevolenceResult.ResultTypeValueId;
                     benevolenceResultInfo.ResultTypeName = benevolenceResult.ResultTypeValue.Value;
+                    benevolenceResult.LoadAttributes();
+                    benevolenceResultInfo.Attributes = benevolenceResult.Attributes;
+                    benevolenceResultInfo.AttributeValues = benevolenceResult.AttributeValues;
                     brInfoList.Add( benevolenceResultInfo );
                 }
 
@@ -132,9 +211,11 @@ namespace RockWeb.Blocks.Finance
 
             dlDocuments.ItemDataBound += DlDocuments_ItemDataBound;
 
-            _caseWorkerGroupGuid = GetAttributeValue( "CaseWorkerRole" ).AsGuidOrNull();
+            _caseWorkerGroupGuid = GetAttributeValue( AttributeKey.CaseWorkerRole ).AsGuidOrNull();
 
+            AddDynamicColumns();
         }
+
 
         /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
@@ -147,13 +228,13 @@ namespace RockWeb.Blocks.Finance
             if ( !Page.IsPostBack )
             {
                 cpCampus.Campuses = CampusCache.All();
-                ShowDetail( PageParameter( "BenevolenceRequestId" ).AsInteger() );
+                ShowDetail( PageParameter( PageParameterKey.BenevolenceRequestId ).AsInteger() );
             }
             else
             {
                 var rockContext = new RockContext();
-                BenevolenceRequest item = new BenevolenceRequestService(rockContext).Get( hfBenevolenceRequestId.ValueAsInt());
-                if (item == null )
+                BenevolenceRequest item = new BenevolenceRequestService( rockContext ).Get( hfBenevolenceRequestId.ValueAsInt() );
+                if ( item == null )
                 {
                     item = new BenevolenceRequest();
                 }
@@ -161,6 +242,9 @@ namespace RockWeb.Blocks.Finance
 
                 phAttributes.Controls.Clear();
                 Rock.Attribute.Helper.AddEditControls( item, phAttributes, false, BlockValidationGroup, 2 );
+
+
+                Rock.Attribute.Helper.AddEditControls( MockBenevolenceResult, phResultAttributes, false, valResultsSummary.ValidationGroup, 2 );
 
                 confirmExit.Enabled = true;
             }
@@ -205,7 +289,7 @@ namespace RockWeb.Blocks.Finance
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void Block_BlockUpdated( object sender, EventArgs e )
         {
-            ShowDetail( PageParameter( "BenevolenceRequestId" ).AsInteger() );
+            ShowDetail( PageParameter( PageParameterKey.BenevolenceRequestId ).AsInteger() );
         }
 
         /// <summary>
@@ -222,7 +306,12 @@ namespace RockWeb.Blocks.Finance
             dvpResultType.DefinedTypeId = DefinedTypeCache.Get( new Guid( Rock.SystemGuid.DefinedType.BENEVOLENCE_RESULT_TYPE ) ).Id;
             dtbResultSummary.Text = string.Empty;
             dtbAmount.Value = null;
+            hfInfoGuid.Value = Guid.NewGuid().ToString();
 
+            phResultAttributes.Controls.Clear();
+            Rock.Attribute.Helper.AddEditControls( MockBenevolenceResult, phResultAttributes, true, valResultsSummary.ValidationGroup, 2 );
+
+            mdAddResult.SaveButtonText = "Add";
             mdAddResult.Show();
         }
 
@@ -247,6 +336,11 @@ namespace RockWeb.Blocks.Finance
                 dtbResultSummary.Text = resultInfo.ResultSummary;
                 dtbAmount.Value = resultInfo.Amount;
                 hfInfoGuid.Value = e.RowKeyValue.ToString();
+
+                phResultAttributes.Controls.Clear();
+                Rock.Attribute.Helper.AddEditControls( resultInfo, phResultAttributes, true, valResultsSummary.ValidationGroup, 2 );
+
+                mdAddResult.SaveButtonText = "Update";
                 mdAddResult.Show();
             }
         }
@@ -257,7 +351,7 @@ namespace RockWeb.Blocks.Finance
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        protected void gResults_DeleteClick( object sender, RowEventArgs e )
+        protected void gResults_Delete( object sender, RowEventArgs e )
         {
             Guid? infoGuid = e.RowKeyValue as Guid?;
             List<BenevolenceResultInfo> resultList = BenevolenceResultsState;
@@ -283,24 +377,31 @@ namespace RockWeb.Blocks.Finance
             List<BenevolenceResultInfo> benevolenceResultInfoViewStateList = BenevolenceResultsState;
             Guid? infoGuid = hfInfoGuid.Value.AsGuidOrNull();
 
-            if ( infoGuid != null )
+            if ( infoGuid == null )
             {
-                var resultInfo = benevolenceResultInfoViewStateList.FirstOrDefault( r => r.TempGuid == infoGuid );
-                if ( resultInfo != null )
+                infoGuid = Guid.NewGuid();
+            }
+            var resultInfo = benevolenceResultInfoViewStateList.FirstOrDefault( r => r.TempGuid == infoGuid );
+            if ( resultInfo != null )
+            {
+                resultInfo.Amount = dtbAmount.Value;
+                resultInfo.ResultSummary = dtbResultSummary.Text;
+                if ( resultType != null )
                 {
-                    resultInfo.Amount = dtbAmount.Value;
-                    resultInfo.ResultSummary = dtbResultSummary.Text;
-                    if ( resultType != null )
-                    {
-                        resultInfo.ResultTypeValueId = resultType.Value;
-                    }
-
-                    resultInfo.ResultTypeName = dvpResultType.SelectedItem.Text;
+                    resultInfo.ResultTypeValueId = resultType.Value;
                 }
+
+                resultInfo.ResultTypeName = dvpResultType.SelectedItem.Text;
+                Rock.Attribute.Helper.GetEditValues( phResultAttributes, resultInfo );
             }
             else
             {
                 BenevolenceResultInfo benevolenceResultInfo = new BenevolenceResultInfo();
+
+                //We need the attributes and values so that we can populate them later
+
+                benevolenceResultInfo.Attributes = MockBenevolenceResult.Attributes;
+                benevolenceResultInfo.AttributeValues = MockBenevolenceResult.AttributeValues;
 
                 benevolenceResultInfo.Amount = dtbAmount.Value;
 
@@ -312,13 +413,16 @@ namespace RockWeb.Blocks.Finance
 
                 benevolenceResultInfo.ResultTypeName = dvpResultType.SelectedItem.Text;
                 benevolenceResultInfo.TempGuid = Guid.NewGuid();
+                Rock.Attribute.Helper.GetEditValues( phResultAttributes, benevolenceResultInfo );
                 benevolenceResultInfoViewStateList.Add( benevolenceResultInfo );
             }
+
 
             BenevolenceResultsState = benevolenceResultInfoViewStateList;
 
             mdAddResult.Hide();
             pnlView.Visible = true;
+            hfInfoGuid.Value = null;
             BindGridFromViewState();
         }
 
@@ -336,7 +440,7 @@ namespace RockWeb.Blocks.Finance
                 BenevolenceResultService benevolenceResultService = new BenevolenceResultService( rockContext );
 
                 BenevolenceRequest benevolenceRequest = null;
-                int benevolenceRequestId = PageParameter( "BenevolenceRequestId" ).AsInteger();
+                int benevolenceRequestId = PageParameter( PageParameterKey.BenevolenceRequestId ).AsInteger();
 
                 if ( !benevolenceRequestId.Equals( 0 ) )
                 {
@@ -413,6 +517,9 @@ namespace RockWeb.Blocks.Finance
                     resultDB.Amount = resultUI.Amount;
                     resultDB.ResultSummary = resultUI.ResultSummary;
                     resultDB.ResultTypeValueId = resultUI.ResultTypeValueId;
+
+                    resultDB.Attributes = resultUI.Attributes;
+                    resultDB.AttributeValues = resultUI.AttributeValues;
                 }
 
                 if ( benevolenceRequest.IsValid )
@@ -430,6 +537,7 @@ namespace RockWeb.Blocks.Finance
                     {
                         rockContext.SaveChanges();
                         benevolenceRequest.SaveAttributeValues( rockContext );
+                        benevolenceRequest.BenevolenceResults.ToList().ForEach( r => r.SaveAttributeValues( rockContext ) );
                     } );
 
                     // update related documents
@@ -512,13 +620,13 @@ namespace RockWeb.Blocks.Finance
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        protected void lbPrint_Click(object sender, EventArgs e)
+        protected void lbPrint_Click( object sender, EventArgs e )
         {
-            var benevolenceRequestId = this.PageParameter("BenevolenceRequestId").AsIntegerOrNull();       
-            if (benevolenceRequestId.HasValue && !benevolenceRequestId.Equals(0) && !string.IsNullOrEmpty(GetAttributeValue("BenevolenceRequestStatementPage")))
+            var benevolenceRequestId = this.PageParameter( PageParameterKey.BenevolenceRequestId ).AsIntegerOrNull();
+            if ( benevolenceRequestId.HasValue && !benevolenceRequestId.Equals( 0 ) && !string.IsNullOrEmpty( GetAttributeValue( "BenevolenceRequestStatementPage" ) ) )
             {
-                NavigateToLinkedPage("BenevolenceRequestStatementPage", new Dictionary<string, string> { { "BenevolenceRequestId", benevolenceRequestId.ToString() } });
-            }               
+                NavigateToLinkedPage( "BenevolenceRequestStatementPage", new Dictionary<string, string> { { PageParameterKey.BenevolenceRequestId, benevolenceRequestId.ToString() } } );
+            }
         }
 
         /// <summary>
@@ -534,7 +642,7 @@ namespace RockWeb.Blocks.Finance
                 if ( person != null )
                 {
                     // Make sure that the FirstName box gets either FirstName or NickName of person. 
-                    if (!string.IsNullOrWhiteSpace(person.FirstName))
+                    if ( !string.IsNullOrWhiteSpace( person.FirstName ) )
                     {
                         dtbFirstName.Text = person.FirstName;
                     }
@@ -544,11 +652,12 @@ namespace RockWeb.Blocks.Finance
                     }
 
                     //If both FirstName and NickName are blank, let them edit it manually
-                    dtbFirstName.Enabled = string.IsNullOrWhiteSpace(dtbFirstName.Text);
+                    dtbFirstName.Enabled = string.IsNullOrWhiteSpace( dtbFirstName.Text );
 
                     dtbLastName.Text = person.LastName;
                     //If both LastName is blank, let them edit it manually
-                    dtbLastName.Enabled = string.IsNullOrWhiteSpace( dtbLastName.Text ); ;
+                    dtbLastName.Enabled = string.IsNullOrWhiteSpace( dtbLastName.Text );
+                    ;
 
                     dvpConnectionStatus.SetValue( person.ConnectionStatusValueId );
                     dvpConnectionStatus.Enabled = false;
@@ -593,12 +702,12 @@ namespace RockWeb.Blocks.Finance
                     lapAddress.Enabled = false;
 
                     // set the campus but not on page load (e will be null) unless from the person profile page (in which case BenevolenceRequestId in the query string will be 0)
-                    int? requestId = PageParameter( "BenevolenceRequestId" ).AsIntegerOrNull();
-                    
-                    if ( !cpCampus.SelectedCampusId.HasValue && ( e != null || (requestId.HasValue && requestId == 0 ) ) )
+                    int? requestId = PageParameter( PageParameterKey.BenevolenceRequestId ).AsIntegerOrNull();
+
+                    if ( !cpCampus.SelectedCampusId.HasValue && ( e != null || ( requestId.HasValue && requestId == 0 ) ) )
                     {
                         var personCampus = person.GetCampus();
-                        cpCampus.SelectedCampusId = personCampus != null ? personCampus.Id : (int?)null;
+                        cpCampus.SelectedCampusId = personCampus != null ? personCampus.Id : ( int? ) null;
                     }
                 }
             }
@@ -617,7 +726,7 @@ namespace RockWeb.Blocks.Finance
 
         protected void fileUpDoc_FileUploaded( object sender, EventArgs e )
         {
-            var fileUpDoc = (Rock.Web.UI.Controls.FileUploader)sender;
+            var fileUpDoc = ( Rock.Web.UI.Controls.FileUploader ) sender;
 
             if ( fileUpDoc.BinaryFileId.HasValue )
             {
@@ -633,7 +742,7 @@ namespace RockWeb.Blocks.Finance
         /// <param name="e">The <see cref="FileUploaderEventArgs"/> instance containing the event data.</param>
         protected void fileUpDoc_FileRemoved( object sender, FileUploaderEventArgs e )
         {
-            var fileUpDoc = (Rock.Web.UI.Controls.FileUploader)sender;
+            var fileUpDoc = ( Rock.Web.UI.Controls.FileUploader ) sender;
             if ( e.BinaryFileId.HasValue )
             {
                 DocumentsState.Remove( e.BinaryFileId.Value );
@@ -784,7 +893,7 @@ namespace RockWeb.Blocks.Finance
                 ddlCaseWorker.SetValue( benevolenceRequest.CaseWorkerPersonAliasId );
             }
             else
-            { 
+            {
                 if ( benevolenceRequest.CaseWorkerPersonAlias != null )
                 {
                     ppCaseWorker.SetValue( benevolenceRequest.CaseWorkerPersonAlias.Person );
@@ -867,7 +976,7 @@ namespace RockWeb.Blocks.Finance
         /// The class used to store BenevolenceResult info.
         /// </summary>
         [Serializable]
-        public class BenevolenceResultInfo
+        public class BenevolenceResultInfo : IHasAttributes
         {
             [DataMember]
             public int? ResultId { get; set; }
@@ -886,10 +995,63 @@ namespace RockWeb.Blocks.Finance
 
             [DataMember]
             public string ResultSummary { get; set; }
+
+            public int Id
+            {
+                get
+                {
+                    return ResultId ?? 0;
+                }
+            }
+
+            [DataMember]
+            public Dictionary<string, AttributeCache> Attributes { get; set; }
+
+            [DataMember]
+            public Dictionary<string, AttributeValueCache> AttributeValues { get; set; }
+
+            public Dictionary<string, string> AttributeValueDefaults { get { return null; } }
+
+            public string GetAttributeValue( string key )
+            {
+                if ( this.AttributeValues != null &&
+                    this.AttributeValues.ContainsKey( key ) )
+                {
+                    return this.AttributeValues[key].Value;
+                }
+
+                if ( this.Attributes != null &&
+                    this.Attributes.ContainsKey( key ) )
+                {
+                    return this.Attributes[key].DefaultValue;
+                }
+
+                return null;
+            }
+
+            public List<string> GetAttributeValues( string key )
+            {
+                string value = GetAttributeValue( key );
+                if ( !string.IsNullOrWhiteSpace( value ) )
+                {
+                    return value.SplitDelimitedValues().ToList();
+                }
+
+                return new List<string>();
+            }
+
+            public void SetAttributeValue( string key, string value )
+            {
+                if ( this.AttributeValues != null &&
+                this.AttributeValues.ContainsKey( key ) )
+                {
+                    this.AttributeValues[key].Value = value;
+                }
+            }
         }
 
         #endregion
 
-        
+
     }
 }


### PR DESCRIPTION
## Proposed Changes

Hello, 
There was a need to add attributes to Benevolence Results. This is a PR to add UI to the Benevolence Request Detail block to allow this functionality.

![image](https://user-images.githubusercontent.com/495787/118413433-4e859580-b66d-11eb-8b9c-bbcdf044565f.png)

![image](https://user-images.githubusercontent.com/495787/118413394-25fd9b80-b66d-11eb-8c64-0afd8ec8c0d4.png)


## Types of changes
I would categorize this as an enhancement. It adds non-breaking functionality and very minor bug fixes.

## Checklist
- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [ ] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
Because this block stores the Benevolence Result changes in the view state using the BenevolenceResultInfo POCO, I needed it to inherit IHasAttributes to work with the existing UI helpers. I implemented the interface and added the necessary UI for the attributes. Attributes that are marked "Show In Grid" will display in the results grid. I used a mock instance of BenevolenceResult to load the attributes for the UI as needed.

Additionally while working on this I did some minor fixes:
 -  The grid was set to allow sorting, but it was never wired up; so I removed sorting. 
 - The modal's save button would have the text "Add" no matter if you were adding a new Result or updating it. It now shows "Add" when adding and "Update" when updating.
 - Updated the Attributes and PageParameter strings to use constants.