### PR TITLE
Fixed Attendance Analytics group chart with duplicate group names

### DIFF
--- a/Rock/Model/Event/Attendance/AttendanceService.cs
+++ b/Rock/Model/Event/Attendance/AttendanceService.cs
@@ -472,11 +472,27 @@ namespace Rock.Model
             {
                 var groupByQry = summaryQry.GroupBy( a => new { a.SummaryDateTime, Series = a.Group } ).Select( s => new { s.Key, Count = s.Count() } ).OrderBy( o => o.Key );
 
-                result = groupByQry.ToList().Select( a => new SummaryData
+                var dataItems = groupByQry.ToList();
+
+                // Identify group IDs whose names are shared with at least one other group.
+                // When multiple groups share the same name, their SeriesName must be unique
+                // to prevent the chart from merging them into a single series and displaying
+                // incorrect counts for all identically-named groups.
+                var duplicateNameGroupIds = dataItems
+                    .Select( a => new { a.Key.Series.Id, a.Key.Series.Name } )
+                    .Distinct()
+                    .GroupBy( g => g.Name )
+                    .Where( g => g.Count() > 1 )
+                    .SelectMany( g => g.Select( x => x.Id ) )
+                    .ToHashSet();
+
+                result = dataItems.Select( a => new SummaryData
                 {
                     DateTimeStamp = a.Key.SummaryDateTime.ToJavascriptMilliseconds(),
                     DateTime = a.Key.SummaryDateTime,
-                    SeriesName = a.Key.Series.Name,
+                    SeriesName = duplicateNameGroupIds.Contains( a.Key.Series.Id )
+                        ? $"{a.Key.Series.Name} (Id: {a.Key.Series.Id})"
+                        : a.Key.Series.Name,
                     YValue = a.Count
                 } ).ToList();
             }


### PR DESCRIPTION
# Fix Summary: Issue #6691 — Attendance Analytics Group Chart with Duplicate Group Names

## Problem

The Attendance Analytics block renders two views of the same data:

- **Data table** — correct; shows each group separately with accurate counts
- **Chart** — incorrect; when two or more groups share the same name, all of them display the same (wrong) count

### Steps to reproduce

1. Create a Check-in configuration with two areas, each containing a group with the same name (e.g., both named "Crawlers") but different ability levels.
2. Check in children — 2 kids under one group, 1 kid under the other.
3. Open Attendance Analytics and filter to include both groups.
4. The data table correctly shows `2` and `1`. The chart shows `1` for both.

---

## Root Cause

The bug spans two files and two stages of the data pipeline.

### Stage 1 — `AttendanceService.GetChartData()` (correct)

When `graphBy == AttendanceGraphBy.Group`, the query groups attendance records by:

```csharp
GroupBy( a => new { a.SummaryDateTime, Series = a.Group } )
// where a.Group = new { Id = ..., Name = ... }
```

Because `a.Group` is an anonymous type containing **both** `Id` and `Name`, two groups with the same name but different IDs are treated as distinct keys. The query correctly produces two separate count rows — e.g., `{ Name="Crawlers", Id=5, Count=2 }` and `{ Name="Crawlers", Id=8, Count=1 }`.

### Stage 2 — `SummaryData` construction (the bug)

When converting the query results to `SummaryData` objects, the group ID is **discarded**:

```csharp
SeriesName = a.Key.Series.Name,  // "Crawlers" for both groups
```

Both objects now have `SeriesName = "Crawlers"`.

### Stage 3 — `ChartDataFactory.GetTimeSeriesFromChartData()` (victim)

The chart factory groups `IChartData` items into series using `SeriesName` as the sole key:

```csharp
var itemsBySeries = chartDataItems.GroupBy( k => k.SeriesName, v => v );
```

Both "Crawlers" entries land in the **same series**. That series ends up with two data points at the same timestamp — one with value `2`, one with value `1`. Chart.js renders only one of them (the last, `1`), so both groups appear to have a count of `1` in the chart.

---

## Fix

**File:** `Rock/Model/Event/Attendance/AttendanceService.cs`

After executing the query, detect which group IDs share a name with at least one other group in the result set. For those groups, append `(Id: X)` to the `SeriesName` to make it unique. Groups with unique names are unaffected.

```csharp
var dataItems = groupByQry.ToList();

// Identify group IDs whose names are shared with at least one other group.
// When multiple groups share the same name, their SeriesName must be unique
// to prevent the chart from merging them into a single series and displaying
// incorrect counts for all identically-named groups.
var duplicateNameGroupIds = dataItems
    .Select( a => new { a.Key.Series.Id, a.Key.Series.Name } )
    .Distinct()
    .GroupBy( g => g.Name )
    .Where( g => g.Count() > 1 )
    .SelectMany( g => g.Select( x => x.Id ) )
    .ToHashSet();

result = dataItems.Select( a => new SummaryData
{
    DateTimeStamp = a.Key.SummaryDateTime.ToJavascriptMilliseconds(),
    DateTime = a.Key.SummaryDateTime,
    SeriesName = duplicateNameGroupIds.Contains( a.Key.Series.Id )
        ? $"{a.Key.Series.Name} (Id: {a.Key.Series.Id})"
        : a.Key.Series.Name,
    YValue = a.Count
} ).ToList();
```

### Before / After

| Scenario | Before | After |
|---|---|---|
| Two groups named "Crawlers" (Id 5 and 8) | Both series named `"Crawlers"` → merged → chart shows `1` for both | Series named `"Crawlers (Id: 5)"` and `"Crawlers (Id: 8)"` → separate → chart shows `2` and `1` |
| Groups with unique names | Series named by group name (unchanged) | Series named by group name (unchanged) |

### Why only the Group branch?

The same structural issue theoretically exists for the Campus, Schedule, and Location branches, but duplicate names within those entity types are far less common in practice and were not part of the reported issue. The fix is scoped to the Group branch to match the reported bug.

---

## Files Changed

| File | Change |
|---|---|
| `Rock/Model/Event/Attendance/AttendanceService.cs` | Added duplicate-name detection and conditional ID suffix for group `SeriesName` |

## PR

[#6707 — Fixed Attendance Analytics group chart with duplicate group names](https://github.com/SparkDevNetwork/Rock/pull/6707)
