### PR TITLE
+ Fixed swapped autocomplete attributes for City and County address fields. City now correctly uses address-level2 and County uses address-level3, matching the HTML autocomplete standard. Previously, browsers using autofill would populate City with county data and vice versa. (Fixes #6696)

### DIFF
--- a/Rock.JavaScript.Obsidian/Framework/Controls/addressControl.obs
+++ b/Rock.JavaScript.Obsidian/Framework/Controls/addressControl.obs
@@ -184,7 +184,7 @@
         isVisible: true,
         label: "County",
         rules: RequirementLevel.Unspecified,
-        autocomplete: "address-level2"
+        autocomplete: "address-level3"
     });
     const state = reactive<FieldConfig>({
         isVisible: true,
@@ -291,7 +291,7 @@
             city.isVisible = data.cityRequirement !== RequirementLevel.Unavailable;
             city.rules = data.cityRequirement;
             city.label = data.cityLabel ?? city.label;
-            city.autocomplete = county.isVisible ? "address-level3" : "address-level2";
+            city.autocomplete = "address-level2";
 
             state.isVisible = data.stateRequirement !== RequirementLevel.Unavailable;
             state.rules = data.stateRequirement;

--- a/Rock/Web/UI/Controls/AddressControl.cs
+++ b/Rock/Web/UI/Controls/AddressControl.cs
@@ -1092,7 +1092,7 @@ namespace Rock.Web.UI.Controls
             {
                 writer.AddAttribute( "class", "form-group" + ( localityIsVisible ? " col-sm-3" : " col-sm-6" ) );
                 writer.RenderBeginTag( HtmlTextWriterTag.Div );
-                _tbCity.Attributes["autocomplete"] = ( localityIsVisible ? "address-level3" : "address-level2" );
+                _tbCity.Attributes["autocomplete"] = "address-level2";
                 _tbCity.RenderControl( writer );
                 writer.RenderEndTag();  // div.form-group
             }
@@ -1102,7 +1102,7 @@ namespace Rock.Web.UI.Controls
             {
                 writer.AddAttribute( "class", "form-group col-sm-3" );
                 writer.RenderBeginTag( HtmlTextWriterTag.Div );
-                _tbCounty.Attributes["autocomplete"] = "address-level2";
+                _tbCounty.Attributes["autocomplete"] = "address-level3";
                 _tbCounty.RenderControl( writer );
                 writer.RenderEndTag();  // div.form-group
             }


### PR DESCRIPTION
https://claude.ai/code/session_0132MH6t58sAsHpDbrTDnTsz