### PR TITLE
Fixed issue where redis cached servers lost grouptype ref

### DIFF
--- a/Rock/CheckIn/KioskGroupType.cs
+++ b/Rock/CheckIn/KioskGroupType.cs
@@ -36,7 +36,6 @@ namespace Rock.CheckIn
         /// <value>
         /// The type of the group.
         /// </value>
-        [DataMember]
         public GroupTypeCache GroupType => GroupTypeCache.Get( GroupTypeId );
 
         /// <summary>
@@ -45,6 +44,7 @@ namespace Rock.CheckIn
         /// <value>
         /// The group type identifier.
         /// </value>
+        [DataMember]
         public int GroupTypeId { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes
While testing 1.12.5 with a Redis cache I noticed that check-in would not stay open. If I switched back to memory cache it would work, but not with Redis. I tracked this down to an optimization in cache that lost it's data on serialization. The fix was to just change what data is serialized by moving the [DataMember] decoration. I tested this with and without redis and it seems to have fixed the issue. 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)