### PR TITLE
Fixed Schedule Type Dropdown not loading values on Campus Detail Block

### DIFF
--- a/RockWeb/Blocks/Core/CampusDetail.ascx.cs
+++ b/RockWeb/Blocks/Core/CampusDetail.ascx.cs
@@ -1026,6 +1026,7 @@ namespace RockWeb.Blocks.Core
         private void ShowCampusScheduleEdit( Guid campusScheduleGuid )
         {
             hfCampusScheduleGuid.Value = campusScheduleGuid.ToString();
+            dvpScheduleType.DefinedTypeId = DefinedTypeCache.Get(Rock.SystemGuid.DefinedType.SCHEDULE_TYPE.AsGuid()).Id;
             dlgSchedule.Show();
 
             if ( campusScheduleGuid == Guid.Empty )


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

Fixes: #5127 

The campus editor block was not correctly loading the values for the defined values picker for campus schedule types. The only option available was the default "Weekend Service" even though there were additional defined values.

The issue was because the pickers are assigned a DefinedTypeId in `LoadDropDowns` which is called by `ShowEditDetails` but the Schedule Type picker is in a modal that isn't on the screen at that point. When it gets added to the screen later, it didn't have a DefinedTypeId assigned and only showed the default value as an option.

I added assigning the DefinedTypeId to `ShowCampusScheduleEdit`; similar to how the topics were being loaded for `ShowCampusTopicEdit`. That causes it to load the values for the picker after it gets added to the screen.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.