### PR TITLE
Fix Attribute Matrix Items timeout on save

### DIFF
--- a/Rock/Model/Core/AttributeValue/AttributeValue.Logic.cs
+++ b/Rock/Model/Core/AttributeValue/AttributeValue.Logic.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
+using System.Data.Entity.SqlServer;
 using System.Data.SqlTypes;
 using System.Linq;
 
@@ -471,9 +472,17 @@ namespace Rock.Model
             var attributeService = new AttributeService( rockContext );
             var attributeValueService = new AttributeValueService( rockContext );
 
-            var matrixGuidQuery = attributeMatrixService.Queryable().AsNoTracking().Where( am =>
-                am.AttributeMatrixItems.Any( ami => ami.Id == EntityId ) )
-                .Select( am => am.Guid.ToString() );
+            // Get the matrix that contains the current entity.
+            var matrixQuery = attributeMatrixService.Queryable().AsNoTracking().Where( am =>
+                am.AttributeMatrixItems.Any( ami => ami.Id == EntityId ) );
+
+            var matrixGuidQuery = matrixQuery.Select( am => am.Guid.ToString() );
+
+            // Build a checksum subquery to leverage the indexed ValueChecksum
+            // column, preventing SQL Server from choosing a full table scan on
+            // AttributeValue.Value. See issue #6743.
+            var matrixGuidChecksumQuery = matrixQuery
+                .Select( am => SqlFunctions.Checksum( am.Guid.ToString() ) );
 
             var matrixFieldType = FieldTypeCache.Get( SystemGuid.FieldType.MATRIX );
             var attributeIdQuery = attributeService.Queryable().AsNoTracking().Where( a =>
@@ -481,7 +490,9 @@ namespace Rock.Model
                 .Select( a => a.Id );
 
             var attributeValue = attributeValueService.Queryable().AsNoTracking().FirstOrDefault( av =>
-                 attributeIdQuery.Contains( av.AttributeId ) && matrixGuidQuery.Contains( av.Value ) );
+                 attributeIdQuery.Contains( av.AttributeId )
+                 && matrixGuidChecksumQuery.Contains( ( int? ) av.ValueChecksum )
+                 && matrixGuidQuery.Contains( av.Value ) );
 
             return attributeValue;
         }


### PR DESCRIPTION
## Summary
- **Fixes #6743** — Attribute Matrix Items sometimes fail to save due to SQL Server choosing a bad query plan that full-table-scans `AttributeValue.Value`.
- Adds a `ValueChecksum` pre-filter to `GetRootMatrixAttributeValue()` using `SqlFunctions.Checksum()`, allowing SQL Server to leverage the indexed `ValueChecksum` column before doing the expensive string comparison.
- The `AttributeValueExpressionVisitor` only optimizes `==`/`!=` expressions, not `.Contains()`, so this query needed the checksum filter added manually.

## Test plan
- [ ] Edit an attribute matrix item on an entity and save — verify it saves successfully
- [ ] Confirm the generated SQL includes a `ValueChecksum IN (SELECT CHECKSUM(...))` clause via SQL Profiler
- [ ] Verify no regression on systems with large `AttributeValue` tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)