### PR TITLE
Optimize Group Scheduler query by matching in memory

### DIFF
--- a/Rock.Blocks/Group/Scheduling/GroupScheduler.cs
+++ b/Rock.Blocks/Group/Scheduling/GroupScheduler.cs
@@ -627,13 +627,6 @@ namespace Rock.Blocks.Group.Scheduling
                 return;
             }
 
-            // Get any already-existing attendance occurrence records tied to the [group, location, schedule, occurrence date] occurrences
-            // we're retrieving. We'll need these IDs to facilitate scheduling within the Obsidian JavaScript block. Note that we'll create
-            // any missing attendance occurrence records below, before sending the final, filtered collection of occurrences back to the client.
-            var attendanceOccurrencesQry = new AttendanceOccurrenceService( rockContext )
-                .Queryable()
-                .AsNoTracking();
-
             // Determine the actual start and end dates, based on the date range validation that has already taken place.
             // For the end date, add a day (and set it to the START of that day) so we can follow Rock's rule: let your
             // start be "inclusive" and your end be "exclusive".
@@ -644,7 +637,11 @@ namespace Rock.Blocks.Group.Scheduling
             // Go ahead and materialize the list so we can:
             //  1) Perform additional, in-memory filtering.
             //  2) Set the scheduled start date/time(s) on the returned instances; these represent the "occurrences" that may be scheduled.
-            var groupLocationSchedules = new GroupLocationService( rockContext )
+            //
+            // NOTE: We project to an anonymous type first to avoid EF6 materialization issues with class constructors,
+            // then convert to GroupLocationSchedule after materialization. We also fetch AttendanceOccurrences separately
+            // to avoid correlated subquery performance issues.
+            var groupLocationScheduleData = new GroupLocationService( rockContext )
                 .Queryable()
                 .AsNoTracking()
                 .Where( gl =>
@@ -679,6 +676,10 @@ namespace Rock.Blocks.Group.Scheduling
                         || gls.Schedule.EffectiveEndDate.Value >= actualStartDate
                     )
                 )
+                .ToList(); // Materialize the anonymous type first
+
+            // Now convert to GroupLocationSchedule objects in memory (avoids EF6 projection limitations)
+            var groupLocationSchedules = groupLocationScheduleData
                 .Select( gls => new GroupLocationSchedule
                 {
                     Group = gls.Group,
@@ -687,14 +688,40 @@ namespace Rock.Blocks.Group.Scheduling
                     Location = gls.Location,
                     Schedule = gls.Schedule,
                     Config = gls.Config,
-                    AttendanceOccurrences = attendanceOccurrencesQry.Where( ao =>
-                        ao.GroupId == gls.Group.Id
-                        && ao.LocationId == gls.Location.Id
-                        && ao.ScheduleId == gls.Schedule.Id
-                    )
-                    .ToList()
+                    AttendanceOccurrences = new List<AttendanceOccurrence>()
                 } )
                 .ToList();
+
+            // Fetch AttendanceOccurrences separately to avoid correlated subquery performance issues.
+            // We'll match them to their GroupLocationSchedules in memory.
+            if ( groupLocationSchedules.Any() )
+            {
+                var glsGroupIds = groupLocationSchedules.Select( gls => gls.Group.Id ).Distinct().ToList();
+                var glsLocationIds = groupLocationSchedules.Select( gls => gls.Location.Id ).Distinct().ToList();
+                var glsScheduleIds = groupLocationSchedules.Select( gls => gls.Schedule.Id ).Distinct().ToList();
+
+                var attendanceOccurrences = new AttendanceOccurrenceService( rockContext )
+                    .Queryable()
+                    .AsNoTracking()
+                    .Where( ao =>
+                        ao.GroupId.HasValue && glsGroupIds.Contains( ao.GroupId.Value )
+                        && ao.LocationId.HasValue && glsLocationIds.Contains( ao.LocationId.Value )
+                        && ao.ScheduleId.HasValue && glsScheduleIds.Contains( ao.ScheduleId.Value )
+                    )
+                    .ToList();
+
+                // Match AttendanceOccurrences to their GroupLocationSchedules in memory.
+                foreach ( var gls in groupLocationSchedules )
+                {
+                    gls.AttendanceOccurrences = attendanceOccurrences
+                        .Where( ao =>
+                            ao.GroupId == gls.Group.Id
+                            && ao.LocationId == gls.Location.Id
+                            && ao.ScheduleId == gls.Schedule.Id
+                        )
+                        .ToList();
+                }
+            }
 
             // Remove any schedules that don't actually have any start date/time(s) within the specified date range, and set the start date/time(s) on those that remain.
             if ( !skipFullScheduleValidation && groupLocationSchedules.Any() )


### PR DESCRIPTION
Refactored attendance occurrence retrieval logic to improve performance by fetching attendance occurrences separately and matching them in memory.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Please include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

The `GetLocationsAndSchedules` method in the Group Scheduler block was using a correlated subquery pattern to fetch `AttendanceOccurrences` within the main LINQ projection. This caused Entity Framework 6 to execute a separate database query for each group/location/schedule combination (N+1 query problem), resulting in poor performance when viewing schedules for multiple groups across several weeks.

This PR refactors the data retrieval to use a "fetch then stitch" pattern:

1. **First query**: Fetch all `GroupLocationSchedule` data, projecting to an anonymous type first to avoid EF6 materialization issues with class constructors, then converting to `GroupLocationSchedule` objects in memory with empty `AttendanceOccurrences` lists.

2. **Second query**: Fetch all relevant `AttendanceOccurrence` records in a single query using `IN` clauses based on the distinct group, location, and schedule IDs from the first query.

3. **In-memory matching**: Iterate through the `GroupLocationSchedule` objects and assign the appropriate `AttendanceOccurrences` from the second query result.

This reduces database round-trips from N+1 (potentially hundreds) down to just 2, significantly improving page load times for the Group Scheduler block.

Fixes: #6662

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [ ] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

This is a performance optimization with no functional changes to the Group Scheduler behavior. The same data is retrieved and processed; only the retrieval pattern has changed to reduce database load.


## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

No documentation changes required. This is an internal performance optimization with no UI or behavioral changes.

## Migrations
If your pull request requires a migration, please *exclude the migration from the Rock.Migration project*, but submit it with your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.

No migrations required.