### PR TITLE
Update GetQRCode.ashx.cs to allow RGBA values

### DIFF
--- a/RockWeb/App_Code/GetQRCode.ashx.cs
+++ b/RockWeb/App_Code/GetQRCode.ashx.cs
@@ -1,4 +1,4 @@
-// <copyright>
+﻿// <copyright>
 // Copyright by the Spark Development Network
 //
 // Licensed under the Rock Community License (the "License");
@@ -59,7 +59,6 @@ namespace RockWeb
                     return;
                 }
 
-                // 
                 var pixelsPerModule = context.Request.QueryString["pixelsPerModule"].AsIntegerOrNull() ?? 20;
 
                 using ( var qrGenerator = new QRCodeGenerator() )
@@ -73,9 +72,9 @@ namespace RockWeb
                     context.ApplicationInstance.CompleteRequest();
                 }
             }
-            catch (Exception)
+            catch ( Exception )
             {
-                if (!context.Response.IsClientConnected)
+                if ( !context.Response.IsClientConnected )
                 {
                     // if client disconnected, ignore
                 }
@@ -86,6 +85,16 @@ namespace RockWeb
             }
         }
 
+        /// <summary>
+        /// Generates a stream containing the QR code graphic based on the provided data and output type.
+        /// </summary>
+        /// <param name="qrCodeData">The QR code data to be rendered.</param>
+        /// <param name="outputType">The type of output to generate ("svg" or "png").</param>
+        /// <param name="pixelsPerModule">The number of pixels per module in the QR code graphic.</param>
+        /// <param name="backgroundColor">The background color for the QR code, in hex format.</param>
+        /// <param name="foregroundColor">The foreground color for the QR code, in hex format.</param>
+        /// <returns>A <see cref="Stream"/> containing the generated QR code graphic.</returns>
+        /// <exception cref="ArgumentException">Thrown when the output type is not recognized or when color hex values are invalid.</exception>
         private Stream GetResponseStream( QRCodeData qrCodeData, string outputType, int pixelsPerModule, string backgroundColor, string foregroundColor )
         {
             if ( outputType.Equals( "svg", StringComparison.OrdinalIgnoreCase ) )
@@ -101,13 +110,19 @@ namespace RockWeb
             else
             {
                 // For PNG, convert hex colors to byte arrays directly
-                byte[] lightColor = HexToByteArray( foregroundColor );
-                byte[] darkColor = HexToByteArray( backgroundColor );
+                var lightColor = HexToByteArray( backgroundColor );
+                var darkColor = HexToByteArray( foregroundColor );
                 var qrCodeImage = new PngByteQRCode( qrCodeData ).GetGraphic( pixelsPerModule, darkColor, lightColor );
                 return new MemoryStream( qrCodeImage );
             }
         }
 
+        /// <summary>
+        /// Converts a hex color string to a byte array representing the RGBA color.
+        /// </summary>
+        /// <param name="hex">The hex color string (6 or 8 digits, with or without a leading '#').</param>
+        /// <returns>A byte array representing the RGBA color.</returns>
+        /// <exception cref="ArgumentException">Thrown when the hex color string is not a valid 6 or 8 digit hex value.</exception>
         private byte[] HexToByteArray( string hex )
         {
             if ( !Regex.IsMatch( hex, @"^#?([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$" ) )


### PR DESCRIPTION
## Proposed Changes
https://community.rockrms.com/ideas/2009/allow-customizable-colors-for-qr-codes

This change allows for RGBA hex values in the QR Code generator. These values can come in as RRGGBB, or RRGGBBAA hex values.

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [ x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [ x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x ] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ x] Unit tests pass locally with my changes
- [ x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
I made these changes with 6 and 8 digit RGBA values in mind, not 3 or 4-length values (like CSS allows). If that is something people would also like to see in the change, I can accommodate that. I think it would be useful to incorporate the RockColor utilities class into this because it has a Dictionary of CSS hex values and their keywords.

The only downside of that is that you still need to convert the hex values into a `byte[]` because of QRCoder's method overloads.

## Documentation
New documentation should be applied once these changes are made so that users understand the flexibility they now have when creating QR codes.