### PR TITLE
Fix NullReferenceException in ConnectionRequestActivityChangeTransaction.LaunchWorkflow

### DIFF
--- a/Rock/Transactions/ConnectionRequestActivityChangeTransaction.cs
+++ b/Rock/Transactions/ConnectionRequestActivityChangeTransaction.cs
@@ -155,6 +155,11 @@ namespace Rock.Transactions
                 if ( ConnectionRequestActivityGuid.HasValue )
                 {
                     connectionRequestActivity = new ConnectionRequestActivityService( rockContext ).Get( ConnectionRequestActivityGuid.Value );
+                    if ( connectionRequestActivity == null )
+                    {
+                        return;
+                    }
+
                     var workflow = Rock.Model.Workflow.Activate( workflowType, name );
 
                     List<string> workflowErrors;


### PR DESCRIPTION
Guard against the case where a ConnectionRequestActivity is deleted between
when the transaction is queued and when it is executed. Previously, calling
.Get() could return null and the subsequent access of
connectionRequestActivity.ConnectionRequestId would throw a NullReferenceException
during RockQueue.Drain(). Now we return early if the activity no longer exists.

Fixes #6423