### PR TITLE
Fixed an issue in Obsidian Registration Entry where expired discount codes were throwing exception

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/discountCodeForm.partial.ts
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/discountCodeForm.partial.ts
@@ -104,9 +104,15 @@ export default defineComponent({
         async tryDiscountCode(): Promise<void> {
             this.loading = true;
             try {
+                let isExistingDiscountCode = false;
+                if (this.registrationEntryState.discountCode != "") {
+                    isExistingDiscountCode = this.viewModel.isExistingRegistration
+                }
+
                 const result = await this.invokeBlockAction<CheckDiscountCodeResult>("CheckDiscountCode", {
                     code: this.discountCodeInput,
-                    registrantCount: this.registrationEntryState.registrants.length
+                    registrantCount: this.registrationEntryState.registrants.length,
+                    isExistingRegistration: isExistingDiscountCode
                 });
 
                 if (result.isError || !result.data) {

--- a/Rock/Model/Event/Registration/RegistrationService.cs
+++ b/Rock/Model/Event/Registration/RegistrationService.cs
@@ -116,8 +116,9 @@ namespace Rock.Model
         /// <param name="currentPerson">The current person.</param>
         /// <param name="discountCode">The discount code in use that should be verified.</param>
         /// <param name="errorMessage">The error result.</param>
+        /// <param name="isExistingRegistration">If the registration is an existing registration.</param>
         /// <returns></returns>
-        public RegistrationContext GetRegistrationContext( int registrationInstanceId, Guid? registrationGuid, Person currentPerson, string discountCode, out string errorMessage )
+        public RegistrationContext GetRegistrationContext( int registrationInstanceId, Guid? registrationGuid, Person currentPerson, string discountCode, out string errorMessage, bool isExistingRegistration )
         {
             var rockContext = Context as RockContext;
             Registration registration = null;
@@ -139,7 +140,7 @@ namespace Rock.Model
             {
                 var registrationTemplateDiscountService = new RegistrationTemplateDiscountService( rockContext );
 
-                context.Discount = registrationTemplateDiscountService.GetDiscountByCodeIfValid( registrationInstanceId, discountCode );
+                context.Discount = registrationTemplateDiscountService.GetDiscountByCodeIfValid( registrationInstanceId, discountCode, isExistingRegistration );
 
                 if ( context.Discount == null )
                 {


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This change fixes an issue in the Obsidian Registration Entry block where when a user goes to make a payment on an existing registration that has a discount code that was valid at the time, but has since expired, the block throws an unhandled NullReferenceException.

This fixes the issue by disabling the discount code validator when the registration is an existing registration and the discount code was already filled in. This is the same approach that the C# block takes.

Screenshot of before this fix (an unhandled NullReferenceException is thrown when trying to make a payment on a registration that uses an expired discount code):

![ObsidianRegistrationExpiredDiscountCodesThrowingExceptionError](https://user-images.githubusercontent.com/110615344/235773548-5d1b3046-8084-419a-b4e7-102ff5b43738.png)

Screenshot of after this fix (the block doesn't validate the existing discount code and allows the user to make a payment):

![ObsidianRegistrationExpiredDiscountCodesThrowingExceptionFix](https://user-images.githubusercontent.com/110615344/235773627-bd070f45-746e-4fc9-b83c-6dd7dfd946de.png)

Fixes: #5430 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations