### PR TITLE
Fix Campus field type configuration value retrieval

### DIFF
--- a/Rock/Field/Types/CampusFieldType.cs
+++ b/Rock/Field/Types/CampusFieldType.cs
@@ -677,7 +677,7 @@ namespace Rock.Field.Types
 
                 if ( cblSelectableValues != null )
                 {
-                    var selectableValues = new List<string>( cblSelectableValues.SelectedValues );
+                    var selectableValues = configurationValues.GetValueOrNull( SELECTABLE_CAMPUSES_KEY )?.SplitDelimitedValues( false );
 
                     var activeCampuses = CampusCache.All( cbIncludeInactive.Checked ).Select( v => new { Text = v.Name, Value = v.Id } );
                     cblSelectableValues.DataSource = activeCampuses;


### PR DESCRIPTION
## Proposed Changes

This PR fixes a bug in the `CampusFieldType.SetConfigurationValues` method where selectable campus values were being retrieved from the UI control instead of from the configuration values dictionary.

The original code was reading `cblSelectableValues.SelectedValues` directly from the control, which would be empty during configuration load. The fix changes it to properly retrieve the stored configuration value using `configurationValues.GetValueOrNull(SELECTABLE_CAMPUSES_KEY)?.SplitDelimitedValues(false)`, ensuring that previously saved campus selections are correctly restored when the field configuration is loaded.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] This is a single-commit PR
- [x] I verified my PR does not include whitespace/formatting changes
- [ ] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [ ] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added any required unit tests or integration tests that prove my fix is effective
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments

This is a straightforward bug fix that corrects the source of configuration data being used. The change ensures that the configuration persistence mechanism works correctly for campus field type selectable values.

https://claude.ai/code/session_012inrHacg6aSmkZDAnFBmMs