### PR TITLE
Workflow - Fixed Issue Caused By Double Clicking Action Buttons

### DIFF
--- a/Rock/Model/Workflow/WorkflowActionForm/WorkflowActionFormUserAction.cs
+++ b/Rock/Model/Workflow/WorkflowActionForm/WorkflowActionFormUserAction.cs
@@ -113,7 +113,7 @@ namespace Rock.Model
 
             // Add other buttons that have been configured to disable validation.
             // In accordance with the Rock documentation, button validation can be disabled
-            // by replacing the text "{{ ButtonClick }}" with "return true;" in the Button HTML Attribute.
+            // by replacing the text "{{ ButtonClick }}" with "{{ ButtonCancel }}" in the Button HTML Attribute.
             // Add any buttons with this configuration to the collection of Cancel buttons.
             var buttonType = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.BUTTON_HTML );
 
@@ -126,7 +126,7 @@ namespace Rock.Model
                     buttonHtml = buttonHtml.ToLower().Replace( " ", "" );
 
                     if ( !buttonHtml.Contains( "{{buttonclick}}" )
-                         && buttonHtml.Contains( "onclick=\"returntrue;\"" ) )
+                         && buttonHtml.Contains( "onclick=\"{{buttoncancel}}\"" ) )
                     {
                         cancelButtonList.Add( buttonDefinedValue.Guid );
                     }

--- a/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx
+++ b/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx
@@ -131,10 +131,24 @@
                     }
                 }
 
+                var buttons = document.querySelectorAll("div.workflow-entry-panel div.actions a.btn");
+                buttons.forEach(e => e.setAttribute("disabled", "true"));
+
                 return true;
             }
+            function handleWorkflowCancelButtonClick() {
+                var buttons = document.querySelectorAll("div.workflow-entry-panel div.actions a.btn");
+                buttons.forEach(e => e.setAttribute("disabled", "true"));
 
+                return true;
+            }
         </script>
+
+        <style>
+            .btn.disabled, .btn[disabled], fieldset[disabled] .btn {
+                pointer-events: none;
+            }
+        </style>
 
     </ContentTemplate>
 </asp:UpdatePanel>

--- a/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
+++ b/RockWeb/Blocks/WorkFlow/WorkflowEntry.ascx.cs
@@ -2707,6 +2707,9 @@ namespace RockWeb.Blocks.WorkFlow
 
                 buttonMergeFields.Add( "ButtonClick", buttonClickScript );
 
+                string buttonCancelScript = "handleWorkflowCancelButtonClick();";
+                buttonMergeFields.Add( "ButtonCancel", buttonCancelScript );
+
                 var buttonLinkScript = Page.ClientScript.GetPostBackClientHyperlink( this, button.ActionName );
                 buttonMergeFields.Add( "ButtonLink", buttonLinkScript );
 


### PR DESCRIPTION
## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Please include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This fixes an issue where double-clicking the action buttons on a workflow form would cause an error. This fixes that issue by putting some client-side JavaScript on the page that disables all action buttons after one has been clicked as long as the form is valid. This prevents subsequent clicks from registering before the postback has been completed.

One result of this fix is that the Cancel button and other buttons that skip validation will need to have the `handleWorkflowCancelButtonClick()` JavaScript function in their `onclick` event instead of having "`return true;`". The new JavaScript function returns true after it handles disabling the action buttons so that they can't be clicked before the postback completes. I've put this new function in the ButtonCancel merge field so that if someone wants to change a normal button to a button that ignores validation, they just have to change "`{{ ButtonClick }}`" to "`{{ ButtonCancel }}`" in the button's HTML.

If a Rock instance ends up with "`return true;`" instead of "`{{ ButtonCancel }}`", the Cancel buttons on their workflow forms will have the same bug that they currently have. To get this fix, they will need to use "`{{ ButtonCancel }}`".

Fixes: #5723

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

There is a line in the Blasting Off With Workflows book that will need to be updated. The section that will need updating is Working With Entry Forms > Buttons > Cancel Buttons. Here, the last sentence will need to be changed from:

> To keep the validation from occurring simply use the Cancel button type or change the {{ ButtonClick }} merge field to be "return true;".

To:

> To keep the validation from occurring simply use the _Cancel_ button type or change the {{ ButtonClick }} merge field to be "{{ ButtonCancel }}".

## Migrations

A migration will need to be built that looks at the [Button HTML defined type](https://rocksolidchurchdemo.com/admin/general/defined-types/44) and replace "`onclick="return true;"`" with "`onclick="{{ ButtonCancel }}"`" in the Button HTML field for each of the defined values.

I would be willing to write the migration for this if someone would be able to point me in the direction of some documentation for how to write migrations.