### PR TITLE
Changed single-select to multi-select in group placement group picker.

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationInstanceGroupPlacement.ascx
+++ b/RockWeb/Blocks/Event/RegistrationInstanceGroupPlacement.ascx
@@ -292,7 +292,7 @@
                         <div class="row">
                             <div class="col-md-6">
                                 <Rock:NotificationBox ID="nbAddExistingPlacementGroupWarning" runat="server" NotificationBoxType="Warning" Dismissable="true" />
-                                <Rock:GroupPicker ID="gpAddExistingPlacementGroup" runat="server" Label="Group" ValidationGroup="vgAddPlacementGroup" OnSelectItem="gpAddExistingPlacementGroup_SelectItem" />
+                                <Rock:GroupPicker ID="gpAddExistingPlacementGroup" runat="server" Label="Group" ValidationGroup="vgAddPlacementGroup" AllowMultiSelect="true" OnSelectItem="gpAddExistingPlacementGroup_SelectItem" />
                             </div>
                         </div>
                     </asp:Panel>

--- a/RockWeb/Blocks/Event/RegistrationInstanceGroupPlacement.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationInstanceGroupPlacement.ascx.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.Entity;
 using System.Linq;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
@@ -1067,28 +1068,24 @@ namespace RockWeb.Blocks.Event
 
             if ( bgAddNewOrExistingPlacementGroup.SelectedValue == AddPlacementGroupTab.AddExistingGroup.ConvertToInt().ToString() )
             {
-                var existingGroupId = gpAddExistingPlacementGroup.SelectedValue.AsIntegerOrNull();
-                if ( !existingGroupId.HasValue )
-                {
-                    return;
-                }
-
-                var existingPlacementGroup = new GroupService( rockContext ).Get( existingGroupId.Value );
-                if ( existingPlacementGroup == null )
-                {
-                    return;
-                }
-
-                var groupType = GroupTypeCache.Get( groupTypeId );
-
-                if ( groupTypeId != existingPlacementGroup.GroupTypeId )
-                {
-                    nbAddExistingPlacementGroupWarning.Text = "Group must have a group type of " + groupType.Name + ".";
-                    return;
-                }
-
                 placementGroups = new List<Group>();
-                placementGroups.Add( existingPlacementGroup );
+                var existingGroupIds = gpAddExistingPlacementGroup.SelectedValuesAsInt();
+
+                foreach ( var groupId in existingGroupIds )
+                {
+                    var existingPlacementGroup = new GroupService( rockContext ).Get( groupId );
+                    if ( existingPlacementGroup == null )
+                    {
+                        continue;
+                    }
+
+                    if ( groupTypeId != existingPlacementGroup.GroupTypeId )
+                    {
+                        continue;
+                    }
+
+                    placementGroups.Add( existingPlacementGroup );
+                }
             }
             else if ( bgAddNewOrExistingPlacementGroup.SelectedValue == AddPlacementGroupTab.AddMultipleGroups.ConvertToInt().ToString() )
             {
@@ -1233,11 +1230,18 @@ namespace RockWeb.Blocks.Event
         protected void gpAddExistingPlacementGroup_SelectItem( object sender, EventArgs e )
         {
             int groupTypeId = hfRegistrationTemplatePlacementGroupTypeId.Value.AsInteger();
-            var selectedGroup = new GroupService( new RockContext() ).Get( gpAddExistingPlacementGroup.SelectedValue.AsInteger() );
-            if ( !IsValidExistingGroup( selectedGroup, groupTypeId ) )
+            var selectedGroupIds = gpAddExistingPlacementGroup.SelectedValuesAsInt();
+            var selectedGroups = new GroupService( new RockContext() )
+                .Queryable().AsNoTracking()
+                .Where( g => selectedGroupIds.Contains( g.Id ) )
+                .ToList();
+
+            var invalidGroups = selectedGroups.Where( g => !IsValidExistingGroup( g, groupTypeId ) );
+
+            if ( invalidGroups.Any() )
             {
                 var groupType = GroupTypeCache.Get( groupTypeId );
-                nbAddExistingPlacementGroupWarning.Text = string.Format( "The selected group must be a {0} group", groupType );
+                nbAddExistingPlacementGroupWarning.Text = string.Format( "The selected groups must be {0} groups", groupType );
                 nbAddExistingPlacementGroupWarning.Visible = true;
             }
             else
@@ -1280,7 +1284,7 @@ namespace RockWeb.Blocks.Event
         /// </returns>
         private bool IsValidExistingGroup( Group selectedGroup, int groupTypeId )
         {
-            return selectedGroup.GroupTypeId == groupTypeId;
+            return selectedGroup?.GroupTypeId == groupTypeId;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes

When selecting placement groups, there is only an option to select one group at a time or all the groups under a parent group. We would like to be able to quickly select multiple groups that aren't necessarily under the same parent group.

![placement-group-multi-select](https://user-images.githubusercontent.com/902855/132364406-525933ce-7a09-4939-9e06-ce1a767d8228.png)


## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Enhancement

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [X] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [X] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [X] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [X] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
This change was a big help for our church's 2021 camp season, as it greatly reduced the amount of time required to configure placement groups.