### PR TITLE
Fixed Electronic Signature action erroring with "Captcha was not valid" on Obsidian Workflow Entry block (Fixes #6967)

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/WorkFlow/WorkflowEntry/Actions/electronicSignature.obs
+++ b/Rock.JavaScript.Obsidian.Blocks/src/WorkFlow/WorkflowEntry/Actions/electronicSignature.obs
@@ -12,7 +12,11 @@
             </div>
         </div>
 
-        <div class="well">
+        <div v-if="isCaptchaEnabled" v-show="!isCaptchaComplete">
+            <Captcha ref="captchaElement"></Captcha>
+        </div>
+
+        <div v-if="!isCaptchaEnabled || isCaptchaComplete" class="well">
             <ElectronicSignature v-model="signature"
                                  :documentTerm="documentTerm"
                                  :isDrawn="isDrawn"
@@ -24,14 +28,16 @@
 </template>
 
 <script setup lang="ts">
+    import Captcha from "@Obsidian/Controls/captcha.obs";
     import ElectronicSignature from "@Obsidian/Controls/electronicSignature.obs";
     import { SignatureType } from "@Obsidian/Enums/Core/signatureType";
     import { Guid } from "@Obsidian/Types";
     import { asBoolean } from "@Obsidian/Utility/booleanUtils";
     import { newGuid } from "@Obsidian/Utility/guid";
     import { useSuspense } from "@Obsidian/Utility/suspense";
+    import { BlockActionContextBag } from "@Obsidian/ViewModels/Blocks/blockActionContextBag";
     import { ElectronicSignatureValue } from "@Obsidian/ViewModels/Controls/electronicSignatureValue";
-    import { computed, ref } from "vue";
+    import { computed, onMounted, ref } from "vue";
     import { interactiveActionProps } from "../types";
 
     const enum ComponentConfigurationKey {
@@ -57,6 +63,9 @@
     // #region Values
 
     const signature = ref<ElectronicSignatureValue>();
+    const isCaptchaComplete = ref<boolean>(false);
+    const captchaElement = ref<InstanceType<typeof Captcha> | undefined>();
+    const captchaToken = ref<string | null | undefined>();
     let frameLoadOperationKey: Guid | undefined = newGuid();
 
     // #endregion
@@ -116,8 +125,48 @@
             [ComponentDataKey.SignedByEmail]: signature.value?.signedByEmail
         };
 
-        await props.submit(newData);
+        let actionContext: BlockActionContextBag | undefined;
+
+        if (captchaToken.value) {
+            actionContext = {
+                ...actionContext,
+                captcha: captchaToken.value
+            };
+        }
+
+        await props.submit(newData, actionContext);
     }
+
+    // #endregion
+
+    // #region Functions
+
+    /**
+     * Waits for the CAPTCHA control to provide a token so it can be sent
+     * to the server along with the signed document.
+     */
+    async function waitForCaptcha(): Promise<void> {
+        if (!props.isCaptchaEnabled || !captchaElement.value) {
+            return;
+        }
+
+        captchaToken.value = await captchaElement.value.getToken() || null;
+
+        if (!captchaToken.value) {
+            isCaptchaComplete.value = false;
+        }
+        else {
+            isCaptchaComplete.value = true;
+        }
+    }
+
+    // #endregion
+
+    // #region Lifecycle Hooks
+
+    onMounted(async () => {
+        await waitForCaptcha();
+    });
 
     // #endregion
 


### PR DESCRIPTION
## Description
When a workflow with a Signature Document (Electronic Signature) action runs on the Obsidian Workflow Entry block with CAPTCHA support enabled, completing the signature fails with "Captcha was not valid" (#6967, affects v19.2/v19.3, still present in v19.4).

The block's `GetNextInteractiveAction` action validates CAPTCHA on every invocation. The entry form component acquires a token and sends it in the block action context, but the electronic signature component submitted without one, so the server always rejected the request.

## Fix
`electronicSignature.obs` now follows the same pattern as `entryForm.obs`: it renders the Captcha control when CAPTCHA is enabled, waits for a token on mount, keeps the signature panel hidden until the captcha completes, and passes the token in the `BlockActionContextBag` when submitting the signed document.

Verified with ESLint and a full Obsidian Blocks type-check build.