### PR TITLE
Fixed "Benevolence Request Add" action to prompt for Benevolence Type.

### DIFF
--- a/Rock/Attribute/BenevolenceTypeFieldAttribute.cs
+++ b/Rock/Attribute/BenevolenceTypeFieldAttribute.cs
@@ -1,0 +1,42 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+
+namespace Rock.Attribute
+{
+    /// <summary>
+    /// Field Attribute to select a benevolence type
+    /// </summary>
+    [AttributeUsage( AttributeTargets.Class, AllowMultiple = true, Inherited = true )]
+    public class BenevolenceTypeFieldAttribute : FieldAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BenevolenceTypeFieldAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="description">The description.</param>
+        /// <param name="required">if set to <c>true</c> [required].</param>
+        /// <param name="defaultValue">The default benevolence type guid.</param>
+        /// <param name="category">The category.</param>
+        /// <param name="order">The order.</param>
+        /// <param name="key">The key.</param>
+        public BenevolenceTypeFieldAttribute(string name = "Benevolence Type", string description = "", bool required = true, string defaultValue = "", string category = "", int order = 0, string key = null)
+            : base(name, description, required, defaultValue, category, order, key, typeof(Rock.Field.Types.BenevolenceTypeFieldType).FullName)
+        {
+        }
+    }
+}

--- a/Rock/Field/Types/BenevolenceTypeFieldType.cs
+++ b/Rock/Field/Types/BenevolenceTypeFieldType.cs
@@ -1,0 +1,204 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.UI.Controls;
+
+namespace Rock.Field.Types
+{
+    /// <summary>
+    /// Field Type used to display a dropdown list of benevolence types
+    /// </summary>
+    [Serializable]
+    [RockPlatformSupport( Utility.RockPlatform.WebForms )]
+    public class BenevolenceTypeFieldType : FieldType, IEntityFieldType
+    {
+
+        #region Formatting
+
+        /// <summary>
+        /// Returns the field's current value(s)
+        /// </summary>
+        /// <param name="parentControl">The parent control.</param>
+        /// <param name="value">Information about the value</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="condensed">Flag indicating if the value should be condensed (i.e. for use in a grid column)</param>
+        /// <returns></returns>
+        public override string FormatValue(Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed)
+        {
+            string formattedValue = string.Empty;
+
+            Guid? guid = value.AsGuidOrNull();
+            if (guid.HasValue)
+            {
+                using (var rockContext = new RockContext())
+                {
+                    var type = new BenevolenceTypeService(rockContext).GetNoTracking(guid.Value);
+                    if (type != null)
+                    {
+                        formattedValue = type.Name;
+                    }
+                }
+            }
+
+            return base.FormatValue(parentControl, formattedValue, configurationValues, condensed);
+        }
+
+        #endregion
+
+        #region Edit Control
+
+        /// <summary>
+        /// Creates the control(s) necessary for prompting user for a new value
+        /// </summary>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="id"></param>
+        /// <returns>
+        /// The control
+        /// </returns>
+        public override Control EditControl(Dictionary<string, ConfigurationValue> configurationValues, string id)
+        {
+            var editControl = new RockDropDownList { ID = id };
+            editControl.Items.Add(new ListItem());
+
+            var types = new BenevolenceTypeService(new RockContext())
+                .Queryable().AsNoTracking()
+                .OrderBy(o => o.Name)
+                .Select(o => new
+                {
+                    o.Guid,
+                    o.Name,
+                })
+                .ToList();
+
+            if (types.Any())
+            {
+                foreach (var type in types)
+                {
+                    var listItem = new ListItem(type.Name, type.Guid.ToString().ToUpper());
+                    editControl.Items.Add(listItem);
+                }
+
+                return editControl;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Reads new values entered by the user for the field
+        /// </summary>
+        /// <param name="control">Parent control that controls were added to in the CreateEditControl() method</param>
+        /// <param name="configurationValues"></param>
+        /// <returns></returns>
+        public override string GetEditValue(Control control, Dictionary<string, ConfigurationValue> configurationValues)
+        {
+            var picker = control as DropDownList;
+            if (picker != null)
+            {
+                // picker has value as BenevolenceType.Guid
+                return picker.SelectedValue;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Sets the value.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <param name="configurationValues"></param>
+        /// <param name="value">The value.</param>
+        public override void SetEditValue(Control control, Dictionary<string, ConfigurationValue> configurationValues, string value)
+        {
+            var editControl = control as ListControl;
+            if (editControl != null)
+            {
+                editControl.SetValue(value);
+            }
+        }
+
+        #endregion
+
+        #region Entity Methods
+
+        /// <summary>
+        /// Gets the edit value as the IEntity.Id
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <returns></returns>
+        public int? GetEditValueAsEntityId(System.Web.UI.Control control, Dictionary<string, ConfigurationValue> configurationValues)
+        {
+            Guid guid = GetEditValue(control, configurationValues).AsGuid();
+            var item = new BenevolenceTypeService(new RockContext()).Get(guid);
+            return item != null ? item.Id : (int?)null;
+        }
+
+        /// <summary>
+        /// Sets the edit value from IEntity.Id value
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <param name="configurationValues">The configuration values.</param>
+        /// <param name="id">The identifier.</param>
+        public void SetEditValueFromEntityId(System.Web.UI.Control control, Dictionary<string, ConfigurationValue> configurationValues, int? id)
+        {
+            var item = new BenevolenceTypeService(new RockContext()).Get(id ?? 0);
+            string guidValue = item != null ? item.Guid.ToString() : string.Empty;
+            SetEditValue(control, configurationValues, guidValue);
+        }
+
+        /// <summary>
+        /// Gets the entity.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public IEntity GetEntity(string value)
+        {
+            return GetEntity(value, null);
+        }
+
+        /// <summary>
+        /// Gets the entity.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="rockContext">The rock context.</param>
+        /// <returns></returns>
+        public IEntity GetEntity(string value, RockContext rockContext)
+        {
+            Guid? guid = value.AsGuidOrNull();
+            if (guid.HasValue)
+            {
+                rockContext = rockContext ?? new RockContext();
+                return new BenevolenceTypeService(rockContext).Get(guid.Value);
+            }
+
+            return null;
+        }
+
+        #endregion
+
+    }
+}

--- a/Rock/Rock.csproj
+++ b/Rock/Rock.csproj
@@ -486,6 +486,7 @@
     <Compile Include="Attribute\AttributeCategoryFieldAttribute.cs" />
     <Compile Include="Attribute\AttributeFieldAttribute.cs" />
     <Compile Include="Attribute\AssessmentTypesFieldAttribute.cs" />
+    <Compile Include="Attribute\BenevolenceTypeFieldAttribute.cs" />
     <Compile Include="Attribute\BlockTemplateFieldAttribute.cs" />
     <Compile Include="Attribute\CheckListFieldAttribute.cs" />
     <Compile Include="Attribute\IconSvgAttribute.cs" />
@@ -792,6 +793,7 @@
     <Compile Include="Data\RockContextReadOnly.cs" />
     <Compile Include="Field\ConfigurationValueUsage.cs" />
     <Compile Include="Field\FieldTypeUsage.cs" />
+    <Compile Include="Field\Types\BenevolenceTypeFieldType.cs" />
     <Compile Include="Field\Types\MediaWatchFieldType.cs" />
     <Compile Include="Financial\GivingJourneyHelper.cs" />
     <Compile Include="Financial\IObsidianHostedGatewayComponent.cs" />

--- a/Rock/Workflow/Action/Finance/BenevolenceRequestAdd.cs
+++ b/Rock/Workflow/Action/Finance/BenevolenceRequestAdd.cs
@@ -39,13 +39,14 @@ namespace Rock.Workflow.Action
     [WorkflowTextOrAttribute( "Request Description", "Request Description Attribute", "Text or workflow attribute that contains the benevolence request description. <span class='tip tip-lava'></span>", false, "", "", 1, "RequestDescription",
         new string[] { "Rock.Field.Types.TextFieldType", "Rock.Field.Types.MemoFieldType" }, 3 )]
     [DefinedValueField( Rock.SystemGuid.DefinedType.BENEVOLENCE_REQUEST_STATUS, "Request Status", "The request status to use.", true, false, Rock.SystemGuid.DefinedValue.BENEVOLENCE_PENDING, "", 2 )]
-    [WorkflowAttribute( "Case Worker", "Workflow attribute that contains the person who should be assigned as the case worker.", false, "", "", 3, null,
+    [BenevolenceTypeField( "Benevolence Type", "The benevolence type to use.", true, SystemGuid.BenevolenceType.BENEVOLENCE, "", 3 )]
+    [WorkflowAttribute( "Case Worker", "Workflow attribute that contains the person who should be assigned as the case worker.", false, "", "", 4, null,
         new string[] { "Rock.Field.Types.PersonFieldType" } )]
-    [CampusField("Campus", "The campus for the request. If blank the person's campus will be used.", false, "", "", 4)]
-    [WorkflowTextOrAttribute( "Government Id", "Government Id Attribute", "Text or workflow attribute that contains the government. <span class='tip tip-lava'></span>", false, "", "", 5, "GovernmentId",
+    [CampusField("Campus", "The campus for the request. If blank the person's campus will be used.", false, "", "", 5)]
+    [WorkflowTextOrAttribute( "Government Id", "Government Id Attribute", "Text or workflow attribute that contains the government. <span class='tip tip-lava'></span>", false, "", "", 6, "GovernmentId",
         new string[] { "Rock.Field.Types.TextFieldType" } )]
 
-    [WorkflowAttribute( "Benevolence Request", "Workflow attribute to set the returned benevolence request to.", false, "", "", 6, null,
+    [WorkflowAttribute( "Benevolence Request", "Workflow attribute to set the returned benevolence request to.", false, "", "", 7, null,
         new string[] { "Rock.Field.Types.BenevolenceRequestFieldType" } )]
     public class BenevolenceRequestAdd : ActionComponent
     {
@@ -85,6 +86,16 @@ namespace Rock.Workflow.Action
             if ( statusValue == null )
             {
                 var errorMessage = "Invalid request status provided.";
+                errorMessages.Add( errorMessage );
+                action.AddLogEntry( errorMessage, true );
+                return false;
+            }
+
+            // get request type
+            var requestType = new BenevolenceTypeService( rockContext ).Get( GetAttributeValue( action, "BenevolenceType" ) );
+            if ( requestType == null )
+            {
+                var errorMessage = "Invalid benevolence type provided.";
                 errorMessages.Add( errorMessage );
                 action.AddLogEntry( errorMessage, true );
                 return false;
@@ -146,6 +157,7 @@ namespace Rock.Workflow.Action
 
             request.ConnectionStatusValueId = requestPerson.ConnectionStatusValueId;
             request.RequestStatusValueId = statusValue.Id;
+            request.BenevolenceTypeId = requestType.Id;
 
             rockContext.SaveChanges();
 


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

The "Benevolence Request Add" workflow action was failing with a foreign key exception because it wasn't setting any value for the new (added in v13) BenevolenceTypeId property. This issue just showed up in v13.4 because the presave hook that was setting a default value [was removed](https://github.com/SparkDevNetwork/Rock/commit/d9d5e8b9ad20af87496637b05d091faac97f8045).

This PR adds a new field type and attribute for Benevolence Type and also adds an option to the workflow action to select the desired Benevolence Type of the created request. 

For the workflow action attribute, I used `SystemGuid.BenevolenceType.BENEVOLENCE` as the default value so that the previous (v13 - v13.3) behavior was maintained if someone hasn't selected a different type.

Fixes: #5046 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

I have tested this fix against v13.4 as well as the develop branch (currently v1.14.0.13).

A simpler alternative I considered was to just hard-code the BenevelonceTypeId to `SystemGuid.BenevolenceType.BENEVOLENCE` in the workflow action. This would have restored the same functionality that was in v13 -v13.3 where the default type was always used.

I decided against that simpler solution because it is more flexible to allow the user to specify the type of request they are wanting to create.

## Documentation
N/A

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.