### PR TITLE
Update CheckListFieldType to use Tabler icons

### DIFF
--- a/Rock/Field/Types/CheckListFieldType.cs
+++ b/Rock/Field/Types/CheckListFieldType.cs
@@ -121,9 +121,10 @@ namespace Rock.Field.Types
                     string formattedValue = string.Empty;
                     foreach ( var keyValuePair in keyValuePairs )
                     {
+                        var iconClass = values.Any( a => a == keyValuePair.Key ) ? "ti ti-square-check" : "ti ti-square";
                         formattedValue += string.Format( @"<div>
-                                <i class='far fa{1}-square'></i> {0}
-                               </div>", keyValuePair.Value, values.Any( a => a == keyValuePair.Key ) ? "-check" : "" );
+                                <i class='{1}'></i> {0}
+                               </div>", keyValuePair.Value, iconClass );
                     }
                     return formattedValue;
                 }


### PR DESCRIPTION
## Proposed Changes

Updates the CheckListFieldType to use Tabler icons (`ti ti-square-check` and `ti ti-square`) instead of Font Awesome icons (`far fa-check-square` and `far fa-square`). This change improves icon consistency and modernizes the icon library used throughout the field type.

The refactoring also improves code clarity by extracting the icon class determination into a separate variable before use in the HTML template, making the code more maintainable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] This is a single-commit PR
- [x] I verified my PR does not include whitespace/formatting changes
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)

## Further comments

This is a straightforward icon library migration within the CheckListFieldType's HTML rendering method. The functional behavior remains identical—checked items display a filled square icon and unchecked items display an empty square icon—only the icon class names have been updated to use the Tabler icon set.

https://claude.ai/code/session_01KBP3jSxKAwLCXAnQvghpWX