### PR TITLE
Fixed an issue where clicking the back button was throwing an exception

### DIFF
--- a/RockWeb/Blocks/CheckIn/AbilityLevelSelect.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/AbilityLevelSelect.ascx.cs
@@ -329,6 +329,8 @@ namespace RockWeb.Blocks.CheckIn
 
                 lNoOptionTitle.Text = GetAttributeValue( AttributeKey.NoOptionTitle );
                 lNoOptionCaption.Text = GetAttributeValue( AttributeKey.NoOptionCaption );
+
+                lbBack.Visible = false;
             }
             else
             {

--- a/RockWeb/Blocks/CheckIn/TimeSelect.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/TimeSelect.ascx.cs
@@ -87,7 +87,7 @@ namespace RockWeb.Blocks.CheckIn
                             if ( !schedules.Any() )
                             {
                                 CheckInPerson person = CurrentCheckInState.CheckIn.Families.Where( f => f.Selected ).SelectMany( f => f.People.Where( p => p.Selected ) ).FirstOrDefault();
-                                string msg = $"<p>{string.Format( GetAttributeValue( AttributeKey.NoCheckinOptionsMessage ), person.Person.FullName )}</p>" ;
+                                string msg = $"<p>{string.Format( GetAttributeValue( AttributeKey.NoCheckinOptionsMessage ), person?.Person?.FullName != null ? person.Person.FullName : "they" )}</p>";
                                 ProcessSelection( maWarning, () => schedules.Count > 0, msg, true );
                             }
 


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This change fixes an issue with check-in where a NullReferenceException is thrown and an error page is shown when a user is unable to checkin and clicks the "Back" button that is displayed on that page.

This change fixes that issue by doing two things. First, this change hides the "Back" button on the Ability Level Select block when the user is not able to check in. Second, this change also adds a null check to the Time Select block so that if somehow someone gets there with a null People list, the block will not break.

The following screenshot is before the change. Clicking the "Back" button would show an error page.
![A page that tells the user that they cannot check in with a "Back" button](https://github.com/SparkDevNetwork/Rock/assets/110615344/2aa999ec-da57-41e1-a802-5396c197c212)

The following screenshot is after the change. Notice that there is no longer a back button when the "Sorry, there are currently not any available options to check into." message is shown.
![A page that tells the user that they cannot check in without a "Back" button](https://github.com/SparkDevNetwork/Rock/assets/110615344/402fe72c-ff9e-48d7-94f8-54edfca83452)

Fixes: #5446

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations