### PR TITLE
Update Default Lava Template to only include Additional Confirmation Details if the registrant count is greater than 0.

### DIFF
--- a/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx.cs
+++ b/RockWeb/Blocks/Event/RegistrationTemplateDetail.ascx.cs
@@ -126,9 +126,11 @@ namespace RockWeb.Blocks.Event
 </p>
 {% endif %}
 
-<p>
-    {{ RegistrationInstance.AdditionalConfirmationDetails }}
-</p>
+{% if registrantCount > 0 %}
+    <p>
+        {{ RegistrationInstance.AdditionalConfirmationDetails }}
+    </p>
+{% endif %}
 
 <p>
     If you have any questions please contact {{ RegistrationInstance.ContactPersonAlias.Person.FullName }} at {{ RegistrationInstance.ContactEmail }}.


### PR DESCRIPTION
## Proposed Changes
Currently the default lava template confirmation email includes the Event Registration Instance's Additional Confirmation Details for waitlist members. The waitlist members receive this same confirmation email when they are moved off of the waitlist and complete registration. The additional confirmation details are NOT needed in the initial confirmation email they receive, and just serve to confuse the waitlist registrar.This PR will cause the Default Lava Template for the Confirmation Email to exclude Waitlist recipients from receiving the Additional Confirmation Details portion of the confirmation email.@KarenRossi84 discovered this issue. We've also discussed this with @mikejed to try and confirm my sanity ;)Fixes: #5747

## Types of changes
What types of changes does your code introduce to Rock?

_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
* [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging. 
* [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
* [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
* [ ] Unit tests pass locally with my changes -- **I don't know how to do unit tests**
* [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
* [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

-->

It would be neat if there was a way to write a migration to go in and update _existing_ lava templates to include the {% if %} loop. But I don't know how to do so, if it's even possible.

## Documentation
<!--

If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.

-->

The section in the documentation for the Event & Calendar Guide should be updated with language calling out that waitlist recipients do not receive the additional confirmation details. For example, change it from:

> While you're free to modify this email, we've provided a template that should work in most cases. Below we've shown what this sample email will look like. Note that the highlighted section comes from the Additional Confirmation Details field of the registration instance.

To:

> While you're free to modify this email, we've provided a template that should work in most cases. Below we've shown what this sample email will look like. Note that the highlighted section comes from the Additional Confirmation Details field of the registration instance. The provided lava template _does not_ include Additional Confirmation Details for waitlist recipients.

Thanks!


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206586198709555