### PR TITLE
Add Weekly to DateDiff Lava filter

### DIFF
--- a/Rock.Lava/Filters/Generic/TemplateFilters.DatesAndTimes.partial.cs
+++ b/Rock.Lava/Filters/Generic/TemplateFilters.DatesAndTimes.partial.cs
@@ -207,7 +207,7 @@ namespace Rock.Lava.Filters
                     case "m":
                         return ( Int64 ) difference.TotalMinutes;
                     case "w":
-                        return (Int64)(difference.TotalDays / 7);
+                        return ( Int64 )( difference.TotalDays / 7 );
                     case "M":
                         return ( Int64 ) GetMonthsBetween( startDto.Value, endDto.Value );
                     case "Y":

--- a/Rock.Lava/Filters/Generic/TemplateFilters.DatesAndTimes.partial.cs
+++ b/Rock.Lava/Filters/Generic/TemplateFilters.DatesAndTimes.partial.cs
@@ -206,6 +206,8 @@ namespace Rock.Lava.Filters
                         return ( Int64 ) difference.TotalHours;
                     case "m":
                         return ( Int64 ) difference.TotalMinutes;
+                    case "w":
+                        return (Int64)(difference.TotalDays / 7);
                     case "M":
                         return ( Int64 ) GetMonthsBetween( startDto.Value, endDto.Value );
                     case "Y":

--- a/Rock.Tests.UnitTests/Rock/Lava/Filters/DateFilterTests.cs
+++ b/Rock.Tests.UnitTests/Rock/Lava/Filters/DateFilterTests.cs
@@ -666,22 +666,22 @@ namespace Rock.Tests.UnitTests.Lava
         public void DateDiff_CompareDifferenceInWeeks()
         {
             // Same date should result in 0 weeks
-            TestHelper.AssertTemplateOutput("0", "{{ '01-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "0", "{{ '01-Jan-2024' | DateDiff:'01-Jan-2024','w' }}" );
         
             // 7 days apart should result in 1 week
-            TestHelper.AssertTemplateOutput("1", "{{ '01-Jan-2024' | DateDiff:'08-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "1", "{{ '01-Jan-2024' | DateDiff:'08-Jan-2024','w' }}" );
         
             // 6 days apart should result in 0 weeks (round down)
-            TestHelper.AssertTemplateOutput("0", "{{ '01-Jan-2024' | DateDiff:'07-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "0", "{{ '01-Jan-2024' | DateDiff:'07-Jan-2024','w' }}" );
         
             // 11 days apart should result in 1 week (round down)
-            TestHelper.AssertTemplateOutput("1", "{{ '01-Jan-2024' | DateDiff:'12-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "1", "{{ '01-Jan-2024' | DateDiff:'12-Jan-2024','w' }}" );
         
             // 14 days apart should result in 2 weeks
-            TestHelper.AssertTemplateOutput("2", "{{ '01-Jan-2024' | DateDiff:'15-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "2", "{{ '01-Jan-2024' | DateDiff:'15-Jan-2024','w' }}" );
         
             // 21 days apart should result in 3 weeks
-            TestHelper.AssertTemplateOutput("3", "{{ '01-Jan-2024' | DateDiff:'22-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "3", "{{ '01-Jan-2024' | DateDiff:'22-Jan-2024','w' }}" );
         }
         
         /// <summary>
@@ -691,10 +691,10 @@ namespace Rock.Tests.UnitTests.Lava
         public void DateDiff_CompareEarlierDateInWeeks_YieldsNegativeInteger()
         {
             // Negative intervals
-            TestHelper.AssertTemplateOutput("-1", "{{ '08-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
-            TestHelper.AssertTemplateOutput("-1", "{{ '12-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
-            TestHelper.AssertTemplateOutput("-2", "{{ '15-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
-            TestHelper.AssertTemplateOutput("-3", "{{ '22-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput( "-1", "{{ '08-Jan-2024' | DateDiff:'01-Jan-2024','w' }}" );
+            TestHelper.AssertTemplateOutput( "-1", "{{ '12-Jan-2024' | DateDiff:'01-Jan-2024','w' }}" );
+            TestHelper.AssertTemplateOutput( "-2", "{{ '15-Jan-2024' | DateDiff:'01-Jan-2024','w' }}" );
+            TestHelper.AssertTemplateOutput( "-3", "{{ '22-Jan-2024' | DateDiff:'01-Jan-2024','w' }}" );
         }
 
 

--- a/Rock.Tests.UnitTests/Rock/Lava/Filters/DateFilterTests.cs
+++ b/Rock.Tests.UnitTests/Rock/Lava/Filters/DateFilterTests.cs
@@ -660,6 +660,45 @@ namespace Rock.Tests.UnitTests.Lava
         #region Filter Tests: DateDiff
 
         /// <summary>
+        /// Requesting the difference between two dates in weeks should yield the result as multiples of 7 days, rounding down.
+        /// </summary>
+        [TestMethod]
+        public void DateDiff_CompareDifferenceInWeeks()
+        {
+            // Same date should result in 0 weeks
+            TestHelper.AssertTemplateOutput("0", "{{ '01-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+        
+            // 7 days apart should result in 1 week
+            TestHelper.AssertTemplateOutput("1", "{{ '01-Jan-2024' | DateDiff:'08-Jan-2024','w' }}");
+        
+            // 6 days apart should result in 0 weeks (round down)
+            TestHelper.AssertTemplateOutput("0", "{{ '01-Jan-2024' | DateDiff:'07-Jan-2024','w' }}");
+        
+            // 11 days apart should result in 1 week (round down)
+            TestHelper.AssertTemplateOutput("1", "{{ '01-Jan-2024' | DateDiff:'12-Jan-2024','w' }}");
+        
+            // 14 days apart should result in 2 weeks
+            TestHelper.AssertTemplateOutput("2", "{{ '01-Jan-2024' | DateDiff:'15-Jan-2024','w' }}");
+        
+            // 21 days apart should result in 3 weeks
+            TestHelper.AssertTemplateOutput("3", "{{ '01-Jan-2024' | DateDiff:'22-Jan-2024','w' }}");
+        }
+        
+        /// <summary>
+        /// Requesting the difference between a target date and an earlier date should yield a negative number of weeks.
+        /// </summary>
+        [TestMethod]
+        public void DateDiff_CompareEarlierDateInWeeks_YieldsNegativeInteger()
+        {
+            // Negative intervals
+            TestHelper.AssertTemplateOutput("-1", "{{ '08-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput("-1", "{{ '12-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput("-2", "{{ '15-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+            TestHelper.AssertTemplateOutput("-3", "{{ '22-Jan-2024' | DateDiff:'01-Jan-2024','w' }}");
+        }
+
+
+        /// <summary>
         /// Requesting the difference between a target date and a later date should yield a positive number of days.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Notice

**In case you are submitting a non bug-fix-PR, we highly recommend you to engage in a PR discussion first.**

There are many factors we consider before accepting a pull request. This includes:
1. Whether or not the Rock system you run is a standard, main-line build. If it is not, there is a lower chance we will accept your request since it may impact some other part of the system you don't regularly use.
2. Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock.

With the PR discussion we can assess your proposed changes before you start working on it so that we can come up with the best possible approach to it. This may include:
1. Coming up with an alternate approach that does not involve changes to core.
2. Advising how your proposed solution be done in a different way that is more efficient and consistent with the rest of the system.
3. Have one of our core developers make the changes for you. This may be the case if the change involves intricate tasks like an EF migration or something similar.


## Proposed Changes

Add a weekly option in the DateDiff Lava Filter

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further Comments
I think this is sufficient for adding the weeks option into DateDiff. I'm not aware off any surprises that would come out of simply dividing by 7 days since a week is a consistent length unlike a month.

Perhaps something to check would be overflow? Any comments would be useful!

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

Update the Lava filter documentation to have "weekly":
```
Takes two datetimes and returns the difference in the unit you provide. You can provide the value 'Now' for either the start or end date.

Additional Details
Valid units are:

Y - Years
M - Months
w - Weeks
d - Days
h - Hours
m - Minutes
s - Seconds
```