### PR TITLE
Fixed an issue in Obsidian Registration Entry where the progress bar was using the wrong field for first name

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/utils.partial.ts
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/utils.partial.ts
@@ -18,7 +18,7 @@
 import { Guid } from "@Obsidian/Types";
 import { PersonBag } from "@Obsidian/ViewModels/Entities/personBag";
 import { newGuid } from "@Obsidian/Utility/guid";
-import { RegistrantBasicInfo, RegistrantInfo, RegistrantsSameFamily, RegistrationEntryBlockFormFieldViewModel, RegistrationEntryBlockFormViewModel, RegistrationEntryBlockViewModel, RegistrationPersonFieldType } from "./types";
+import { RegistrantBasicInfo, RegistrantInfo, RegistrantsSameFamily, RegistrationEntryBlockFormFieldViewModel, RegistrationEntryBlockFormViewModel, RegistrationEntryBlockViewModel, RegistrationPersonFieldType, RegistrationFieldSource } from "./types";
 
 /** If all registrants are to be in the same family, but there is no currently authenticated person,
  *  then this guid is used as a common family guid */
@@ -66,9 +66,9 @@ export function getDefaultRegistrantInfo(currentPerson: PersonBag | null, viewMo
 export function getRegistrantBasicInfo(registrant: RegistrantInfo, registrantForms: RegistrationEntryBlockFormViewModel[]): RegistrantBasicInfo {
     const fields = registrantForms?.reduce((acc, f) => acc.concat(f.fields), [] as RegistrationEntryBlockFormFieldViewModel[]) || [];
 
-    const firstNameGuid = fields.find(f => f.personFieldType === RegistrationPersonFieldType.FirstName)?.guid || "";
-    const lastNameGuid = fields.find(f => f.personFieldType === RegistrationPersonFieldType.LastName)?.guid || "";
-    const emailGuid = fields.find(f => f.personFieldType === RegistrationPersonFieldType.Email)?.guid || "";
+    const firstNameGuid = fields.find(f => f.personFieldType === RegistrationPersonFieldType.FirstName && f.fieldSource === RegistrationFieldSource.PersonField)?.guid || "";
+    const lastNameGuid = fields.find(f => f.personFieldType === RegistrationPersonFieldType.LastName && f.fieldSource === RegistrationFieldSource.PersonField)?.guid || "";
+    const emailGuid = fields.find(f => f.personFieldType === RegistrationPersonFieldType.Email && f.fieldSource === RegistrationFieldSource.PersonField)?.guid || "";
 
     return {
         firstName: (registrant?.fieldValues[firstNameGuid] || "") as string,


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This fixes an issue where the Obsidian Registration Entry block would use the value of the first field as the registrant's First Name in the progress bar instead of using the value of the First Name field.

This fixes this by adding an additional constraint to the function that finds the First Name field so that it can only find Person Fields.

Screenshot of before this fix (the value of the Text field is used as the first name on the progress bar):
![FirstNameOnProgressBarObsidianBlock](https://user-images.githubusercontent.com/110615344/231855646-86755d18-d322-4ca1-ab76-34820283a09a.png)

Screenshot of after this fix (the value of the First Name field is used as the first name on the progress bar):
![FirstNameOnProgressBarFix](https://user-images.githubusercontent.com/110615344/231855669-9ececeda-f9ec-4686-a5bb-91fc6d832a46.png)

Fixes: #5400 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1204413526410820">image.png</a>
