### PR TITLE
Fix FriendlyScheduleText for one-time schedules to use proper date formatting

### DIFF
--- a/Rock/Model/Core/Schedule/Schedule.Logic.cs
+++ b/Rock/Model/Core/Schedule/Schedule.Logic.cs
@@ -960,7 +960,7 @@ namespace Rock.Model
                     }
                     else if ( dates.Count() == 1 )
                     {
-                        result = "Once at " + calendarEvent.DtStart.Value.ToShortDateTimeString();
+                        result = "Once on " + dates.First().ToString( "MMMM d, yyyy" ) + " at " + dates.First().ToString( "h:mm tt" );
                     }
                     else
                     {


### PR DESCRIPTION
Changed "Once at 3/29/2026 11:00 AM" to display as "Once on March 29, 2026 at 11:00 AM"
by using a long month name format and separating date and time with "on"/"at" prepositions.

Fixes #6694