### PR TITLE
Fix typos in comments

### DIFF
--- a/Rock.JavaScript.Obsidian/Framework/FieldTypes/phoneNumberFieldComponents.ts
+++ b/Rock.JavaScript.Obsidian/Framework/FieldTypes/phoneNumberFieldComponents.ts
@@ -67,7 +67,7 @@ export const EditComponent = defineComponent({
             is reset back to the prior value in RockField and the Field.Edit component, however, the phone number is still
             up-to-date in PhoneNumberBox...
 
-            By adding this short debounce, we ensure that all the updates from the PhoneNumberBox are propogated up to the
+            By adding this short debounce, we ensure that all the updates from the PhoneNumberBox are propagated up to the
             Field.Edit component, THEN we emit a single change up from there to prevent the race from happening and all
             the updates stay in place.
 

--- a/RockWeb/Blocks/Mobile/MobileApplicationDetail.ascx.cs
+++ b/RockWeb/Blocks/Mobile/MobileApplicationDetail.ascx.cs
@@ -1358,7 +1358,7 @@ namespace RockWeb.Blocks.Mobile
         /// </summary>
         /// <remarks>
         /// "async void" is not normal, but WebForms has special logic to deal with
-        /// it that allows await to be used and ensures HttpContext is propogated
+        /// it that allows await to be used and ensures HttpContext is propagated
         /// along the async call chain.
         /// </remarks>
         /// <param name="sender">The source of the event.</param>


### PR DESCRIPTION
## Summary
- fix misspellings of "propagated" in MobileApplicationDetail and phoneNumberFieldComponents

## Testing
- `npm test` *(fails: no test specified)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684061576fb08331962297db9d2311da