### PR TITLE
Fix Page Views block not resolving Page with IdKey (Fixes #6939)

### DIFF
--- a/RockWeb/Blocks/Administration/PageViews.ascx.cs
+++ b/RockWeb/Blocks/Administration/PageViews.ascx.cs
@@ -298,8 +298,9 @@ namespace RockWeb.Blocks.Administration
         {
             if ( _pageCache == null )
             {
-                var pageId = PageParameter( PageParamKey.Page ).AsInteger();
-                _pageCache = PageCache.Get( pageId );
+                var pageKey = PageParameter( PageParamKey.Page );
+                var allowIntegerIdentifier = !this.PageCache.Layout.Site.DisablePredictableIds;
+                _pageCache = PageCache.Get( pageKey, allowIntegerIdentifier );
             }
 
             return _pageCache;


### PR DESCRIPTION
Fixes #6939

## Problem

The Page Views block (Settings > CMS > Pages > [page] > Page Views) fails to resolve the target Page when the route parameter is an IdKey — which is how Rock's own CMS Pages grid links to it by default. The block resolved the parameter with `PageParameter( "Page" ).AsInteger()`, so a hashid like `k3QG1l4ebV` parsed to `0`, leaving the title stuck on the generic "Page Views" and the grid showing "No Page Views Found" even though view records exist.

## Fix

Resolve the parameter with `PageCache.Get( pageKey, allowIntegerIdentifier )`, the standard entity-key resolution (Id, Guid, or IdKey), honoring the site's `DisablePredictableIds` setting. This mirrors how the Obsidian rewrite of this block already resolves the page on `develop` (`Rock.Blocks/Administration/PageViews.cs`, `GetInteractionPage()`); this PR brings the same behavior to the WebForms block still shipping in v19.x, so it targets `hotfix-19.4`.

## Testing

- Reproduced on the demo site per the issue: `/admin/cms/pages/k3QG1l4ebV/views` shows the generic title and empty grid, while `/admin/cms/pages/12/views` works.
- With this change, `PageCache.Get( key, allowIntegerIdentifier )` resolves int, Guid, and IdKey forms identically, so both URL forms resolve the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)