### PR TITLE
Fixed a Formatting on the Group History Timeline Lava Template

### DIFF
--- a/RockWeb/Themes/Rock/Assets/Lava/GroupHistoryTimeline.lava
+++ b/RockWeb/Themes/Rock/Assets/Lava/GroupHistoryTimeline.lava
@@ -218,7 +218,7 @@
                 {%- if dateDiff > 1 -%}
                 {%- assign dateLabel = historySummaryByDateByVerb.FirstHistoryDateTime | Date:'dddd, MMMM d' -%}
                 <span>{{ dateLabel }}{%- if currentYear != firstHistoryYear -%}
-                {{ firstHistoryYear }}
+                {{ ', ' | Append:firstHistoryYear }}
                 {%- endif -%}</span>
                 {%- elseif dateDiff == 1 -%}
                     Yesterday


### PR DESCRIPTION
## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Please include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This fixes an issue in the Group History Timeline lava template where there would not be a space between the date and the year on section headings. This fixes that issue by appending a comma and space to the beginning of the year in order to follow date formatting conventions. Appending this to the beginning of the year means that the comma and space will only be shown if the year is.

**Before this fix:**

![GroupHistoryYearBefore](https://github.com/SparkDevNetwork/Rock/assets/110615344/4e2eb6c5-98a4-421d-813e-fb5cfb97b9ae)

**After this fix:**

![GroupHistoryYearAfter](https://github.com/SparkDevNetwork/Rock/assets/110615344/1b4f10a0-ed3a-4d3b-9837-b4d736e5445f)

Fixes: #5826 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
<!--
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
-->