### PR TITLE
+ (Lava) Added a new lava filter to determine if date falls within a range

### DIFF
--- a/Rock.Tests.UnitTests/Rock/Lava/Filters/DateFilterTests.cs
+++ b/Rock.Tests.UnitTests/Rock/Lava/Filters/DateFilterTests.cs
@@ -62,7 +62,7 @@ namespace Rock.Tests.UnitTests.Lava
         {
             // Set the test timezone.
             LavaTestHelper.SetRockDateTimeToAlternateTimezone();
-              
+
             // Initialize the test calendar data.
             _tzId = RockDateTime.OrgTimeZoneInfo.Id;
             _today = RockDateTime.Today;
@@ -943,6 +943,43 @@ namespace Rock.Tests.UnitTests.Lava
 
                 TestHelper.AssertTemplateOutput( engine, "today", "{{ dateTimeInput | DaysFromNow }}", mergeValues2 );
             } );
+        }
+
+        #endregion
+
+        #region Filter Tests: IsDateBetween
+
+        /// <summary>
+        /// Verifies when no format string is provided, the start and end date ranges default to SOD and EOD respectively.
+        /// </summary>
+        [TestMethod]
+        public void IsDateBetween_WithoutFormatString_AdjustsStartAndEndTimes()
+        {
+            var template = "{{ '2022-05-01 09:00' | IsDateBetween:'2022-05-01 12:00','2022-05-01 07:00' }}";
+
+            TestHelper.AssertTemplateOutput( "true", template );
+        }
+
+        /// <summary>
+        /// Verifies when a format string if provided, the start and end date ranges maintain their given times.
+        /// </summary>
+        [TestMethod]
+        public void IsDateBetween_WithFormatString_DoesNotAdjustTimes()
+        {
+            var template = "{{ '2022-05-01 09:00' | IsDateBetween:'2022-05-01 12:00','2022-05-01 07:00','yyyy-MM-dd HH:mm' }}";
+
+            TestHelper.AssertTemplateOutput( "false", template );
+        }
+
+        /// <summary>
+        /// Verifies that filter works when DateTime or DateTimeOffset input is sent.
+        /// </summary>
+        [TestMethod]
+        public void IsDateBetween_WithDateTimeOrDateTimeOffsetAsInput()
+        {
+            var template = "{{ targetDate | IsDateBetween:startDate,endDate }}";
+            var mergeValues = new LavaDataDictionary() { { "targetDate", DateTime.Parse( "2022-05-02" ) }, { "startDate", DateTime.Parse( "2022-05-01" ) }, { "endDate", DateTime.Parse( "2022-05-03" ) } };
+            TestHelper.AssertTemplateOutput( "true", template, mergeValues );
         }
 
         #endregion


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

New lava filter to determine if a target datetime falls within a given range of two other datetimes. 

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
Single date filter, appears to work with both lava engines in my testing. 

## Documentation
Documentation was already added to the CC in rock community. 

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.