### PR TITLE
Update WebsiteLavaTemplateCache to respect the Cache Control setting on the admin toolbar

### DIFF
--- a/Rock/Lava/WebsiteLavaTemplateCache.cs
+++ b/Rock/Lava/WebsiteLavaTemplateCache.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 //
+using System;
+using System.Collections.Generic;
 using Rock.Web.Cache;
 
 namespace Rock.Lava
@@ -31,5 +33,27 @@ namespace Rock.Lava
         public ILavaTemplate Template { get; set; }
 
         #endregion
+
+        /// <summary>
+        /// Gets an item from cache, and if not found, executes the itemFactory to create item and add to cache.
+        /// The CACHE_CONTROL_COOKIE will be inspected to see if cached value should be ignored.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="itemFactory">The item factory.</param>
+        /// <param name="keyFactory">The key factory to create a list of keys for the type. This will only be used if a list does not already exist.</param>
+        /// <returns></returns>
+        internal protected static new WebsiteLavaTemplateCache GetOrAddExisting( string key, Func<WebsiteLavaTemplateCache> itemFactory, Func<List<string>> keyFactory = null )
+        {
+            if ( System.Web.HttpContext.Current != null )
+            {
+                var isCachedEnabled = System.Web.HttpContext.Current.Request.Cookies.Get( RockCache.CACHE_CONTROL_COOKIE );
+                if ( isCachedEnabled != null && !isCachedEnabled.Value.AsBoolean() )
+                {
+                    return null;
+                }
+            }
+
+            return ItemCache<WebsiteLavaTemplateCache>.GetOrAddExisting( key, itemFactory, keyFactory );
+        }
     }
 }


### PR DESCRIPTION
## Notice

**In case you are submitting a non bug-fix-PR, we highly recommend you to engage in a PR discussion first.**

There are many factors we consider before accepting a pull request. This includes:
1. Whether or not the Rock system you run is a standard, main-line build. If it is not, there is a lower chance we will accept your request since it may impact some other part of the system you don't regularly use.
2. Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock.

With the PR discussion we can assess your proposed changes before you start working on it so that we can come up with the best possible approach to it. This may include:
1. Coming up with an alternate approach that does not involve changes to core.
2. Advising how your proposed solution be done in a different way that is more efficient and consistent with the rest of the system.
3. Have one of our core developers make the changes for you. This may be the case if the change involves intricate tasks like an EF migration or something similar.


## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Please include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

Fixes: #5249 

Currently, when you are trying to change the contents of a lava include file (using Magnus or editing the file directly on the server), the changes can take several minutes to show up unless you manually clear the cache. This is because the WebsiteLavaTemplateCache is [using a hash of the content as the cache key](https://github.com/SparkDevNetwork/Rock/blob/6176894de4a2ed5495fad3efa22036617b908803/Rock/Lava/WebsiteLavaTemplateCacheService.cs#L254). 

Normally this is fine because a change to the lava would invalidate the cache. However, with an `{% include %}` tag, there is no change to the lava that is being processed (It's hashing the include statement, not the contents of the included file).

In this PR, I've modified the WebsiteLavaTemplateCache to look at the "cache bypass" setting similar to how this setting affects the RockCache. This will allow an admin to bypass the template cache while developing.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

I originally wanted to find a way to have the cache look at the contents of the included file. However, the processing for the `{% include %}` tag is implemented in the Fluid library. 

Without making changes to the Fluid library, the best solution I could find was to bypass the lava template caching when the cache bypass is enabled.

I copied basically the same logic that was used in RockCache to bypass the cache: https://github.com/SparkDevNetwork/Rock/blob/7e8513ff4d670e8640d1ec215068cfc630fda8c1/Rock/Web/Cache/RockCache.cs#L330-L337

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.