### PR TITLE
Added JS check for zone in addition to index to fire postback to save…

### DIFF
--- a/RockWeb/Blocks/Mobile/MobilePageDetail.ascx
+++ b/RockWeb/Blocks/Mobile/MobilePageDetail.ascx
@@ -233,9 +233,11 @@
         // Setup dragula to allow re-ordering within the actions.
         //
         var reorderOldIndex = -1;
+        var reorderOldZone = "";
         var reorderDrake = dragula(componentContainers, {
             moves: function (el, source, handle, sibling) {
                 reorderOldIndex = $(source).children().index(el);
+                reorderOldZone = $(el).closest('.js-block-zone').data('zone-name');
                 return $(handle).hasClass('js-reorder');
             },
             revertOnSpill: true
@@ -245,7 +247,7 @@
             var newIndex = $(target).children().index(el);
             var zone = $(el).closest('.js-block-zone').data('zone-name');
             var blockId = $(el).find('.js-block').data('block-id');
-            if (reorderOldIndex !== newIndex) {
+            if (reorderOldIndex !== newIndex || reorderOldZone !== zone) {
                 var postback = "javascript:__doPostBack('<%= lbDragCommand.ClientID %>', 'reorder-block|" + zone + "|" + blockId + "|" + newIndex + "')";
                 window.location = postback;
             }


### PR DESCRIPTION
… configuration

## Proposed Changes

The issue raised in 4566 is happening because the js drag reorder function is only checking for an index change, so when a block is dragged into a new zone with the same index it is not firing a postback event that saves the updated configuration of blocks. Added a condition that index is not the same or zone is not the same so event will fire in that particular instance. 

Fixes: #4566

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

Minor change.