### PR TITLE
Fix penny drift in fee coverage distribution across accounts

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionEntryV2.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionEntryV2.ascx.cs
@@ -3307,19 +3307,22 @@ mission. We are so grateful for your commitment.</p>
             var selectedAccountAmounts = caapPromptForAccountAmounts.AccountAmounts.Where( a => a.Amount.HasValue && a.Amount != 0 ).ToArray();
 
             var totalFeeCoverageAmount = GetSelectedFeeCoverageAmount();
-            var totalSelectedAmounts = selectedAccountAmounts.Sum( a => a.Amount.Value );
 
-            foreach ( var selectedAccountAmount in selectedAccountAmounts )
+            // Use largest-remainder distribution so the per-account rounded fees always sum to exactly
+            // the target total, eliminating penny drift when multiple allocations are present.
+            var accountAmountValues = selectedAccountAmounts.Select( a => a.Amount.Value ).ToArray();
+            var feeCoveragePerAccount = DistributeFeeCoverage( accountAmountValues, totalFeeCoverageAmount );
+
+            for ( int i = 0; i < selectedAccountAmounts.Length; i++ )
             {
+                var selectedAccountAmount = selectedAccountAmounts[i];
                 var transactionDetail = new T();
 
                 transactionDetail.AccountId = selectedAccountAmount.AccountId;
-                if ( totalFeeCoverageAmount > 0 )
+                if ( feeCoveragePerAccount[i] > 0m )
                 {
-                    decimal portionOfTotalAmount = decimal.Divide( selectedAccountAmount.Amount.Value, totalSelectedAmounts );
-                    decimal feeCoverageAmountForAccount = decimal.Round( portionOfTotalAmount * totalFeeCoverageAmount, 2 );
-                    transactionDetail.Amount = selectedAccountAmount.Amount.Value + feeCoverageAmountForAccount;
-                    transactionDetail.FeeCoverageAmount = feeCoverageAmountForAccount;
+                    transactionDetail.Amount = selectedAccountAmount.Amount.Value + feeCoveragePerAccount[i];
+                    transactionDetail.FeeCoverageAmount = feeCoveragePerAccount[i];
                 }
                 else
                 {
@@ -3400,6 +3403,80 @@ mission. We are so grateful for your commitment.</p>
             }
 
             return totalFeeCoverageAmount;
+        }
+
+        /// <summary>
+        /// Distributes a total fee coverage amount across accounts proportionally by gift amount,
+        /// using the largest-remainder method (penny reconciliation) to ensure the per-account
+        /// rounded values sum to exactly the target total. This prevents penny drift that occurs
+        /// when each row is rounded independently.
+        /// </summary>
+        /// <param name="accountAmounts">Gift amount per account (positive values).</param>
+        /// <param name="totalFeeCoverage">Total fee coverage to distribute.</param>
+        /// <returns>Per-account fee coverage amounts whose sum equals the currency-rounded total fee coverage.</returns>
+        private static decimal[] DistributeFeeCoverage( decimal[] accountAmounts, decimal totalFeeCoverage )
+        {
+            totalFeeCoverage = decimal.Round( totalFeeCoverage, 2, MidpointRounding.AwayFromZero );
+
+            if ( accountAmounts.Length == 0 || totalFeeCoverage <= 0m )
+            {
+                return new decimal[accountAmounts.Length];
+            }
+
+            var totalGift = accountAmounts.Sum();
+            var count = accountAmounts.Length;
+            var fees = new decimal[count];
+            var remainders = new decimal[count];
+
+            // Floor each row's proportional fee to whole cents and track the fractional remainder
+            // so we can later identify which rows should receive the extra penny(ies).
+            for ( int i = 0; i < count; i++ )
+            {
+                decimal exact = totalGift == 0m
+                    ? 0m
+                    : ( accountAmounts[i] / totalGift ) * totalFeeCoverage;
+
+                fees[i] = decimal.Floor( exact * 100m ) / 100m;
+                remainders[i] = exact - fees[i];
+            }
+
+            // Distribute any remaining cents to the rows with the largest fractional remainders,
+            // breaking ties by giving amount (largest first) for a deterministic result.
+            int centsToDistribute = ( int ) Math.Round( ( totalFeeCoverage - fees.Sum() ) * 100m, MidpointRounding.AwayFromZero );
+
+            if ( centsToDistribute > 0 )
+            {
+                var indices = Enumerable.Range( 0, count )
+                    .OrderByDescending( i => remainders[i] )
+                    .ThenByDescending( i => accountAmounts[i] )
+                    .ToArray();
+
+                for ( int j = 0; j < centsToDistribute && j < count; j++ )
+                {
+                    fees[indices[j]] += 0.01m;
+                }
+            }
+            else if ( centsToDistribute < 0 )
+            {
+                // Remove cents from rows with the smallest remainders that still have at least a penny,
+                // to handle the rare over-allocation case.
+                int centsToRemove = -centsToDistribute;
+                var indices = Enumerable.Range( 0, count )
+                    .OrderBy( i => remainders[i] )
+                    .ThenByDescending( i => fees[i] )
+                    .ToArray();
+
+                for ( int j = 0; j < indices.Length && centsToRemove > 0; j++ )
+                {
+                    if ( fees[indices[j]] >= 0.01m )
+                    {
+                        fees[indices[j]] -= 0.01m;
+                        centsToRemove--;
+                    }
+                }
+            }
+
+            return fees;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes

This PR fixes a rounding/penny drift issue in the Transaction Entry V2 block's fee coverage distribution logic. When multiple accounts receive fee coverage amounts, the previous implementation rounded each account's proportional fee independently, which could cause the sum of rounded fees to differ from the target total by a penny or more.

The fix implements the **largest-remainder method** (also known as penny reconciliation) to distribute fee coverage amounts. This ensures that:
1. Each account's fee is calculated proportionally based on its gift amount
2. Per-account fees are rounded to the nearest cent
3. The sum of all per-account fees equals exactly the target total fee coverage amount

The new `DistributeFeeCoverage()` method:
- Calculates each account's proportional fee
- Floors each to whole cents and tracks fractional remainders
- Distributes remaining cents to accounts with the largest remainders (breaking ties by gift amount for deterministic results)
- Handles edge cases where rounding might result in over-allocation

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] This is a single-commit PR
- [x] I verified my PR does not include whitespace/formatting changes
- [x] By contributing code, I agree to license my contribution under the Rock Community License Agreement

## Further comments

The change is backward compatible and only affects the internal calculation of per-account fee coverage amounts. The logic is deterministic and handles edge cases (zero amounts, negative remainders) appropriately.

https://claude.ai/code/session_01AovbKrSUUHrq2RKNT9aJRd