### PR TITLE
Fix cache refresh error when App_Data/Cache folder missing

### DIFF
--- a/RockWeb/Blocks/Administration/SystemInfo.ascx.cs
+++ b/RockWeb/Blocks/Administration/SystemInfo.ascx.cs
@@ -177,15 +177,20 @@ namespace RockWeb.Blocks.Administration
             // Delete all cached files
             try
             {
-                var dirInfo = new DirectoryInfo( Path.Combine( webAppPath, "App_Data/Cache" ) );
-                foreach ( var childDir in dirInfo.GetDirectories() )
+                var cachePath = Path.Combine( webAppPath, "App_Data/Cache" );
+                if ( Directory.Exists( cachePath ) )
                 {
-                    childDir.Delete( true );
+                    var dirInfo = new DirectoryInfo( cachePath );
+                    foreach ( var childDir in dirInfo.GetDirectories() )
+                    {
+                        childDir.Delete( true );
+                    }
+                    foreach ( var file in dirInfo.GetFiles().Where( f => f.Name != ".gitignore" ) )
+                    {
+                        file.Delete();
+                    }
                 }
-                foreach ( var file in dirInfo.GetFiles().Where( f => f.Name != ".gitignore" ) )
-                {
-                    file.Delete();
-                }
+
                 msgs.Add( "Cached files have been deleted" );
             }
             catch ( Exception ex )


### PR DESCRIPTION
## Summary
- Fixes the "Clear Cache" button on the System Info page showing an alarming error when the `App_Data/Cache` folder doesn't exist.
- The Rock Cleanup job deletes this folder, and if no file types are configured to cache to the server, it may never get recreated — making this a common scenario.
- Added a `Directory.Exists()` check before attempting to enumerate and delete cached files, so the operation completes gracefully when the folder is absent.

Fixes #6745

## Test plan
- [ ] Run the Rock Cleanup job to ensure `App_Data/Cache` is deleted
- [ ] Immediately click "Clear Cache" on the System Info page — should succeed without error
- [ ] Verify clearing cache still works correctly when `App_Data/Cache` does exist with files in it

🤖 Generated with [Claude Code](https://claude.com/claude-code)