### PR TITLE
Add GroupLocations to Attendance Reminders Job

### DIFF
--- a/Rock/Jobs/SendGroupAttendanceReminders.cs
+++ b/Rock/Jobs/SendGroupAttendanceReminders.cs
@@ -46,12 +46,6 @@ namespace Rock.Jobs
         IsRequired = true,
         DefaultValue = "1",
         Order = 1 )]
-    [GroupTypeField( "Group Type",
-        Description = "The Group type to send attendance reminders for.",
-        IsRequired = false,
-        DefaultValue = Rock.SystemGuid.GroupType.GROUPTYPE_SMALL_GROUP,
-        Order = 0,
-        Key = AttributeKey.GroupType)]
 
     #endregion Job Attributes
 
@@ -68,12 +62,6 @@ namespace Rock.Jobs
             /// The method to use when determining how the notice should be sent.
             /// </summary>
             public const string SendUsing = "SendUsing";
-
-            /// <summary>
-            /// The Group Type to limit what Groups get sent reminders.
-            /// </summary>
-            public const string GroupType = "GroupType"
-
         }
 
         #endregion Attribute Keys
@@ -118,17 +106,9 @@ namespace Rock.Jobs
                 }
             }
 
-            var selectedGroupType = GroupTypeCache.Get( GetAttributeValue( AttributeKey.GroupType ) );
-
             var groupTypeQry = new GroupTypeService( rockContext ).Queryable()
                 .Where( t => t.TakesAttendance && t.SendAttendanceReminder )
                 .Include( t => t.AttendanceReminderSystemCommunication );
-
-            if ( selectedGroupType != null )
-            {
-                groupTypeQry = groupTypeQry
-                    .Where( g => g.Id == selectedGroupType.Id );
-            }
 
             var groupTypeList = groupTypeQry.ToList();
             foreach ( var groupType in groupTypeList )


### PR DESCRIPTION
Adds Reminders for Group Locations and Schedule Preferences to the SendGroupAttendanceReminders Job


## Notice

**In case you are submitting a non bug-fix-PR, we highly recommend you to engage in a PR discussion first.**

There are many factors we consider before accepting a pull request. This includes:
1. Whether or not the Rock system you run is a standard, main-line build. If it is not, there is a lower chance we will accept your request since it may impact some other part of the system you don't regularly use.
2. Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock.

With the PR discussion we can assess your proposed changes before you start working on it so that we can come up with the best possible approach to it. This may include:
1. Coming up with an alternate approach that does not involve changes to core.
2. Advising how your proposed solution be done in a different way that is more efficient and consistent with the rest of the system.
3. Have one of our core developers make the changes for you. This may be the case if the change involves intricate tasks like an EF migration or something similar.


## Proposed Changes

# Significant Update to Send Attendance Reminders Job

## Description:

This PR introduces a significant update to the Send Attendance Reminders Job. Our church was looking for a solution to send out Attendance Reminders for Group Locations instead of just the Group's Schedule property.

The existing Core Job has so much of this functionality already built out that it seems like a good start would be modifying it to accept GroupLocations and Schedule Preferences. This would be an opt-in feature of the Service Job, so that the existing functionality remains unchanged upon upgrade but the administrators could make changes that engage the new parts.
 
Three additional Group Type properties could be useful for this change:
1. Limit Group Leader Attendance Reminders to Schedule Preferences
2. Create Attendance Reminders for GroupLocations
3. Always Send First Reminder:

Example for Always Send First Reminder:
**Serving Teams**
  1. People can check in at an iPad when check in is open, often an hour before the event time. 
  2. The group leader can get a message to add/review/edit attendance.  At this point, that first send date time has been recorded. 
  3. Now that there is at least one attendance record plus an initial send date time, we should not be sending follow up messages to the leader.
  
**Small Groups** (in line with what is currently existing) 
  1. There is no check in ahead of time. 
  2. The group leader gets a text message to add attendance records. At this point, that first send date time has been recorded. 
  3. If the group leader does not take attendance, no records exist, so follow up continues. 
  5. Once an attendance record exists or the reminder pattern reaches the end of what is set in the group type, follow up stops. 

## Changes Made:

1. **Add boolean property to Group Type for Sending Reminders for Checkin Attendance:**
- **Discussion:** Create a new **Group Type** property or setting that enables the **Group Type** to send Attendance Reminders for **Attendance Occurrences** that already have Attendees. A reason an **Attendance Occurrence** would have Attendees before reminders would be iPad check-in or kiosk check-in. It would be useful to enable the Group Leaders to receive Attendance Reminders for even these in case **Group Members** slip through the cracks.

  

2. **Use the Group’s GroupLocations for Creating Attendance Occurrences:**

- **Old Code:**

```csharp
    private static List<GroupOccurrence> GetOccurrencesForSchedule(
        Schedule schedule,
        List<DateTime> dates,
        DateTime startDate,
        DateTime endDate,
        TimeSpan reminderTimeOffset,
        Location location = null )
    {
        var occurrences = new List<GroupOccurrence>();

        if ( !string.IsNullOrWhiteSpace( schedule?.iCalendarContent ) )
        {
            var icalDates = schedule.GetICalOccurrences( startDate, endDate );
            // If schedule has an iCal schedule, get occurrences between start and end dates
            foreach( var occurrence in icalDates )
            {
                var startTime = occurrence.Period.StartTime.Value;
                var sendRemindersStartingAt = startTime.TimeOfDay.Subtract( reminderTimeOffset );

                if ( dates.Contains( startTime.Date ) && RockDateTime.Now.TimeOfDay >= sendRemindersStartingAt )
                {
                    // Include this occurrence
                    occurrences.Add( new GroupOccurrence { OccurrenceDate = startTime, Location = location, Schedule = schedule } );
                }
            }
        }
        else if ( schedule?.WeeklyDayOfWeek.HasValue ?? false)
        {
            // If schedule does not have an iCal, then check for weekly schedule and calculate occurrences starting with first attendance or current week
            foreach( var date in dates )
            {
                if ( date.DayOfWeek == schedule.WeeklyDayOfWeek.Value )
                {
                    var startTime = date;
                    if ( schedule.WeeklyTimeOfDay.HasValue )
                    {
                        startTime = startTime.Add( schedule.WeeklyTimeOfDay.Value );
                    }

                    var sendRemindersStartingAt = startTime.TimeOfDay.Subtract( reminderTimeOffset );
                    if ( RockDateTime.Now.TimeOfDay >= sendRemindersStartingAt )
                    {
                        //Include this occurrence
                        occurrences.Add( new GroupOccurrence { OccurrenceDate = startTime, Location = location, Schedule = schedule } );
                    }
                }
            }
        }
        return occurrences;
    }
}
```

- **New Code:**

```csharp
  /// <summary>
  /// Gets all occurrence dates.
  /// </summary>
  /// <param name="groupType">Type of the group.</param>
  /// <param name="dates">The dates.</param>
  /// <param name="startDate">The start date.</param>
  /// <param name="endDate">The end date.</param>
  /// <param name="rockContext">The rock context.</param>
  /// <returns></returns>
  private static Dictionary<int, List<GroupOccurrence>> GetAllOccurenceDates(
      GroupType groupType,
      List<DateTime> dates,
      DateTime startDate,
      DateTime endDate,
      RockContext rockContext )
  {
      var groupService = new GroupService( rockContext );

      // Find all 'occurrences' for the groups that occur on the affected dates
      var occurrences = new Dictionary<int, List<GroupOccurrence>>();
      var groupsToRemind = groupService
          .Queryable( "Schedule" ).AsNoTracking()
          .IsGroupType( groupType.Id )
          .IsActive()
          .HasActiveLeader()
          .Where( g => g.ScheduleId.HasValue || g.GroupLocations.Any( gl => gl.Schedules.Any() ) );

      var currentTime = RockDateTime.Now.TimeOfDay;
      int groupTypeOffSetMinutes = groupType.AttendanceReminderSendStartOffsetMinutes ?? 0;
      var reminderTimeOffset = new TimeSpan( 0, groupTypeOffSetMinutes, 0 );

      foreach (var group in groupsToRemind)
      {
          // Add the group 
          occurrences.Add( group.Id, new List<GroupOccurrence>() );

          if ( group.ScheduleId.HasValue )
          {
              var scheduleOccurrences = GetOccurrencesForSchedule( group.Schedule, dates, startDate, endDate, reminderTimeOffset );
              occurrences[group.Id].AddRange( scheduleOccurrences );
          }

          var groupLocations = group.GroupLocations;
          foreach( var groupLocation in groupLocations )
          {
              var groupSchedules = groupLocation.Schedules;
              foreach( var schedule in groupSchedules )
              {
                  var scheduleOccurrences = GetOccurrencesForSchedule( schedule, dates, startDate, endDate, reminderTimeOffset, groupLocation.Location );
                  occurrences[group.Id].AddRange( scheduleOccurrences );
              }
          }
      }

      return occurrences;
  }
```

- **Discussion:** The update allows for **Attendance Occurrences** to be created using the Group’s **GroupLocations** (if available). The original way of solely using the Group's **Schedule** property would still be functional.


3. **Send Attendance Reminders to Group Leaders Only if the Occurrence Matches Their Schedule Preference:**



```csharp
var schedulePreferences = leader.GroupMemberAssignments.ToList();

//If the leader has preferences, then only create messages for their preferences (scheduleId)
// If they don't have preferences, then we can send out messages for all the occurrences to them.
var leaderOccurrences = occurrences.FirstOrDefault( o => o.Key == leader.GroupId ).Value;

if ( schedulePreferences.Count > 0)
{
    leaderOccurrences = leaderOccurrences
        .Where(leaderOccurrence => schedulePreferences
            .Any(schedulePreference =>
                IsScheduleMatch(leaderOccurrence, schedulePreference)
                && IsLocationMatch(leaderOccurrence, schedulePreference)
        ))
        .ToList();
}
```

- **Discussion:** This change allows for Group Leaders to only be sent Attendance Reminders for Attendance Occurrences when they match their Schedule Preferences (Group Member Assignments).
	- The logic here is that we're checking:
	  - If the Occurrence's Schedule and the Leader's Schedule Preference Match
	  - If the Occurrence's Location matches the Leader's Schedule Preference Location, or the Attendance Occurrence's Location is null, or the Leader's Schedule Preference Location is null.

This change would increase the relevancy of the Attendance Reminders for the Group Leaders. This should also be implemented as a property/setting in the **Group Type**. The rationale for this would be that Groups of Group Type A should use GroupLocations and Schedule, while Groups of Group Type B only use Schedule.

  

4. **Simplify Attendance Occurrence Code Using Core GetOrAdd() Method:**

- **Old Code:**

```csharp
 /// <summary>
 /// Creates the attendance occurence for sent reminders (so that we know not to send the same reminder again today).
 /// </summary>
 /// <param name="occurrenceDate">The occurrence date.</param>
 /// <param name="leader">The leader.</param>
 private void CreateAttendanceOccurenceForSentReminders( DateTime occurrenceDate, GroupMember leader )
 {
	 /*
	     3/16/2023 - SMC
	     The purpose of this method is to store the current time on an AttendanceOccurrence in the
	     AttendanceReminderLastSentDateTime field, so that we know attendance reminders have already
	     been sent for this occurrence today (so that when the job runs again on the same day, it does
	     not re-send the same notifications it already sent.

	     This method will first look for an existing AttendanceOccurrence record before creating one.
	     Note that we cannot use the AttendanceOccurrenceService.GetOrAdd() methods because the job is
	     unaware of the location, but we may need to read existing occurrences that have a location.

	     Reason: Tracking sent attendance reminders.
	 */

         using ( var rockContext = new RockContext() )
         {
             var attendanceOccurrenceService = new AttendanceOccurrenceService( rockContext );

             // Check for an existing attendance occurrence record.
             var attendanceOccurrence = attendanceOccurrenceService.Queryable()
                 .Where(
                     o => o.OccurrenceDate == occurrenceDate.Date
                     && o.GroupId == leader.GroupId
                     && o.ScheduleId == leader.Group.ScheduleId
                 ).FirstOrDefault();

             if ( attendanceOccurrence == null )
             {
                 // Create the AttendanceOccurrence record for this occurrence.
                 attendanceOccurrence = new AttendanceOccurrence
                 {
                     OccurrenceDate = occurrenceDate,
                     GroupId = leader.GroupId,
                     ScheduleId = leader.Group.ScheduleId,
                 };
                 attendanceOccurrenceService.Add( attendanceOccurrence );
             }

             attendanceOccurrence.AttendanceReminderLastSentDateTime = RockDateTime.Now;

             rockContext.SaveChanges();
         }
     }
 }
```

- **New Code:**

```csharp
///  <summary>
/// Creates the attendance occurrence for sent reminders (so that we know not to send the same reminder again today).
///  </summary>
///  <param  name="occurrenceDate">The occurrence date.</param>
///  <param  name="leader">The leader.</param>
private void CreateAttendanceOccurrenceForSentReminders( GroupOccurrence occurrence, GroupMember leader )
{
	using ( var rockContext = new RockContext() )
	{
		var attendanceOccurrenceService = new AttendanceOccurrenceService(rockContext);
		var attendanceOccurrence = attendanceOccurrenceService.GetOrAdd( occurrence.OccurrenceDate, leader.GroupId, occurrence.Location?.Id, occurrence.Schedule.Id );
		attendanceOccurrence.AttendanceReminderLastSentDateTime = RockDateTime.Now;
		rockContext.SaveChanges();
	}
}
```

- **Discussion:** This simplification reduces the LOC for the `CreateAttendanceOccurrenceForSentReminders` method and leverages an existing `GetOrAdd` method from the AttendanceOccurrenceService class. This change could already be used if you swap in a null value for the `locationId` parameter.

```csharp
/// <summary>
/// Gets the specified occurrence record, creating it if necessary. Ensures that an AttendanceOccurrence
/// record exists for the specified date, schedule, locationId and group. If it doesn't exist, it is
/// created and saved to the database.
/// NOTE: When looking for a matching occurrence, if null groupId, locationId or scheduleId is given
/// any matching record must also not have a group, location or schedule.
/// </summary>
/// <param name="occurrenceDate">The occurrence date.</param>
/// <param name="groupId">The group identifier.</param>
/// <param name="locationId">The location identifier.</param>
/// <param name="scheduleId">The schedule identifier.</param>
/// <returns>An existing or new attendance occurrence</returns>
public AttendanceOccurrence GetOrAdd( DateTime occurrenceDate, int? groupId, int? locationId, int? scheduleId )
{
    return GetOrAdd( occurrenceDate, groupId, locationId, scheduleId, null );
}
```
The above is the `GetOrAdd` method from `AttendanceOccurrenceService.cs`

  

## Assumptions
Below is a listing of key assumptions for this work:

1. **Groups with GroupLocations also have a Schedule attached to either the GroupLocation or the Group itself:**
- **Assumption:** GroupLocations without a Schedule attached will use the Group’s Schedule.

2. **Groups with Schedules will still be able to send Attendance Reminders as usual:**
- **Assumption:** Existing functionality remains intact and operational.

3. **Group Leaders without Schedule Preferences get Reminders for all Occurrences:**
- **Assumption:** Default behavior ensures leaders without specific preferences receive all reminders.

# Alternatives

Several alternatives were considered before settling on the current proposal:

1. **Service Job Attributes instead of modifying Group Type:** 
   - Put Attributes on the Service Job for check-in reminders and GroupLocation Reminders, instead of modifying the **Group Type** model.
   - This isn't as flexible as modifying **Group Type**, but it does reduce a possible migration

2. **Workflow Method:**
   - If someone has a way to do this with Workflows that is fast and easy to understand, then that'd be a definite alternative.

# Adoption Strategy

To ensure smooth adoption of the updates, the following steps will be taken:

1. **Documentation:** 
   - Update the manuals to reflect the new changes to the Service Job so churches are aware of any changes should make.
   - Provide comments in the Release Notes that describe the modification to the Service Job and/or **Group Type** model.

2. **Opt-in Changes:** 
   - The changes would not immediately affect how the Service Job currently performs on an upgrade. 
   - If the Service Job should accept new attributes, then they should have default values that match the current behavior of the Job.
   - If the Group Type should be modified for new properties (check-in reminders and/or Group Location reminders), then it should not affect the current behavior of the Job either.
	   - The default values of the properties would reflect what is currently shown (so probably both false values)

# Unresolved Questions

If there is anything I missed in this write-up feel free to let me know. This is a hefty PR and since it affects a core Job it's necessary to have input on the implementation details.

---

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
We chose this solution because the Service Job had a good foundation to start from. We attempted to wire up a few Workflows that used the REST API, however, that wouldn't be as simple a solution as this is.
We are currently exploring a custom Job (not an outright replacement of the Core job) to handle Attendance Reminders in this new way.
Any comments and questions are welcome for expanding on this further and nailing everything down.

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->
This change shouldn't affect the UI of anything severely. However, it should be documented in the manuals (if it were to be accepted) so that churches have knowledge of the new capabilities and how they can leverage them.

## Migrations
This PR may or may not require a Migration depending on how the implementation details get worked out. The Migration would be on the GroupType model to add additional settings.