### PR TITLE
Fix Person Entry defaulting Marital Status to Married

### DIFF
--- a/Rock.Blocks/WorkFlow/WorkflowEntry.cs
+++ b/Rock.Blocks/WorkFlow/WorkflowEntry.cs
@@ -1341,17 +1341,10 @@ namespace Rock.Blocks.Workflow
                 mobileAddress = familyLocation != null ? Rock.Mobile.MobileHelper.GetMobileAddress( familyLocation ) : null;
             }
 
-            Guid? maritalStatusGuid;
-
-            if ( personEntryPerson != null )
-            {
-                maritalStatusGuid = personEntryPerson.MaritalStatusValue?.Guid;
-            }
-            else
-            {
-                // default to Married if this is a new person
-                maritalStatusGuid = Rock.SystemGuid.DefinedValue.PERSON_MARITAL_STATUS_MARRIED.AsGuid();
-            }
+            // Get the current marital status if the person exists,
+            // otherwise leave it null so we don't default new people
+            // to "Married" when no marital status is provided.
+            Guid? maritalStatusGuid = personEntryPerson?.MaritalStatusValue?.Guid;
 
             return new WorkflowFormPersonEntry
             {

--- a/Rock/Workflow/Action/WorkflowControl/UserForm.cs
+++ b/Rock/Workflow/Action/WorkflowControl/UserForm.cs
@@ -517,11 +517,10 @@ namespace Rock.Workflow.Action
                 }
             }
 
-            // Get current marital status or default to Married if this will
-            // be a new person.
-            var maritalStatusGuid = personEntryPerson != null
-                ? personEntryPerson.MaritalStatusValue?.Guid
-                : Rock.SystemGuid.DefinedValue.PERSON_MARITAL_STATUS_MARRIED.AsGuid();
+            // Get the current marital status if the person exists,
+            // otherwise leave it null so we don't default new people
+            // to "Married" when no marital status is provided.
+            var maritalStatusGuid = personEntryPerson?.MaritalStatusValue?.Guid;
 
             return new PersonEntryValuesBag
             {


### PR DESCRIPTION
## Summary
- Fixed Person Entry forms incorrectly defaulting Marital Status to "Married" for new persons when no value was provided
- Applied fix to both the Obsidian WorkflowEntry block (`Rock.Blocks`) and the legacy UserForm workflow action (`Rock`)
- When the Marital Status field is hidden, new person records are no longer created with "Married" and existing matched persons' status is no longer overwritten

Fixes #6747

## Test plan
- [ ] Create a Form Builder workflow with Person Entry, uncheck "Autofill Current Person", hide Marital Status field
- [ ] Submit the form with a new person — verify Marital Status is blank/null (not "Married")
- [ ] Submit the form with an existing person who has "Single" — verify their status remains "Single"
- [ ] Enable Marital Status field and submit with a selection — verify it applies correctly
- [ ] Test with spouse entry enabled and Marital Status hidden — verify neither person gets "Married"

🤖 Generated with [Claude Code](https://claude.com/claude-code)