### PR TITLE
Update Obsidian badges block to display HTML in tooltips by default

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Crm/PersonDetail/badges.ts
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Crm/PersonDetail/badges.ts
@@ -99,7 +99,7 @@ export default defineComponent({
                 return;
             }
 
-            tooltip(Array.from(containerRef.value.querySelectorAll(".rockbadge[data-toggle=\"tooltip\"]")));
+            tooltip(Array.from(containerRef.value.querySelectorAll(".rockbadge[data-toggle=\"tooltip\"]")), { html: true, sanitize: false });
             popover(Array.from(containerRef.value.querySelectorAll(".rockbadge[data-toggle=\"popover\"]")));
         });
 


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

In v13 and below tooltips on badges were set to display HTML by default. In the v14 Obsidian rewrite of the person profile page's badge block, you have to manually enable HTML on a per-badge basis with `data-html="true"`. 

This PR restores the pre-v14 functionality.

Fixes: #5263 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
I wasn't sure whether to just enable HTML or to also disable sanitization. I opted to restore the pre-v14 functionality of not sanitizing the badges since that is how it was before. Also, sanitization breaks tables in the badge tooltip.

Pre-v14 badge component showing that HTML was enabled and sanitization was disabled: https://github.com/SparkDevNetwork/Rock/blob/713c8e66d6c3066ba5e2d04f7664764d07c268cf/Rock/Web/UI/Controls/Badges/BadgeControl.cs#L168

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

Technically, no updates are necessary since the existing tooltip functionality wan't documented. It would be nice to add an example to the [badges page](https://community.rockrms.com/styling/components/badges) of the style guide showing how to do tooltips.

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.